### PR TITLE
PCHR-3919: Show non-working days on leave calendar

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/leave-calendar-day.html
@@ -6,8 +6,8 @@
   uib-tooltip-clickable="true"
   ng-class="{
     'chr_leave-calendar__day-container--type--weekend': day.contactData.isWeekend,
-    'chr_leave-calendar__day-container--non-working': day.contactData.isNonWorkingDay,
-    'chr_leave-calendar__day-container--public-holiday': day.contactData.isPublicHoliday
+    'chr_leave-calendar__day-container--type--non-working': day.contactData.isNonWorkingDay,
+    'chr_leave-calendar__day-container--type--public-holiday': day.contactData.isPublicHoliday
   }">
   <div class="chr_leave-calendar__item"
     ng-repeat="(leaveRequestIndex, leaveRequest) in day.contactData.leaveRequestsToShowInCell"


### PR DESCRIPTION
## Overview

This PR shows non-working days in the Staff Leave Calendar. It also now shows public holidays.

## Before

<img width="1192" alt="screen shot 2018-06-25 at 15 31 47" src="https://user-images.githubusercontent.com/3973243/41856459-13822230-788d-11e8-8359-422f597887e3.png">

## After

<img width="1171" alt="screen shot 2018-06-25 at 15 37 02" src="https://user-images.githubusercontent.com/3973243/41856797-e10e2aa0-788d-11e8-9698-154ca8e39c45.png">

## Technical Details

Match HTML classes with CSS selectors:

```js
chr_leave-calendar__day-container--non-working
// to 
chr_leave-calendar__day-container--type--non-working
// and
chr_leave-calendar__day-container--public-holiday
// to
chr_leave-calendar__day-container--type--public-holiday
```
```html
<div class="chr_leave-calendar__day-container"
  ...
  ng-class="{
    'chr_leave-calendar__day-container--type--weekend': day.contactData.isWeekend,
    'chr_leave-calendar__day-container--type--non-working': day.contactData.isNonWorkingDay,
    'chr_leave-calendar__day-container--type--public-holiday': day.contactData.isPublicHoliday
  }">
```
```css
/* Already like that */
.chr_leave-calendar__day-container--type--non-working {
  background-color: $chr-leave-calendar-item-non-working-day-background-color;
}
.chr_leave-calendar__day-container--type--public-holiday {
  background-color: $chr-leave-calendar-item-public-holiday-background-color;
}
.chr_leave-calendar__day-container--type--weekend {
  background-color: $chr-leave-calendar-item-weekend-background-color;
}
```

-----
Only manual tests were performed.