### PR TITLE
PCHR-3611: Remove Main And Other Location Types

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
@@ -16,7 +16,7 @@ trait CRM_HRCore_Upgrader_Steps_1018 {
     $this->up1018_setDefaultLocationType('Work');
     $this->up1018_reserveLocationTypes(['Work', 'Personal']);
     $this->up1018_disableLocationType('Billing');
-    $this->up1018_deleteLocationTypes(['Home', 'Correspondence']);
+    $this->up1018_deleteLocationTypes(['Home', 'Correspondence', 'Main', 'Other']);
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview

Remove the "Main" and "Other" location types as they are not required.

## Before

The "Main" and "Other" location types existed on some sites

## After

The "Main" and "Other" location types are removed