### PR TITLE
PCHR-3820: Add Leave Request ACL Rules to LeaveRequest.getAttachments API

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachment.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachment.php
@@ -2,9 +2,30 @@
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_Service_LeaveManager as LeaveManagerService;
-use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRights;
+use CRM_HRLeaveAndAbsences_Service_LeaveRequestRights as LeaveRequestRightsService;
 
 class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment {
+
+  /**
+   * @var LeaveManagerService
+   */
+  private $leaveManagerService;
+
+  /**
+   * @var LeaveRequestRightsService
+   */
+  private $leaveRequestRightsService;
+
+  /**
+   * CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment constructor.
+   *
+   * @param LeaveRequestRightsService $leaveRequestRights
+   * @param LeaveManagerService $leaveManager
+   */
+  public function __construct(LeaveRequestRightsService $leaveRequestRights, LeaveManagerService $leaveManager) {
+    $this->leaveManagerService = $leaveManager;
+    $this->leaveRequestRightsService = $leaveRequestRights;
+  }
 
   /**
    * Uses the Attachment API to delete an attachment associated with a LeaveRequest.
@@ -24,9 +45,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment {
 
     if ($attachment['count'] > 0) {
       $leaveRequest = LeaveRequest::findById($attachment['values'][0]['entity_id']);
-      $leaveManagerService = new LeaveManagerService();
 
-      if ($leaveManagerService->currentUserIsAdmin() || $leaveManagerService->currentUserIsLeaveManagerOf($leaveRequest->contact_id)) {
+      if ($this->leaveManagerService->currentUserIsAdmin() || $this->leaveManagerService->currentUserIsLeaveManagerOf($leaveRequest->contact_id)) {
         return $this->callAttachmentAPI('delete', $params);
       }
 
@@ -81,17 +101,16 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment {
    * retrieve all Leave attachments for all contacts.
    *
    * @param array $params
+   * @param LeaveRequestRights $leaveRequestRights
    *
    * @return array
    */
   public function get($params) {
     $leaveRequestID = isset($params['entity_id']) ? $params['entity_id'] : '';
     $leaveRequest = LeaveRequest::findById($leaveRequestID);
-    $leaveManagerService = new LeaveManagerService();
-    $leaveRequestRights = new LeaveRequestRights($leaveManagerService);
-    $accessibleContacts = $leaveRequestRights->getLeaveContactsCurrentUserHasAccessTo();
+    $accessibleContacts = $this->leaveRequestRightsService->getLeaveContactsCurrentUserHasAccessTo();
 
-    if ($leaveManagerService->currentUserIsAdmin() || in_array($leaveRequest->contact_id, $accessibleContacts)) {
+    if ($this->leaveManagerService->currentUserIsAdmin() || in_array($leaveRequest->contact_id, $accessibleContacts)) {
       return $this->callAttachmentAPI('get', $params);
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -709,11 +709,15 @@ function _civicrm_api3_leave_request_getattachments_spec(&$spec) {
 function civicrm_api3_leave_request_getattachments($params) {
   $params['entity_id'] = $params['leave_request_id'];
   $params['entity_table'] = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
+  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment();
 
-  $result =  civicrm_api3('Attachment', 'get', $params);
+  $result =  $leaveRequestAttachmentService->get($params);
 
-  if ($result['count'] > 0) {
+  if (!empty($result)) {
     array_walk($result['values'], '_civicrm_api3_leave_request_filter_attachment_fields');
+  }
+  else{
+    $result = civicrm_api3_create_success([]);
   }
 
   return $result;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/api/v3/LeaveRequest.php
@@ -709,8 +709,9 @@ function _civicrm_api3_leave_request_getattachments_spec(&$spec) {
 function civicrm_api3_leave_request_getattachments($params) {
   $params['entity_id'] = $params['leave_request_id'];
   $params['entity_table'] = CRM_HRLeaveAndAbsences_BAO_LeaveRequest::getTableName();
-  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment();
-
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestRights = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment($leaveRequestRights, $leaveManagerService);
   $result =  $leaveRequestAttachmentService->get($params);
 
   if (!empty($result)) {
@@ -770,7 +771,9 @@ function _civicrm_api3_leave_request_deleteattachment_spec(&$spec) {
  * @return array
  */
 function civicrm_api3_leave_request_deleteattachment($params) {
-  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment();
+  $leaveManagerService = new CRM_HRLeaveAndAbsences_Service_LeaveManager();
+  $leaveRequestRights = new CRM_HRLeaveAndAbsences_Service_LeaveRequestRights($leaveManagerService);
+  $leaveRequestAttachmentService = new CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachment($leaveRequestRights, $leaveManagerService);
   return $leaveRequestAttachmentService->delete($params);
 }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachmentTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestAttachmentTest.php
@@ -53,10 +53,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
   public function testDeleteShouldDeleteAttachmentWhenLoggedInUserIsAnAdmin() {
     $params = $this->getDefaultLeaveRequestParams();
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
-
-    $leaveManagerService = $this->getLeaveManagerServiceWhenUserIsAdmin();
-    $leaveRequestRights = new LeaveRightsService($leaveManagerService);
-    $leaveRequestAttachmentService = new LeaveRequestAttachmentService($leaveRequestRights, $leaveManagerService);
+    $leaveRequestAttachmentService = $this->createLeaveRequestAttachmentsServiceWhenUserIsAdmin();
 
     $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
     $attachment2 = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
@@ -112,10 +109,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
   public function testDeleteShouldThrowAnExceptionWhenAttachmentHasBeenDeletedBefore() {
     $params = $this->getDefaultLeaveRequestParams();
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
-
-    $leaveManagerService = $this->getLeaveManagerServiceWhenUserIsAdmin();
-    $leaveRequestRights = new LeaveRightsService($leaveManagerService);
-    $leaveRequestAttachmentService = new LeaveRequestAttachmentService($leaveRequestRights, $leaveManagerService);
+    $leaveRequestAttachmentService = $this->createLeaveRequestAttachmentsServiceWhenUserIsAdmin();
 
     $attachment = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest->id]);
 
@@ -132,10 +126,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
    */
   public function testDeleteShouldThrowAnExceptionWhenAttachmentDoesNotExist() {
     $leaveRequestID = 1;
-
-    $leaveManagerService = $this->getLeaveManagerServiceWhenUserIsAdmin();
-    $leaveRequestRights = new LeaveRightsService($leaveManagerService);
-    $leaveRequestAttachmentService = new LeaveRequestAttachmentService($leaveRequestRights, $leaveManagerService);
+    $leaveRequestAttachmentService = $this->createLeaveRequestAttachmentsServiceWhenUserIsAdmin();
 
     $leaveRequestAttachmentService->delete(['leave_request_id' => $leaveRequestID, 'attachment_id' => 1]);
   }
@@ -204,7 +195,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
     $attachment1 = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest1->id]);
     $attachment2 = $this->createAttachmentForLeaveRequest(['entity_id' => $leaveRequest2->id]);
 
-
     $leaveManagerService = $this->getLeaveManagerServiceWhenUserIsAdmin();
     $leaveRightsService = $this->prophesize(LeaveRightsService::class);
     $leaveRightsService->getLeaveContactsCurrentUserHasAccessTo()->willReturn([]);
@@ -218,7 +208,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
     $this->assertEquals($staff1Attachment['values'][0]['id'], $attachment1['id']);
     $this->assertEquals($staff1Attachment['values'][0]['name'], $attachment1['name']);
 
-    $this->assertCount(1, $staff1Attachment['values']);
+    $this->assertCount(1, $staff2Attachment['values']);
     $this->assertEquals($staff2Attachment['values'][0]['id'], $attachment2['id']);
     $this->assertEquals($staff2Attachment['values'][0]['name'], $attachment2['name']);
   }
@@ -240,5 +230,13 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestAttachmentTest extends BaseHead
 
   private function getLeaveManagerServiceWhenUserIsLeaveApprover($leaveContact) {
    return $this->getLeaveManagerService(FALSE, $leaveContact);
+  }
+
+  private function createLeaveRequestAttachmentsServiceWhenUserIsAdmin() {
+    $leaveManagerService = $this->getLeaveManagerServiceWhenUserIsAdmin();
+    $leaveRequestRights = new LeaveRightsService($leaveManagerService);
+    $leaveRequestAttachmentService = new LeaveRequestAttachmentService($leaveRequestRights, $leaveManagerService);
+
+    return $leaveRequestAttachmentService;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -4369,7 +4369,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     civicrm_api3('LeaveRequest', 'getattachments');
   }
 
-  public function testGetAttachments() {
+  public function testGetAttachmentsReturnsAllExpectedFields() {
     $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
       'contact_id' => 1,
       'type_id' => $this->absenceType->id,

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -4415,6 +4415,185 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals($result, $expectedResult);
   }
 
+  public function testGetAttachmentsReturnsManageeAttachmentsOnlyForALeaveManager() {
+    $manager1 = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($manager1['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember1['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    $this->setContactAsLeaveApproverOf($manager1, $staffMember1);
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember1['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember2['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $fileName1 = 'LeaveRequestSampleFile1.txt';
+    $fileName2 = 'LeaveRequestSampleFile2.txt';
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest1->id,
+      'name' => $fileName1
+    ]);
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest2->id,
+      'name' => $fileName2
+    ]);
+
+    // Manager is able to access attachments for his managee
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest1->id, 'sequential' => 1]);
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals($fileName1, $result['values'][0]['name']);
+
+    // Manager is not a Leave approver for staffMember2, hence the results will be empty.
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest2->id, 'sequential' => 1]);
+    $this->assertEmpty($result['values']);
+  }
+
+  public function testGetAttachmentsShouldNotReturnAttachmentsForContactsOtherThanLoggedInUserWhenUserIsNotALeaveApproverOrAdmin() {
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+
+    $this->registerCurrentLoggedInContactInSession($staffMember1['id']);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API'];
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember1['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember1['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember2['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $fileName1 = 'LeaveRequestSampleFile1.txt';
+    $fileName2 = 'LeaveRequestSampleFile2.txt';
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest1->id,
+      'name' => $fileName1
+    ]);
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest2->id,
+      'name' => $fileName2
+    ]);
+
+    //Staff is able to access own Leave attachments
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest1->id, 'sequential' => 1]);
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals($fileName1, $result['values'][0]['name']);
+
+    //Staff is not able to access Leave attachments for other staff
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest2->id, 'sequential' => 1]);
+    $this->assertEmpty($result['values']);
+  }
+
+  public function testGetAttachmentsShouldReturnAllAttachmentsForAllContactsForAdmin() {
+    $adminID = 1;
+    $staffMember1 = ContactFabricator::fabricate();
+    $staffMember2 = ContactFabricator::fabricate();
+
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access AJAX API', 'administer leave and absences'];
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember1['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $staffMember2['id']],
+      ['period_start_date' => '2016-01-01']
+    );
+
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember1['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $staffMember2['id'],
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $fileName1 = 'LeaveRequestSampleFile1.txt';
+    $fileName2 = 'LeaveRequestSampleFile2.txt';
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest1->id,
+      'name' => $fileName1
+    ]);
+
+    $this->createAttachmentForLeaveRequest([
+      'entity_id' => $leaveRequest2->id,
+      'name' => $fileName2
+    ]);
+
+    // Admin is able to access attachments for staffMember1
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest1->id, 'sequential' => 1]);
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals($fileName1, $result['values'][0]['name']);
+
+    // Admin is able to access attachments for staffMember2
+    $result = civicrm_api3('LeaveRequest', 'getAttachments', ['leave_request_id' => $leaveRequest2->id, 'sequential' => 1]);
+    $this->assertCount(1, $result['values']);
+    $this->assertEquals($fileName2, $result['values'][0]['name']);
+  }
+
   /**
    * @expectedException CiviCRM_API3_Exception
    * @expectedExceptionMessage Mandatory key(s) missing from params array: leave_request_id

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -4370,24 +4370,40 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testGetAttachments() {
-    $leaveRequestID = 1;
-    $leaveRequestID2 = 2;
+    $leaveRequest1 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => 1,
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-01'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
+    $leaveRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' =>2,
+      'type_id' => $this->absenceType->id,
+      'from_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'to_date' => CRM_Utils_Date::processDate('2016-01-05'),
+      'from_date_type' => 1,
+      'to_date_type' => 1
+    ]);
+
     $attachment1 = $this->createAttachmentForLeaveRequest([
-      'entity_id' => $leaveRequestID,
+      'entity_id' => $leaveRequest1->id,
       'name' => 'LeaveRequestSampleFile1.txt'
     ]);
 
     $attachment2 = $this->createAttachmentForLeaveRequest([
-      'entity_id' => $leaveRequestID,
+      'entity_id' => $leaveRequest1->id,
       'name' => 'LeaveRequestSampleFile2.txt'
     ]);
 
     $attachment3 = $this->createAttachmentForLeaveRequest([
-      'entity_id' => $leaveRequestID2,
+      'entity_id' => $leaveRequest2->id,
       'name' => 'LeaveRequestSampleFile3.txt'
     ]);
 
-    $params = ['leave_request_id' => $leaveRequestID, 'sequential' => 1];
+    $params = ['leave_request_id' => $leaveRequest1->id, 'sequential' => 1];
     $result = civicrm_api3('LeaveRequest', 'getAttachments', $params);
 
     $expectedResult = [


### PR DESCRIPTION
## Overview
Currently the LeaveRequest.getAttachments API allows a staff to view leave attachments for another staff. This PR incorporates the Leave ACL rules into this API, basically, A staff should only be able to view own attachments, A manager should be able to view attachments for managees only while Admin can view leave attachments for all contacts leave requests.

## Before
- The LeaveRequest.getAttachments API does not return results based on Leave Request ACL rules

## After
- The LeaveRequest.getAttachments API returns results based on Leave Request ACL rules
