### PR TITLE
PCHR-3544: Hide Fields for Contact Summary

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -27,6 +27,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1017;
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1020;
+  use CRM_HRCore_Upgrader_Steps_1021;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
@@ -1,0 +1,82 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1021 {
+  
+  /**
+   * Hide Fields For Contact Summary
+   */
+  public function upgrade_1021() {
+    $valuesRemoved = $this->up1021_getContactEditOptionValues();
+    $optionValues = $this->up1021_getActiveContactEditOptionValues();
+    
+    $activeOptionValues = array_diff($optionValues, $valuesRemoved);
+    civicrm_api3('Setting', 'create', [
+      'contact_edit_options' => $activeOptionValues,
+    ]);
+    
+    return TRUE;
+  }
+  
+  /**
+   * Retrieves active contact edit option setting value
+   *
+   * @return array
+   */
+  private function up1021_getActiveContactEditOptionValues() {
+    $result = civicrm_api3('Setting', 'get', [
+      'sequential' => 1,
+      'return' => ['contact_edit_options'],
+    ]);
+    
+    return $result['values'][0]['contact_edit_options'];
+  }
+  
+  /**
+   * Retrieves value for contact edit options to be removed
+   *
+   * @return array
+   */
+  private function up1021_getContactEditOptionValues() {
+    $values = [];
+    $names = $this->up1021_getUnusedContactEditOptionNames();
+    
+    $params = [
+      'sequential' => 1,
+      'return' => ['value', 'name'],
+      'option_group_id' => 'contact_edit_options',
+      'is_active' => 1,
+      'name' => ['IN' => $names]
+    ];
+    
+    $optionValues = civicrm_api3('OptionValue', 'get', $params);
+    foreach ($optionValues['values'] as $optionValue) {
+      array_push($values, $optionValue['value']);
+    }
+  
+    return $values;
+  }
+  
+  /**
+   * Get names of contact edit options not in use
+   *
+   * @return array
+   */
+  private function up1021_getUnusedContactEditOptionNames() {
+    $names = [];
+    
+    foreach (['Contact', 'IM', 'Website'] as $name) {
+      $params = ['return' => ['id']];
+      if ($name == 'Contact') {
+        $params['suffix_id'] = ['IS NOT NULL' => 1];
+      }
+      
+      $result = civicrm_api3($name, 'get', $params);
+      if ($result['count'] == 0) {
+        array_push($names, $name == 'Contact' ? 'Suffix' : $name);
+      }
+    }
+    
+    return $names;
+  }
+  
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
@@ -4,12 +4,14 @@ trait CRM_HRCore_Upgrader_Steps_1022 {
   
   /**
    * Hide Fields For Contact Summary
+   *
+   * @return bool
    */
   public function upgrade_1022() {
-    $valuesRemoved = $this->up1022_getContactEditOptionValues();
-    $optionValues = $this->up1022_getActiveContactEditOptionValues();
+    $valuesToRemove = $this->up1022_getContactEditOptionValuesToRemove();
+    $activeOptionValues = $this->up1022_getActiveContactEditOptionValues();
     
-    $activeOptionValues = array_diff($optionValues, $valuesRemoved);
+    $activeOptionValues = array_diff($activeOptionValues, $valuesToRemove);
     civicrm_api3('Setting', 'create', [
       'contact_edit_options' => $activeOptionValues,
     ]);
@@ -24,11 +26,10 @@ trait CRM_HRCore_Upgrader_Steps_1022 {
    */
   private function up1022_getActiveContactEditOptionValues() {
     $result = civicrm_api3('Setting', 'get', [
-      'sequential' => 1,
       'return' => ['contact_edit_options'],
     ]);
     
-    return $result['values'][0]['contact_edit_options'];
+    return $result['values'][$result['id']]['contact_edit_options'];
   }
   
   /**
@@ -36,21 +37,20 @@ trait CRM_HRCore_Upgrader_Steps_1022 {
    *
    * @return array
    */
-  private function up1022_getContactEditOptionValues() {
+  private function up1022_getContactEditOptionValuesToRemove() {
     $values = [];
     $names = $this->up1022_getUnusedContactEditOptionNames();
     
     $params = [
-      'sequential' => 1,
       'return' => ['value', 'name'],
       'option_group_id' => 'contact_edit_options',
       'is_active' => 1,
       'name' => ['IN' => $names]
     ];
     
-    $optionValues = civicrm_api3('OptionValue', 'get', $params);
-    foreach ($optionValues['values'] as $optionValue) {
-      array_push($values, $optionValue['value']);
+    $results = civicrm_api3('OptionValue', 'get', $params);
+    foreach ($results['values'] as $result) {
+      array_push($values, $result['value']);
     }
     
     return $values;
@@ -66,13 +66,13 @@ trait CRM_HRCore_Upgrader_Steps_1022 {
     
     foreach (['Contact', 'IM', 'Website'] as $name) {
       $params = ['return' => ['id']];
-      if ($name == 'Contact') {
+      if ($name === 'Contact') {
         $params['suffix_id'] = ['IS NOT NULL' => 1];
       }
       
       $result = civicrm_api3($name, 'get', $params);
       if ($result['count'] == 0) {
-        array_push($names, $name == 'Contact' ? 'Suffix' : $name);
+        array_push($names, $name === 'Contact' ? 'Suffix' : $name);
       }
     }
     


### PR DESCRIPTION
## Overview
Some contact summary fields are visible by default. This PR changes the default for Suffix, Instant messenger and Social Accounts to un-check so they are hidden from users by default

## Before
<img width="666" alt="contact_before" src="https://user-images.githubusercontent.com/1507645/41711119-43e00844-753f-11e8-86ba-7efe1b789f4a.png">


## After
<img width="665" alt="contact_after" src="https://user-images.githubusercontent.com/1507645/41711129-49c7ee84-753f-11e8-85b2-edaab9ce15cf.png">


## Technical Details
Before un-checking the fields, it was ensured that no record previously existed relating to them.

```php
private function up1022_getUnusedContactEditOptionNames() {
    $names = [];
    
    foreach (['Contact', 'IM', 'Website'] as $name) {
      $params = ['return' => ['id']];
      if ($name === 'Contact') {
        $params['suffix_id'] = ['IS NOT NULL' => 1];
      }
      
      $result = civicrm_api3($name, 'get', $params);
      if ($result['count'] == 0) {
        array_push($names, $name === 'Contact' ? 'Suffix' : $name);
      }
    }
    
    return $names;
}
```

They are also compared against previously activated fields. This implies that they are ignored if not previously checked.

```php
public function upgrade_1022() {
    $valuesRemoved = $this->up1022_getContactEditOptionValues();
    $optionValues = $this->up1022_getActiveContactEditOptionValues();
    
    $activeOptionValues = array_diff($optionValues, $valuesRemoved);
    civicrm_api3('Setting', 'create', [
      'contact_edit_options' => $activeOptionValues,
    ]);
    
    return TRUE;
  }
```
