### PR TITLE
PCHR-3911: QuickForm Error on the Localise CiviHR Page

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -93,8 +93,9 @@ function hrui_civicrm_buildForm($formName, &$form) {
     }
   }
 
-  if ($form instanceof CRM_Admin_Form_Setting_Localization) {
-    $form->removeElement('makeMultilingual');
+  if ($form instanceof CRM_Admin_Form_Setting_Localization &&
+    $form->elementExists('makeMultilingual')) {
+      $form->removeElement('makeMultilingual');
   }
 }
 


### PR DESCRIPTION
## Overview
When accessing the localise page on CiviHR, an error was thrown saying `QuickForm Error: nonexistent html element`. This PR fixes the issue.

## Before
<img width="1397" alt="before_quickform_error" src="https://user-images.githubusercontent.com/1507645/41853879-c1c9974e-7886-11e8-9813-dc6760f7dfad.png">


## After
![after_quickform](https://user-images.githubusercontent.com/1507645/41853893-cd15b736-7886-11e8-9f7c-c4d3198f4a4b.gif)


## Technical Details
Check was carried out to ascertain the form `makeMultilingual` element exists, before removing it.
```php
$form->elementExists('makeMultilingual')
```
