### PR TITLE
PCHR-3563: Remove unused fields from contact advanced search

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearch.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearch.php
@@ -3,7 +3,7 @@
 class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch {
   /**
    * Checks if the form is the contact advance search and removes
-   * some unnused fields if so.
+   * some unused fields if so.
    *
    * @param string $formName
    * @param CRM_Core_Form $form
@@ -13,7 +13,7 @@ class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch {
       return;
     }
 
-    $this->removeUnnusedSearchFields($form);
+    $this->removeUnusedSearchFields($form);
   }
 
   /**
@@ -31,12 +31,12 @@ class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch {
   }
 
   /**
-   * Removes a few unnused fields from the contact advanced search, basic
+   * Removes a few unused fields from the contact advanced search, basic
    * section.
    *
    * @param CRM_Core_Form $form
    */
-  private function removeUnnusedSearchFields($form) {
+  private function removeUnusedSearchFields($form) {
     $basicSearchFields = $form->get_template_vars('basicSearchFields');
     $fieldsToRemove = [
       'privacy_toggle',

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearch.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearch.php
@@ -1,0 +1,54 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch {
+  /**
+   * Checks if the form is the contact advance search and removes
+   * some unnused fields if so.
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $this->removeUnnusedSearchFields($form);
+  }
+
+  /**
+   * Returns true if current form is for the contact advanced search.
+   * This indicates if the class should modify the form.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    $expectedFormName = 'CRM_Contact_Form_Search_Advanced';
+
+    return $formName === $expectedFormName;
+  }
+
+  /**
+   * Removes a few unnused fields from the contact advanced search, basic
+   * section.
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function removeUnnusedSearchFields($form) {
+    $basicSearchFields = $form->get_template_vars('basicSearchFields');
+    $fieldsToRemove = [
+      'privacy_toggle',
+      'preferred_communication_method',
+      'preferred_language'
+    ];
+
+    foreach ($fieldsToRemove as $fieldToRemove) {
+      unset($basicSearchFields[$fieldToRemove]);
+    }
+
+    $form->assign('basicSearchFields', $basicSearchFields);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -116,6 +116,7 @@ function hrcore_civicrm_buildForm($formName, &$form) {
   $listeners = [
     new CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier(),
     new CRM_HRCore_Hook_BuildForm_ActivityLinksFilter(),
+    new CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
     new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
   ];

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearchTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearchTest.php
@@ -1,0 +1,59 @@
+<?php
+use CRM_HRCore_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch as ContactAdvancedSearch;
+
+class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearchTest extends BaseHeadlessTest {
+
+  /**
+   * Assets that the hook removes the right fields and leaves others untouched.
+   */
+  public function testRemovingUnnusedFields() {
+    $form = new CRM_Core_Form();
+    $formName = 'CRM_Contact_Form_Search_Advanced';
+    $form->assign('basicSearchFields', [
+      'sort_name' => [],
+      'privacy_toggle' => [],
+      'preferred_communication_method' => [],
+      'preferred_language' => [],
+    ]);
+
+    $hook = new ContactAdvancedSearch();
+    $hook->handle($formName, $form);
+    $fields = $form->get_template_vars('basicSearchFields');
+
+    $this->assertEquals($fields, [
+      'sort_name' => []
+    ]);
+  }
+
+  /**
+   * Asserts that the hook is going to be executed only for the contact
+   * advanced search form.
+   */
+  public function testNotRemovingFieldsIfNotContactAdvancedSearchForm() {
+    $form = new CRM_Core_Form();
+    $formName = 'CRM_RelationshipType_Form';
+    $form->assign('basicSearchFields', $this->getBasicSearchFields());
+
+    $hook = new ContactAdvancedSearch();
+    $hook->handle($formName, $form);
+    $fields = $form->get_template_vars('basicSearchFields');
+
+    $this->assertEquals($fields, $this->getBasicSearchFields());
+  }
+
+  /**
+   * Returns a mock list of basic search fields.
+   *
+   * @return array
+   */
+  private function getBasicSearchFields() {
+    return [
+      'sort_name' => [],
+      'privacy_toggle' => [],
+      'preferred_communication_method' => [],
+      'preferred_language' => [],
+    ];
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearchTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Hook/BuildForm/ContactAdvancedSearchTest.php
@@ -7,7 +7,7 @@ class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearchTest extends BaseHeadlessTe
   /**
    * Assets that the hook removes the right fields and leaves others untouched.
    */
-  public function testRemovingUnnusedFields() {
+  public function testRemovingUnusedFields() {
     $form = new CRM_Core_Form();
     $formName = 'CRM_Contact_Form_Search_Advanced';
     $form->assign('basicSearchFields', [


### PR DESCRIPTION
## description

This PR removes a few unused fields from the Contact's advanced search form:

* Exclude / Include by Privacy Options
* Preferred Communication Method
* Preferred Language

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/41161266-49f8681e-6b00-11e8-8750-7e33f7bc4baf.png)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/41161270-4e2327a8-6b00-11e8-8446-b6b931df81e7.png)


## Technical details

A new buildForm hook was added to handle the removal of the fields:

```php
<?php

class CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch {

  public function handle($formName, &$form) {
    if (!$this->shouldHandle($formName)) {
      return;
    }

    $this->removeUnnusedSearchFields($form);
  }

  private function shouldHandle($formName) {
    $expectedFormName = 'CRM_Contact_Form_Search_Advanced';

    return $formName === $expectedFormName;
  }

  private function removeUnnusedSearchFields($form) {
    $basicSearchFields = $form->get_template_vars('basicSearchFields');
    $fieldsToRemove = [
      'privacy_toggle',
      'preferred_communication_method',
      'preferred_language'
    ];

    foreach ($fieldsToRemove as $fieldToRemove) {
      unset($basicSearchFields[$fieldToRemove]);
    }

    $form->assign('basicSearchFields', $basicSearchFields);
  }

}

```

The implementation is similar as the one for [ActivityFilterSelectFieldsModifier](https://github.com/civicrm/civihr/blob/staging/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityFilterSelectFieldsModifier.php)

## Notes

* This PR is tightly related to this core PR:
https://github.com/civicrm/civicrm-core/pull/12078


----
✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
✅PHP Unit Tests - passed
