### PR TITLE
PCHR-3391: Fix leave type in staff report after request deletion

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/leave-request-dates.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/leave-request-dates.html
@@ -1,9 +1,9 @@
-{{request.from_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
+{{request.from_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : absenceType.calculation_unit_name)}}
 <span ng-if="request.dates.length > 1">
   -
-  {{request.to_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : unit)}}
+  {{request.to_date | formatDate : null : (request.request_type === 'toil' ? 'hours' : absenceType.calculation_unit_name)}}
 </span>
-<span ng-if="request.dates.length === 1 && (unit === 'hours' || request.request_type === 'toil')">
+<span ng-if="request.dates.length === 1 && (absenceType.calculation_unit_name === 'hours' || request.request_type === 'toil')">
   -
   {{request.to_date.slice(11, 16)}}
 </span>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-requests-rows.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-requests-rows.html
@@ -1,14 +1,11 @@
-<tr
-  ng-repeat="request in requests track by $index"
-  ng-init="absenceType = report.absenceTypesIndexed[request.type_id]">
+<tr ng-repeat="request in requests track by $index">
   <td class="chr_leave-report__label">
-    {{absenceType.title}}
+    {{report.absenceTypesIndexed[request.type_id].title}}
     <span ng-if="request.toil_expiry_date">
       (expires {{request.toil_expiry_date | formatDate}})
     </span>
   </td>
-  <td ng-init="unit = absenceType.calculation_unit_name"
-    ng-include="$root.sharedPathTpl + 'components/partials/leave-request-dates.html'"></td>
+  <td ng-include="$root.sharedPathTpl + 'components/partials/leave-request-dates.html'"></td>
   <td>{{report.leaveRequestStatuses[request.status_id].label}}</td>
   <td ng-repeat="absenceType in report.absenceTypesFiltered track by $index"
     title="({{ absenceType.calculation_unit_label | lowercase }})">


### PR DESCRIPTION
## Overview

This PR fixes the issue when you delete a leave request from the Staff Report screen and the leave types are showed wrong.

## Before

The dates of the request that was not deleted are correct, but the leave type is wrong.

![1](https://user-images.githubusercontent.com/3973243/41861590-a8966ed8-7899-11e8-9cbe-97b235a045cd.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/41860154-c8e1d906-7895-11e8-9ffd-e69b3ff9ef81.gif)


## Technical Details

This happens because of `ng-init`, which does not react to the changes.

```js
<tr
  ng-repeat="request in requests track by $index"
  ng-init="absenceType = report.absenceTypesIndexed[request.type_id]"
<!-- ^ nope -->
```

## Comments
This PR also fixes the same issue but with the calculation unit.

------

Only manual tests were performed.