### PR TITLE
PCHR-3603: Relabel Line Manager Relationship

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -26,6 +26,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1016;
   use CRM_HRCore_Upgrader_Steps_1017;
   use CRM_HRCore_Upgrader_Steps_1018;
+  use CRM_HRCore_Upgrader_Steps_1020;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
@@ -1,0 +1,31 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1020 {
+
+  /**
+   * Rename Line Manager Relationship
+   */
+  public function upgrade_1020() {
+    $this->up1020_renameLineManagerRelationship();
+
+    return TRUE;
+  }
+
+  /**
+   * Renaming Line Manager Relationship
+   */
+  private function up1020_renameLineManagerRelationship() {
+    $relationshipType = civicrm_api3('RelationshipType', 'get', [
+      'name_b_a' => 'Line Manager',
+    ]);
+    if (empty($relationshipType['values'])) {
+      return;
+    }
+    civicrm_api3('RelationshipType', 'create', [
+      'id' => $relationshipType['id'],
+      'label_a_b' => 'Is Line Managed by',
+      'label_b_a' => 'Is Line Manager of',
+    ]);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
@@ -3,22 +3,22 @@
 trait CRM_HRCore_Upgrader_Steps_1020 {
 
   /**
-   * Rename Line Manager Relationship
+   * Relabel Line Manager Relationship
    */
   public function upgrade_1020() {
-    $this->up1020_renameLineManagerRelationship();
+    $this->up1020_reLabelLineManagerRelationship();
 
     return TRUE;
   }
 
   /**
-   * Renaming Line Manager Relationship
+   * ReLabeling Line Manager Relationship
    */
-  private function up1020_renameLineManagerRelationship() {
+  private function up1020_reLabelLineManagerRelationship() {
     $relationshipType = civicrm_api3('RelationshipType', 'get', [
       'name_b_a' => 'Line Manager',
     ]);
-    if (empty($relationshipType['values'])) {
+    if (empty($relationshipType['id'])) {
       return;
     }
     civicrm_api3('RelationshipType', 'create', [


### PR DESCRIPTION
## Overview
For old and new sites: Relabel "Line manager" relationship 

'Line Manager is' to 'Is Line Managed by'
'Line Manager' to 'Is Line Manager of'

## Before
![screenshot from 2018-06-21 09 17 45](https://user-images.githubusercontent.com/1692858/41704113-ae3e5f42-7535-11e8-87bc-56bc2473118a.png)

## After
![screenshot from 2018-06-21 09 19 03](https://user-images.githubusercontent.com/1692858/41704124-b6862e78-7535-11e8-8801-9406bb073ae0.png)

## Comments
Only changed the Label, because the name is used explicitly in some places, such as https://github.com/compucorp/civihr/blob/0a7d1905be8e5148222bece35aebb2a4884ebfc4/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Manager.php#L16