### PR TITLE
PCHR-3836: Update Existing Case Types with Case Type Category

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -182,6 +182,42 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
 
     return TRUE;
   }
+  
+  /**
+   * Sets case type category to Vacancy for application type or
+   * to Workflow if otherwise
+   *
+   * @return bool
+   */
+  public function upgrade_1432() {
+    $customFieldId = CRM_Core_BAO_CustomField::getCustomFieldID('Category');
+    if ($customFieldId == null) {
+      return FALSE;
+    }
+    
+    $category = "custom_" . $customFieldId;
+    // set category to Vacancy if name is application
+    civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'name' => 'application',
+      'api.CaseType.create' => [
+        'id' => '$value.id',
+        $category => 'Vacancy'
+      ],
+    ]);
+    
+    // set category to Workflow if name is not application
+    civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'name' => ['!=' => 'application'],
+      'api.CaseType.create' => [
+        'id' => '$value.id',
+        $category => 'Workflow'
+      ],
+    ]);
+    
+    return TRUE;
+  }
 
   /**
    * Replaces (Case) keyword and (Open Case) keyword with (Assignment) keyword


### PR DESCRIPTION
## Overview
After adding [category custom field](https://github.com/compucorp/civihr-tasks-assignments/pull/374) to case type, existing records are to be categorized. If case type name is application, they are defaulted to `Vacancy` otherwise they are defaulted to `Workflow`.

## Before
Existing case types are not grouped by categories

## After
Existing case types are assigned to either vacancy or workflow category.

## Technical Details
The upgrader is executed after the case type category have been setup.
```
$customFieldId = CRM_Core_BAO_CustomField::getCustomFieldID('Category');
if ($customFieldId == null) {
  return FALSE;
}
```