### PR TITLE
PCHR-3889: Create Calendar Feed API, Model and Instance

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/calendar-feed-config.api.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/apis/calendar-feed-config.api.js
@@ -1,0 +1,48 @@
+/* eslint-env amd */
+
+define([
+  'leave-absences/shared/modules/apis',
+  'common/lodash',
+  'common/services/api'
+], function (apis, _) {
+  'use strict';
+
+  apis.factory('CalendarFeedConfigAPI', ['$log', 'api', '$q',
+    function ($log, api, $q) {
+      $log.debug('CalendarFeedConfigAPI');
+
+      var methods = {
+        all: all,
+        create: create
+      };
+
+      /**
+       * Returns all Calendar Feed Configs
+       *
+       * @return {Promise} resolved with an array of objects of feeds
+       */
+      function all () {
+        return this.sendGET('LeaveRequestCalendarFeedConfig', 'get', {}, false)
+          .then(function (response) {
+            return response.values;
+          });
+      }
+
+      /**
+       * Create a new Calendar Feed Config
+       *
+       * @param  {Object} params
+       *   params.title    {String}
+       *   params.timezone {String} eg. "Europe/London"
+       * @return {Promise} resolved with an object of a newly created feed
+       */
+      function create (params) {
+        return this.sendPOST('LeaveRequestCalendarFeedConfig', 'create', params)
+          .then(function (response) {
+            return response.values;
+          });
+      }
+
+      return api.extend(methods);
+    }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/instances/calendar-feed-config.instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/instances/calendar-feed-config.instance.js
@@ -9,6 +9,6 @@ define([
   instances.factory('CalendarFeedConfigInstance', [
     'ModelInstance',
     function (ModelInstance) {
-      return ModelInstance;
+      return ModelInstance.extend({});
     }]);
 });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/instances/calendar-feed-config.instance.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/instances/calendar-feed-config.instance.js
@@ -1,0 +1,14 @@
+/* eslint-env amd */
+
+define([
+  'leave-absences/shared/modules/models-instances',
+  'common/models/instances/instance'
+], function (instances) {
+  'use strict';
+
+  instances.factory('CalendarFeedConfigInstance', [
+    'ModelInstance',
+    function (ModelInstance) {
+      return ModelInstance;
+    }]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/calendar-feed-config.model.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/calendar-feed-config.model.js
@@ -1,0 +1,35 @@
+/* eslint-env amd */
+
+define([
+  'leave-absences/shared/modules/models',
+  'common/models/model',
+  'leave-absences/shared/apis/calendar-feed-config.api',
+  'leave-absences/shared/instances/calendar-feed-config.instance'
+], function (models) {
+  'use strict';
+
+  models.factory('CalendarFeedConfig', [
+    'Model', 'CalendarFeedConfigAPI', 'CalendarFeedConfigInstance',
+    function (Model, CalendarFeedConfigAPI, CalendarFeedConfigInstance) {
+      var methods = {
+        all: all
+      };
+
+      /**
+       * Get all feeds
+       *
+       * @return {Promise} resolves with an array of feeds instances
+       */
+      function all () {
+        return CalendarFeedConfigAPI.all()
+          .then(function (response) {
+            return response.map(function (calendarFeedConfig) {
+              return CalendarFeedConfigInstance.init(calendarFeedConfig, true);
+            });
+          });
+      }
+
+      return Model.extend(methods);
+    }
+  ]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/calendar-feed-config.model.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/shared/models/calendar-feed-config.model.js
@@ -11,9 +11,9 @@ define([
   models.factory('CalendarFeedConfig', [
     'Model', 'CalendarFeedConfigAPI', 'CalendarFeedConfigInstance',
     function (Model, CalendarFeedConfigAPI, CalendarFeedConfigInstance) {
-      var methods = {
+      return Model.extend({
         all: all
-      };
+      });
 
       /**
        * Get all feeds
@@ -28,8 +28,6 @@ define([
             });
           });
       }
-
-      return Model.extend(methods);
     }
   ]);
 });

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/calendar-feed-config-api-mock.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/apis/calendar-feed-config-api-mock.js
@@ -1,0 +1,33 @@
+/* eslint-env amd */
+
+define([
+  'common/lodash',
+  'leave-absences/mocks/data/calendar-feed-config.data',
+  'leave-absences/mocks/module',
+  'common/angularMocks'
+], function (_, calendarFeedConfigData, mocks) {
+  'use strict';
+
+  mocks.factory('CalendarFeedConfigAPIMock', [
+    '$q',
+    function ($q) {
+      var methods = {
+        all: all
+      };
+
+      /**
+       * Returns mocked data for all() method
+       *
+       * @return {Promise} resolves with an array of feed objects
+       */
+      function all () {
+        return $q.resolve()
+          .then(function () {
+            return calendarFeedConfigData.all().values;
+          });
+      }
+
+      return methods;
+    }
+  ]);
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/calendar-feed-config.data.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/data/calendar-feed-config.data.js
@@ -1,0 +1,74 @@
+/* eslint-env amd */
+
+define([
+  'common/lodash'
+], function (_) {
+  var methods = {
+    all: all,
+    singleDataSuccess: singleDataSuccess
+  };
+  var mockData = {
+    all: {
+      is_error: 0,
+      version: 3,
+      count: 3,
+      values: [
+        {
+          id: '1',
+          title: 'One',
+          timezone: 'Africa/Asmara',
+          hash: 'hsh7779kjJJK',
+          created: '2018-01-03 00:00:00'
+        },
+        {
+          id: '5',
+          title: 'Five',
+          timezone: 'Asia/Ulaanbaatar',
+          hash: 'wiYGuefher78ggh38',
+          created: '2018-01-18 23:59:59'
+        },
+        {
+          id: '89',
+          title: 'Eighty Nine',
+          timezone: 'Pacific/Port_Moresby',
+          hash: 'wefjh98wefhbwefIHI',
+          created: '2019-01-18 12:39:01'
+        }
+      ]
+    },
+    singleDataSuccess: {
+      'is_error': 0,
+      'version': 3,
+      'count': 1,
+      'values': [
+        {
+          id: '197',
+          title: 'One Hundred Ninety Seven',
+          timezone: 'Europe/London',
+          hash: '2u3fb8347yfb34y7fUUFHGV',
+          created: '2020-10-20 01:01:45'
+        }
+      ]
+    }
+  };
+
+  /**
+   * Returns a response with all feeds
+   *
+   * @return {Object}
+   */
+  function all () {
+    return _.clone(mockData.all);
+  }
+
+  /**
+   * Returns a response with a single feed
+   *
+   * @return {Object}
+   */
+  function singleDataSuccess () {
+    return _.clone(mockData.singleDataSuccess);
+  }
+
+  return methods;
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/calendar-feed-config.api.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/calendar-feed-config.api.spec.js
@@ -59,9 +59,11 @@ define([
       });
 
       it('calls the "LeaveRequestCalendarFeedConfig.create" endpoint with specified params', function () {
-        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[0]).toBe('LeaveRequestCalendarFeedConfig');
-        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[1]).toBe('create');
-        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[2]).toBe(params);
+        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args).toEqual([
+          'LeaveRequestCalendarFeedConfig',
+          'create',
+          params
+        ]);
       });
 
       it('returns expected data', function () {
@@ -73,13 +75,10 @@ define([
      * Intercept HTTP calls to be handled by httpBackend
      */
     function interceptHTTP () {
-      // Intercept backend calls for CalendarFeedConfigAPI.get
+      // Intercept backend calls for GET CalendarFeedConfigAPI.all
       $httpBackend.whenGET(/action=get&entity=LeaveRequestCalendarFeedConfig/)
         .respond(calendarFeedConfigData.all());
-      // Intercept backend calls for CalendarFeedConfigAPI.get
-      $httpBackend.whenGET(/action=create&entity=LeaveRequestCalendarFeedConfig/)
-        .respond(calendarFeedConfigData.singleDataSuccess());
-      // Intercept backend calls for LeaveRequest.create in POST
+      // Intercept backend calls for POST CalendarFeedConfigAPI.create
       $httpBackend.whenPOST(/\/civicrm\/ajax\/rest/)
         .respond(function (method, url, data) {
           if (mockHelper.isEntityActionInPost(data, 'LeaveRequestCalendarFeedConfig', 'create')) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/calendar-feed-config.api.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/apis/calendar-feed-config.api.spec.js
@@ -1,0 +1,91 @@
+/* eslint-env amd, jasmine */
+
+define([
+  'common/lodash',
+  'leave-absences/mocks/data/calendar-feed-config.data',
+  'leave-absences/mocks/helpers/helper',
+  'leave-absences/shared/apis/calendar-feed-config.api'
+], function (_, calendarFeedConfigData, mockHelper) {
+  'use strict';
+
+  describe('CalendarFeedConfigAPI', function () {
+    var $httpBackend, $rootScope, CalendarFeedConfigAPI, expectedResults;
+
+    beforeEach(module('leave-absences.apis'));
+    beforeEach(inject(['$httpBackend', '$rootScope', 'CalendarFeedConfigAPI',
+      function (_$httpBackend_, _$rootScope_, _CalendarFeedConfigAPI_) {
+        $httpBackend = _$httpBackend_;
+        $rootScope = _$rootScope_;
+        CalendarFeedConfigAPI = _CalendarFeedConfigAPI_;
+
+        interceptHTTP();
+      }
+    ]));
+
+    describe('all()', function () {
+      beforeEach(function () {
+        spyOn(CalendarFeedConfigAPI, 'sendGET').and.callThrough();
+        CalendarFeedConfigAPI
+          .all()
+          .then(function (results) {
+            expectedResults = results;
+          });
+        $rootScope.$digest();
+        $httpBackend.flush();
+      });
+
+      it('calls the "LeaveRequestCalendarFeedConfig.get" endpoint', function () {
+        expect(CalendarFeedConfigAPI.sendGET.calls.mostRecent().args[0]).toBe('LeaveRequestCalendarFeedConfig');
+        expect(CalendarFeedConfigAPI.sendGET.calls.mostRecent().args[1]).toBe('get');
+      });
+
+      it('returns expected data', function () {
+        expect(expectedResults).toEqual(calendarFeedConfigData.all().values);
+      });
+    });
+
+    describe('create()', function () {
+      var params = { any: 'param' };
+
+      beforeEach(function () {
+        spyOn(CalendarFeedConfigAPI, 'sendPOST').and.callThrough();
+        CalendarFeedConfigAPI
+          .create(params)
+          .then(function (results) {
+            expectedResults = results;
+          });
+        $rootScope.$digest();
+        $httpBackend.flush();
+      });
+
+      it('calls the "LeaveRequestCalendarFeedConfig.create" endpoint with specified params', function () {
+        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[0]).toBe('LeaveRequestCalendarFeedConfig');
+        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[1]).toBe('create');
+        expect(CalendarFeedConfigAPI.sendPOST.calls.mostRecent().args[2]).toBe(params);
+      });
+
+      it('returns expected data', function () {
+        expect(expectedResults).toEqual(calendarFeedConfigData.singleDataSuccess().values);
+      });
+    });
+
+    /**
+     * Intercept HTTP calls to be handled by httpBackend
+     */
+    function interceptHTTP () {
+      // Intercept backend calls for CalendarFeedConfigAPI.get
+      $httpBackend.whenGET(/action=get&entity=LeaveRequestCalendarFeedConfig/)
+        .respond(calendarFeedConfigData.all());
+      // Intercept backend calls for CalendarFeedConfigAPI.get
+      $httpBackend.whenGET(/action=create&entity=LeaveRequestCalendarFeedConfig/)
+        .respond(calendarFeedConfigData.singleDataSuccess());
+      // Intercept backend calls for LeaveRequest.create in POST
+      $httpBackend.whenPOST(/\/civicrm\/ajax\/rest/)
+        .respond(function (method, url, data) {
+          if (mockHelper.isEntityActionInPost(data, 'LeaveRequestCalendarFeedConfig', 'create')) {
+            return [201, calendarFeedConfigData.singleDataSuccess()];
+          }
+        });
+    }
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/instances/calendar-feed-config.instance.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/instances/calendar-feed-config.instance.spec.js
@@ -1,0 +1,35 @@
+/* eslint-env amd, jasmine */
+
+define([
+  'common/lodash',
+  'leave-absences/mocks/data/calendar-feed-config.data',
+  'leave-absences/shared/instances/calendar-feed-config.instance',
+  'leave-absences/shared/modules/models'
+], function (_, calendarFeedConfigData) {
+  'use strict';
+
+  describe('CalendarFeedConfigInstance', function () {
+    var CalendarFeedConfigInstance;
+
+    beforeEach(module('leave-absences.models'));
+
+    beforeEach(inject(function (_CalendarFeedConfigInstance_) {
+      CalendarFeedConfigInstance = _CalendarFeedConfigInstance_;
+    }));
+
+    describe('init()', function () {
+      var instance;
+      var sampleFeed = calendarFeedConfigData.all().values[0];
+
+      beforeEach(function () {
+        instance = CalendarFeedConfigInstance.init(sampleFeed, true);
+      });
+
+      it('has initial attributes', function () {
+        expect(_.every(sampleFeed, function (attributeValue, attributeName) {
+          return instance[attributeName] === attributeValue;
+        })).toBe(true);
+      });
+    });
+  });
+});

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/calendar-feed-config.model.spec.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/shared/models/calendar-feed-config.model.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env amd, jasmine */
+
+define([
+  'leave-absences/shared/models/calendar-feed-config.model',
+  'leave-absences/mocks/apis/calendar-feed-config-api-mock',
+  'leave-absences/shared/instances/calendar-feed-config.instance'
+], function () {
+  'use strict';
+
+  describe('CalendarFeedConfig', function () {
+    var $provide, $rootScope, CalendarFeedConfig, CalendarFeedConfigAPI;
+
+    beforeEach(module('leave-absences.models', 'leave-absences.mocks',
+      function (_$provide_) {
+        $provide = _$provide_;
+      }));
+
+    beforeEach(inject(function (_CalendarFeedConfigAPIMock_) {
+      $provide.value('CalendarFeedConfigAPI', _CalendarFeedConfigAPIMock_);
+    }));
+
+    beforeEach(inject(function (_CalendarFeedConfig_, _CalendarFeedConfigAPI_,
+      _$rootScope_) {
+      CalendarFeedConfig = _CalendarFeedConfig_;
+      CalendarFeedConfigAPI = _CalendarFeedConfigAPI_;
+      $rootScope = _$rootScope_;
+    }));
+
+    describe('all()', function () {
+      beforeEach(function () {
+        spyOn(CalendarFeedConfigAPI, 'all').and.callThrough();
+        CalendarFeedConfig.all();
+        $rootScope.$digest();
+      });
+
+      it('calls the equivalent API method', function () {
+        expect(CalendarFeedConfigAPI.all).toHaveBeenCalledWith();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds Calendar Feed API, model and instance files to support further front-end development of the Calendar Feeds. The files allow to:
- Create Calendar Feed
- Get all Calendar Feeds

## Before

The files did not exist.

## After

Calendar Feed API, Modal and Instance exist.

## Technical Details

The files were created in consistency with other API files, models and instances.

----
⏹Manual Tests - omitted
✅Jasmine Tests - augmented and passed
✅JS distributive files - included
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed