### PR TITLE
PCHR-3558: Rename Job Contract End Reason

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1277,6 +1277,24 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     
     return TRUE;
   }
+
+  /**
+   * Renames option group title from job contract end reason
+   * to contract end reasons
+   *
+   * @return bool
+   */
+  public function upgrade_1041() {
+    civicrm_api3('OptionGroup', 'get', [
+      'name' => 'hrjc_contract_end_reason',
+      'api.OptionGroup.create' => [
+        'id' => '$value.id',
+        'title' => 'Contract End Reasons'
+      ],
+    ]);
+    
+    return TRUE;
+  }
   
   /**
    * Creates a navigation menu item using the API


### PR DESCRIPTION
## Overview
This PR renames page title from `Job Contract End Reasons` to `Contract End Reasons`.

## Before
<img width="664" alt="before_hrjc_contract_end_reason" src="https://user-images.githubusercontent.com/1507645/41908970-9f090ebc-793d-11e8-854f-1dc1a98f88c6.png">

## After
<img width="660" alt="after_hrjc_contract_end_reason" src="https://user-images.githubusercontent.com/1507645/41908799-27d4014e-793d-11e8-8d61-e3254d150d7a.png">

## Technical Details
An upgrader was executed to change the page title for job contract end reasons to `Contract End Reasons`
```php
'api.OptionGroup.create' => [
  'id' => '$value.id',
  'title' => 'Contract End Reasons'
],
```
