### PR TITLE
PCHR-3886: Create the Can Administer Calendar Feeds Permission

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -108,6 +108,7 @@ function hrleaveandabsences_civicrm_permission(&$permissions) {
   $permissions['administer leave and absences'] = $prefix . ts('Administer Leave and Absences');
   $permissions['access leave and absences in ssp'] = $prefix . ts('Access Leave and Absences in SSP');
   $permissions['manage leave and absences in ssp'] = $prefix . ts('Manage Leave and Absences in SSP');
+  $permissions['can administer calendar feeds'] = $prefix . ts('Can Administer Calendar Feeds');
 }
 
 /**


### PR DESCRIPTION
## Overview
Based on the Requirements for the Leave Request Calendar Feeds Epic, We need a new permission which when assigned to roles will allow users with such roles to be able to administer a Calendar feed.

## Before
- The `Can Administer Calendar Feeds` Permission does not exist

## After
- The `Can Administer Calendar Feeds` Permission is added via the Leave and Absence Extension
