### PR TITLE
PCHR-3556: Rename Job Contract Deduction Name

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1294,7 +1294,24 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     
     return TRUE;
   }
-
+  
+  /**
+   * Renames page title from job contract deduction name to deductions
+   *
+   * @return bool
+   */
+  public function upgrade_1039() {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => 'hrjc_deduction_name',
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'title' => 'Deductions'
+      ],
+    ]);
+    
+    return TRUE;
+  }
+  
   /**
    * Creates a navigation menu item using the API
    *


### PR DESCRIPTION
## Overview
This PR renames page title from `Job Contract Deduction Name` to `Deductions`.

## Before
<img width="670" alt="before_hrjc_deduction_name" src="https://user-images.githubusercontent.com/1507645/41905585-8de4bc4e-7933-11e8-9a12-5ab2b85f4e1c.png">


## After
<img width="662" alt="after_hrjc_deduction_name" src="https://user-images.githubusercontent.com/1507645/41905764-04a06cb6-7934-11e8-9160-5bf30b165945.png">


## Technical Details
An upgrader was executed to change the page title for job contract deduction to Deductions
```php
'api.OptionGroup.create' => [
  'id' => '$value.id',
  'title' => 'Deductions'
],
```