### PR TITLE
PCHR-3545: Changed Order For Individual Prefix

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -25,6 +25,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1015;
   use CRM_HRCore_Upgrader_Steps_1016;
   use CRM_HRCore_Upgrader_Steps_1017;
+  use CRM_HRCore_Upgrader_Steps_1018;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
@@ -1,0 +1,52 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1018 {
+
+  /**
+   * Changes the Order Of Individual Prefix
+   */
+  public function upgrade_1018() {
+    $this->up1018_changeOrderOfIndividualPrefix();
+
+    return TRUE;
+  }
+
+  /**
+   * Changes The Order of Individual Prefixes
+   */
+  private function up1018_changeOrderOfIndividualPrefix() {
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'individual_prefix',
+    ]);
+
+    $optionValues = $optionValues['values'];
+    foreach ($optionValues as $optionValueId => $optionValue) {
+      switch ($optionValue['name']) {
+        case 'Mr.':
+          $newWeight = 1;
+          break;
+
+        case 'Mrs.':
+          $newWeight = 2;
+          break;
+
+        case 'Ms.':
+          $newWeight = 3;
+          break;
+
+        case 'Miss':
+          $newWeight = 4;
+          break;
+
+        case 'Dr.':
+          $newWeight = 5;
+          break;
+      }
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $optionValueId,
+        'weight' => $newWeight,
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
Change order of individual prefix options to:
1. Mr.
2. Mrs.
3. Ms.
4. Miss
5. Dr.

## Before
The order used was the default for CiviCRM.
![screenshot from 2018-06-19 15 44 05](https://user-images.githubusercontent.com/1692858/41601052-b976c5ac-73d7-11e8-9dbc-647aa97ccec9.png)


## After
![screenshot from 2018-06-19 12 34 04](https://user-images.githubusercontent.com/1692858/41592534-28a594dc-73bd-11e8-856f-55b5222e4fdd.png)

