### PR TITLE
PCHR-3909: Fix Time Related Tests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeExpiryLogTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeExpiryLogTest.php
@@ -128,6 +128,6 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeExpiryLogTest extends BaseHea
 
     $dateNow = new DateTime();
     $expiryLog = LeaveBalanceChangeExpiryLog::create($params);
-    $this->assertEquals($dateNow, new DateTime($expiryLog->created_date), 10);
+    $this->assertEquals($dateNow, new DateTime($expiryLog->created_date), '', 10);
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3631,8 +3631,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ];
 
     $dateNow = new DateTime();
-    $this->assertEquals($dateNow, new DateTime ($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']), '', 10);
-    $this->assertEquals($dateNow, new DateTime ($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']), '', 10);
+    $this->assertEquals(
+      $dateNow,
+      new DateTime($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']),
+      '',
+      10
+    );
+    $this->assertEquals(
+      $dateNow,
+      new DateTime($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']),
+      '',
+      10
+    );
 
     //we need to remove the created dates from the array as its not possible to assert the exact value.
     unset($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -3631,8 +3631,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ];
 
     $dateNow = new DateTime();
-    $this->assertEquals($dateNow, new DateTime($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']), 10);
-    $this->assertEquals($dateNow, new DateTime($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']), 10);
+    $this->assertEquals($dateNow, new DateTime ($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']), '', 10);
+    $this->assertEquals($dateNow, new DateTime ($balanceExpiryLogs[$broughtForwardExpiryRecord->id]['created_date']), '', 10);
 
     //we need to remove the created dates from the array as its not possible to assert the exact value.
     unset($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']);


### PR DESCRIPTION
## Overview

Some tests fail in Jenkins

## Before

Some tests failed in staging. Depending on the time they were there could be a second of difference in two variables which caused a failure.

## After

The difference in time is accounted for

## Technical Details

It doesn't happen all the time, but sometimes staging tests fail.

The failing test is from L&A

```
There was 1 failure:
1) CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest::testCreateExpiryRecordsLogsExpiredBalanceChanges
10
Failed asserting that two DateTime objects are equal.
--- Expected
+++ Actual
@@ @@
-2018-06-20T13:52:23+0100
+2018-06-20T13:52:22+0100
```

The cause seems to be a slight difference in time. This difference happens if the first date is created near a change in seconds, and the second one happens in the next second.

The difference should be handled by the test, however the wrong parameter is passed to `assertEquals`

```
$this->assertEquals(
  $dateNow, 
  new DateTime($balanceExpiryLogs[$toilExpiryRecord->id]['created_date']),
  10
);
```

But looking at the method signature of `assertEquals`

```
public static function assertEquals(
  $expected, 
  $actual,
  $message = '', 
  $delta = 0.0,
  $maxDepth = 10,
  $canonicalize = false,
  $ignoreCase = false
)
```

We can see that `10` is being passed as `$message`, even though it's supposed to be `$delta`. This accounts for the "10" in the Jenkins failure message (see above)
