### PR TITLE
PCHR-3636: (WIP) Apply patch to CiviCRM in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,13 +51,6 @@ pipeline {
           // Build site with CV Buildkit
           sh "civibuild create ${params.CIVIHR_BUILDNAME} --type drupal-clean --civi-ver 4.7.27 --url $WEBURL --admin-pass $ADMIN_PASS"
 
-          sh """
-            cd $DRUPAL_MODULES_ROOT/civicrm
-            wget -O attachments.patch https://gist.githubusercontent.com/davialexandre/199b3ebb2c69f43c07dde0f51fb02c8b/raw/0f11edad8049c6edddd7f865c801ecba5fa4c052/attachments-4.7.27.patch
-            patch -p1 -i attachments.patch
-            rm attachments.patch
-          """
-
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH
           def envBranch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
@@ -72,6 +65,8 @@ pipeline {
             checkoutPrBranchInCiviHRRepos(prBranch)
             mergeEnvBranchInAllRepos(envBranch)
           }
+
+          applyCoreForkPatch()
 
           // The JS tests use the cv tool to find the path  of an extension.
           // For it to work, the extensions have to be installed on the site
@@ -513,5 +508,15 @@ def installCiviHRExtensions() {
     cd $CIVICRM_EXT_ROOT/civihr
     drush cvapi extension.refresh
     ./bin/drush-install.sh
+  """
+}
+
+/**
+ * Applies changes to CiviCRM from the Compucorp fork
+ */
+def applyCoreForkPatch() {
+  sh """
+    cd ${CIVICRM_EXT_ROOT}/civihr
+    ./bin/apply-core-fork-patch.sh
   """
 }


### PR DESCRIPTION
## Overview

We need to use the patches to CiviCRM core from our Compucorp fork in Jenkins, otherwise some of the tests for newer features which rely on core changes will fail.

## Before

Jenkins used the `civicrm/civicrm-core` branch for CiviCRM, without any changes

## After

Jenkins applies the `compucorp/civicrm-core` to the branch used for CiviCRM

## Comments

Since the patches will be applied, the manual patching for attachments changes was removed.