### PR TITLE
PCHR-3570: Footer Changes

### DIFF
--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -28,15 +28,16 @@
   {if !empty($contactId)}
     {include file="CRM/common/contactFooter.tpl"}
   {/if}
-
   <div class="crm-footer" id="civicrm-footer">
     {* PCHR-1323 - Display CiviHR version info. *}
     {ts}Powered by CiviHR {/ts} {civihrVersion}.
-
-    {if !empty($footer_status_severity)}
-      <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
-      <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.
-    </span>&nbsp;
+    {if call_user_func(array('CRM_Core_Permission','check'), 'view system status on footer')}
+      {if !empty($footer_status_severity)}
+        <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
+          <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.
+        </span>
+      &nbsp;
+      {/if}
     {/if}
     CiviHR is openly available under Version 3 of the <a target="_blank" href="http://www.gnu.org/licenses/agpl-3.0.html">GNU AGPL License</a> and can be downloaded from <a target="_blank" href="https://civihr.org">www.civihr.org</a>.
     <div class="text-center">

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -318,6 +318,7 @@ function hrcore_civicrm_permission(&$permissions) {
   $prefix = ts('CiviHR') . ': ';
   $permissions['access CiviCRM developer menu and tools'] = ts('Access CiviCRM developer menu and tools');
   $permissions['access root menu items and configurations'] = $prefix . ts('Access root menu items and configurations');
+  $permissions['view system status on footer'] = $prefix . ts('View System Status on Footer');
 }
 
 /**


### PR DESCRIPTION
## Overview
With this change only root admins and other users with "view system status on footer" will be able to view the System Status on Footer as requested on PCHR-3570

## Before
![after root_admin](https://user-images.githubusercontent.com/1692858/41092309-e29278de-6a48-11e8-9a1e-d96d2742e303.png)
All users could see the system Status

## After
![after root_admin](https://user-images.githubusercontent.com/1692858/41092309-e29278de-6a48-11e8-9a1e-d96d2742e303.png)
Root Admin


![after-hr_admin](https://user-images.githubusercontent.com/1692858/41092311-e2d588b8-6a48-11e8-82ea-b68f05150f6d.png)
HR_Admin
