### PR TITLE
PCHR-3755: Fix duplicated "Localise CiviHR" menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -27,6 +27,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1017;
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1019;
+  use CRM_HRCore_Upgrader_Steps_1020;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php
@@ -126,7 +126,7 @@ trait CRM_HRCore_Upgrader_Steps_1012 {
   ) {
     $params = array_merge([
       'name' => $name,
-      'label' => ts($name),
+      'label' => $name,
       'permission' => $permission,
       'parent_id' => $parentID,
       'is_active' => 1,

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1020.php
@@ -1,0 +1,118 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1020 {
+
+  /**
+   * Removes duplicated "Localise CiviHR" menu item
+   *
+   * This upgrader will:
+   * - Delete any menu item with the "Localise CiviHR" label
+   * - Makes sure that one menu item with the "Localise CiviCRM" label exists
+   *
+   * On the interface, due to the word replace in the HRUI extension, the
+   * "Localise CiviCRM" label will be displayed as "Localise CiviHR".
+   */
+  public function upgrade_1020() {
+    $this->up1020_deleteLocaliseCiviHRMenuItem();
+    $this->up1020_createLocaliseCiviCRMMenuItemIfItDoesNotExist();
+
+    return TRUE;
+  }
+
+  /**
+   * Deletes a menu item with the "Localise CiviHR" label, if it exists.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function up1020_deleteLocaliseCiviHRMenuItem() {
+    civicrm_api3('Navigation', 'get', [
+      'sequential' => 1,
+      'label' => 'Localise CiviHR',
+      'api.Navigation.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * Creates a new menu item with the "Localise CiviCRM" label, if not such
+   * item exists.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function up1020_createLocaliseCiviCRMMenuItemIfItDoesNotExist() {
+    $administerId = $this->up1020_getAdministerMenuId();
+
+    if (!$administerId) {
+      return;
+    }
+
+    $params = [
+      'name' => 'Localise CiviCRM',
+      'label' => 'Localise CiviCRM',
+      'permission' => 'access CiviCRM',
+      'parent_id' => $administerId,
+      'url' => 'civicrm/admin/setting/localization?reset=1'
+    ];
+
+    $result = civicrm_api3('Navigation', 'get', $params);
+
+    if ($result['count'] == 0) {
+      $params['is_active'] = 1;
+      $newItem = civicrm_api3('Navigation', 'create', $params);
+
+      $firstAdministerChild = $this->up1020_getFirstChildOfParent($administerId);
+      // makes Localise CiviCRM the first
+      // CiviCRM does not allow to set the weight when creating a new item, so
+      // we need to update that after it has been created
+      civicrm_api3('Navigation', 'create', [
+        'id' => $newItem['id'],
+        'weight' => ((int) $firstAdministerChild['weight']) - 1
+      ]);
+    }
+  }
+
+  /**
+   * Returns the first child menu item for the item with the given
+   * parent ID.
+   *
+   * The get the first child, the weight of the children will be used
+   * for ordering.
+   *
+   * @param int $parentID
+   *
+   * @return array
+   *   An array representing the menu item record
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  private function up1020_getFirstChildOfParent($parentID) {
+    $result = civicrm_api3('Navigation', 'get', [
+      'sequential' => 1,
+      'parent_id' => $parentID,
+      'options' => ['sort' => 'weight', 'limit' => 1],
+    ])['values'];
+
+    return array_shift($result);
+  }
+
+  /**
+   * Returns the ID of the "Administer" menu for the current domain
+   *
+   * @return int
+   */
+  private function up1020_getAdministerMenuId() {
+    $domain = CRM_Core_Config::domainID();
+
+    try {
+      $administerId = (int) civicrm_api3('Navigation', 'getvalue', [
+        'return' => 'id',
+        'name' => 'Administer',
+        'domain_id' => $domain
+      ]);
+    } catch (Exception $e) {
+      return NULL;
+    }
+
+    return $administerId;
+  }
+
+}


### PR DESCRIPTION
## Overview

In some sites, the "Localise CiviHR" menu (under "Configure") was appearing duplicated. This was happening for two reasons:

- The upgraders were being called twice. This was already fixed by https://github.com/compucorp/civihr/pull/2659
- The upgrader which adds the menu item was relying on translated strings that were not stored in the database. For this reason, it could not find the existing menu item and would end up creating a new one

## Before

On https://github.com/compucorp/civihr/pull/2659, we fixed the issue for new sites, as the upgraders would not run twice anymore. However, the duplicated menu still exists in sites created after the menu item has been added and before the fix was release.

## After

New and existing sites don't have the duplicated menu anymore.

## Technical Details

In CiviHR, we use Word Replacements to replace the word `CiviCRM` by `CiviHR` ([here](https://github.com/compucorp/civihr/blob/staging/hrui/CRM/HRUI/HRUI.mgd.php#L13-L14)). So, something like `ts('Localise CiviCRM')` will return `'Localise CiviHR'`. The configuration for the Word Replacement is in the HRUI extension, meaning that if the extension is not installed, then no replacement will happen.

The code that was used to create the menu item is [the upgrader 1012](https://github.com/compucorp/civihr/blob/61bfe3018cf1797c7e5d13bf5df62cdaf2d0603a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1012.php#L129) of the HRCore extension. As it's possible to see, it uses a `ts()` around the item label, which means that:

- It will only find an item if the translated value has been stored in the database (which is something that should not happen)
- If it doesn't find the item, it will crreate a new one and save the translate label to the database.

When setting up a new site, HRCore is installed before the HRUI extension. So, when the upgrader 1012 runs the word replacement is not available and `'Localise CiviCRM'` will not be translated to `'Localise CiviHR'` and a item with the label `'Localise CiviCRM'` will be created in the database. The next time the upgrader would run (when `drush cvapi extension.upgrade` was called after the site was created) the HRUI would be available and the translation would result in a label equal to `Localise CiviHR`. Since there's no item in the database with that label, a new one would be created. 

In the interface, because of the word replacement, both the `Localise CiviCRM` and `Localise CiviHR` labels are displayed as `Localise CiviHR`, hence the duplicated menu.

This PR adds an upgrader to remove the duplication and make sure that, in the database, only one menu item will exist and its label will be `Localise CiviCRM`, as the translation to `Localise CiviHR` should happen only when displaying the menu on the interface.