### PR TITLE
PCHR-3875: Add tracking of virtual pageviews for contact tabs

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -308,6 +308,13 @@ function hrcore_civicrm_pageRun($page) {
 }
 
 /**
+ * Implements hook_civicrm_coreResourceList().
+ */
+function hrcore_civicrm_coreResourceList(&$items, $region) {
+  CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrcore', 'js/hrcore.js');
+}
+
+/**
  * Implements hook_civicrm_navigationMenu().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/

--- a/uk.co.compucorp.civicrm.hrcore/js/hrcore.js
+++ b/uk.co.compucorp.civicrm.hrcore/js/hrcore.js
@@ -1,0 +1,26 @@
+/* global dataLayer */
+
+(function (window, CRM, dataLayer) {
+  trackContactTabVirtualPageviews();
+
+  /**
+   * Sends a virtual pageview to Google Analytics whenever the user clicks on
+   * any of the tabs of the Contact Summary page
+   *
+   * The path of the pageview is the Contact Summary page path + the selectedChild
+   * param's value of the selected tab, thus simulating the user landing
+   * directly on the tab
+   */
+  function trackContactTabVirtualPageviews () {
+    var contactPagePath = window.location.pathname + '?reset=1&cid=' + CRM.contactId;
+
+    CRM.$('#mainTabContainer').on('tabsactivate', function (event, ui) {
+      var tabName = ui.newTab[0].id.replace('tab_', '');
+
+      dataLayer.push({
+        event: 'virtual-pageview',
+        virtualPageviewPath: contactPagePath + '&selectedChild=' + tabName
+      });
+    });
+  }
+}(window, CRM, dataLayer));


### PR DESCRIPTION
## Overview
This PR adds virtual pageviews tracking for the Contact Summary tabs

The Contact Summary page does not trigger any browser history changes when switching tabs, meaning that Google Analytics cannot track by default the user's movement in it

In order to track the user, a custom script had been added to the hrcore extension which, open the user selecting a tab, creates a virtual pageview and sends it to GA via Google Tag Manager. The pageview has the URL that the page would have if the user were to land directly on the selected tab (so if the selected tab is "Job Roles", the virtual pageview url is `/civicrm/contact/view?reset=1&cid={id}&selectedChild=hrjobroles`)

## Technical Details
The custom script is inside `hrcore.js` a simple, vanilla js file contained in hrcore. There is a long term plan to eventually move the whole of hrui into hrcore, and that's the intent with which this file was created (as said the file is kept simple now, but it will grow in complexity later on as this hrui->hrcore migration will eventually happen)

## Comments
The event used to trigger the virtual pageview is "virtual-pageview" which is defined as a trigger in GTM

<img width="700" alt="trigger" src="https://user-images.githubusercontent.com/6400898/41609570-6a5731fa-73eb-11e8-969b-004e73c83428.png">

The trigger is linked to the "Virtual Pageview" tag, also defined in GTM

<img width="700" alt="tag" src="https://user-images.githubusercontent.com/6400898/41609610-8474bfda-73eb-11e8-9f5c-cfd3f4270537.png">

---

This PR was tested by checking the "Real time" section in GA, and seeing that the virtual pageviews where indeed coming in

<img width="700" alt="realtime" src="https://user-images.githubusercontent.com/6400898/41610345-3f176d14-73ed-11e8-8136-608174335f0a.png">
