### PR TITLE
PCHR-3636: Make Tests more Isolated, Fix SQL Bug

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -1336,7 +1336,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
     $leaveRequestRights = new LeaveRequestRightsService(new LeaveManagerService());
 
     $accessibleContacts = $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo();
-    $contactsAccessIN = "'" . implode(', ', $accessibleContacts) . "'";
+    $contactsAccessIN = implode(', ', $accessibleContacts);
     $notAccessibleLeaveRequestQuery = "SELECT id FROM {$leaveTable} 
       WHERE contact_id NOT IN ($contactsAccessIN) AND request_type ='" . LeaveRequest::REQUEST_TYPE_TOIL . "'";
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -234,10 +234,7 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
   }
 
   public function testGetFromEmailReturnsNullWhenThereIsNoOptionForTheFromEmailAddressOptionGroup() {
-    $values = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'from_email_address']);
-    foreach ($values['values'] as $value) {
-      civicrm_api3('OptionValue', 'delete', ['id' => $value['id']]);
-    }
+    $this->removeAllFromEmailAddresses();
 
     $leaveRequest = new LeaveRequest();
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory, $this->getManagerService());

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Mail/MessageTest.php
@@ -194,6 +194,8 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
   }
 
   public function testGetFromEmailReturnsTheFirstOptionFromTheFromEmailAddressOptionGroupWhenThereIsNoDefaultAddress() {
+    $this->removeAllFromEmailAddresses();
+
     $fromEmailAddress = [
       'From Email 1 <from_email1@testdomain.com>',
       'From Email 2 <from_email2@testdomain.com>',
@@ -232,6 +234,11 @@ class CRM_HRLeaveAndAbsences_Mail_MessageTest extends BaseHeadlessTest {
   }
 
   public function testGetFromEmailReturnsNullWhenThereIsNoOptionForTheFromEmailAddressOptionGroup() {
+    $values = civicrm_api3('OptionValue', 'get', ['option_group_id' => 'from_email_address']);
+    foreach ($values['values'] as $value) {
+      civicrm_api3('OptionValue', 'delete', ['id' => $value['id']]);
+    }
+
     $leaveRequest = new LeaveRequest();
     $message = new Message($leaveRequest, $this->leaveRequestTemplateFactory, $this->getManagerService());
     $fromEmail = $message->getFromEmail();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestMailNotificationSenderTest.php
@@ -84,6 +84,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestMailNotificationSenderTest exte
   }
 
   public function testSendThrowsExceptionWhenFromEmailIsNotConfigured() {
+    $this->removeAllFromEmailAddresses();
+
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
       'contact_id' => $this->leaveContact['id'],

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -4740,6 +4740,8 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testCreateReturnsFalseForFromEmailParameterWhenFromEmailIsNotConfigured() {
+    $this->removeAllFromEmailAddresses();
+
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
     $startDate = new DateTime();
@@ -5039,4 +5041,5 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
       'leave_date' => '2017-01-02']
     );
   }
+
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/helpers/MailHelpersTrait.php
@@ -70,4 +70,17 @@ trait CRM_HRLeaveAndAbsences_MailHelpersTrait {
   private function createDefaultFromEmail($label) {
     $this->createFromEmail($label, true);
   }
+
+  /**
+   * Delete all existing from email addresses
+   */
+  private function removeAllFromEmailAddresses() {
+    $options = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'from_email_address'
+    ]);
+
+    foreach ($options['values'] as $option) {
+      civicrm_api3('OptionValue', 'delete', ['id' => $option['id']]);
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Some tests seem to rely on the order in which they are run. This PR fixes those cases and also uncovered a bug in SQL generation, which was also fixed.

## Before

- Some tests that check behavior if no default FROM email is set will fail when run alone as the FROM email exists
- Generated SQL included an `IN` statement that wrapped the target IDs inside single quotes which meant it was treated as a single string argument instead of a list of integers.

## After

- The tests checking behavior without default FROM email address remove all FROM email addresses before running
- The bug in the SQL generation was fixed

## Notes

Regarding the SQL bug, the tests were passing on Jenkins but not on local sites. Here is an overview of the differences and causes.

#### Local Result

- 2 Leave Requests
- A has ID 3 with contact ID 9
- B has ID 4 with contact ID 10
- The query to find inaccessible contacts is "WHERE contact_id NOT IN ('8, 10')" which returns an array of 2
- Test fails since contact that should be accessible is inaccessible

#### Jenkins Results

- 2 Leave Requests
- A has ID 617 with contact ID 324
- B has ID 618 with contact ID 325
- The query to find inaccessible contacts is "WHERE contact_id NOT IN ('325, 323')" which returns an array of 1
- Tests pass since the accessible contact is not included in the inaccessible results

#### Why do the tests pass in Jenkins?

MySQL will cast the single string item in the `IN` list to an integer. This means '325, 323' becomes '325' which happens to be the result we're looking for. Locally the order is different. If the order had been '10, 8' the test passes (I tried this using `array_reverse`).

See https://stackoverflow.com/q/21762075/1196369 

#### Why is the order different?

Order cannot be relied upon in MySQL. MySQL 5.7 also had some changes to sort order which might explain the difference in this case.

See https://stackoverflow.com/q/21762075/1196369