### PR TITLE
PCHR-3555: Rename Job Contract Benefit Name

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1279,6 +1279,23 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
   
   /**
+   * Renames page title from job contract benefit name to benefits
+   *
+   * @return bool
+   */
+  public function upgrade_1038() {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => 'hrjc_benefit_name',
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'title' => 'Benefits'
+      ],
+    ]);
+    
+    return TRUE;
+  }
+
+  /**
    * Creates a navigation menu item using the API
    *
    * @param string $name


### PR DESCRIPTION
## Overview
This PR renames page title from `Job Contract Benefit Name` to `Benefits`.

## Before
<img width="672" alt="before_hrjobcontract" src="https://user-images.githubusercontent.com/1507645/41902543-9f44a2fe-792b-11e8-9b8c-bf4b639ab625.png">

## After
<img width="667" alt="after_hrjobcontract" src="https://user-images.githubusercontent.com/1507645/41902531-9484f530-792b-11e8-8cd7-14732cb291ff.png">

## Technical Details
An upgrader was executed to change the page title for job contract benefit to Benefits
```php
'api.OptionGroup.create' => [
  'id' => '$value.id',
  'title' => 'Benefits'
],
```