### PR TITLE
PCHR-3557: Rename Job Contract Revision Change Reason

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1313,6 +1313,24 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
   
   /**
+   * Renames option group title from job contract revision change reason to
+   * contract revision reasons
+   *
+   * @return bool
+   */
+  public function upgrade_1040() {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => 'hrjc_revision_change_reason',
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'title' => 'Contract Revision Reasons'
+      ]
+    ]);
+    
+    return TRUE;
+  }
+  
+  /**
    * Creates a navigation menu item using the API
    *
    * @param string $name


### PR DESCRIPTION
## Overview
This PR renames page title from `Job Contract Revision Change Reason` to `Contract Revision Reasons`.

## Before
<img width="666" alt="before_hrjc_revision_change_reason" src="https://user-images.githubusercontent.com/1507645/41907460-d8a4657c-7938-11e8-9621-419adb900774.png">


## After
<img width="665" alt="after_hrjc_revision_change_reason" src="https://user-images.githubusercontent.com/1507645/41907477-e9a5aade-7938-11e8-857a-8188815bcbb9.png">


## Technical Details
An upgrader was executed to change the page title for job contract revision change reason to `Contract Revision Reasons`
```php
'api.OptionGroup.create' => [
  'id' => '$value.id',
  'title' => 'Contract Revision Reasons'
],
```