### PR TITLE
PCHR-3866: Administer Calendar Feeds Functionality

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
@@ -113,4 +113,28 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
       unset($params['created_date'], $params['hash']);
     }
   }
+
+  /**
+   * Returns an array containing all the fields values for the
+   * LeaveRequestCalendarFeedConfig with the given ID.
+   *
+   * This method is mainly used by the LeaveRequestCalendarFeedConfig form, so it
+   * can get the data to fill its fields.
+   *
+   * An empty array is returned if it is not possible to load
+   * the data.
+   *
+   * @param int $id
+   *  The id of the LeaveRequestCalendarFeedConfig to retrieve the values
+   *
+   * @return array An array containing the values
+   */
+  public static function getValuesArray($id) {
+    try {
+      $result = civicrm_api3('LeaveRequestCalendarFeedConfig', 'getsingle', ['id' => $id]);
+      return $result;
+    } catch (CiviCRM_API3_Exception $ex) {
+      return [];
+    }
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
@@ -1,0 +1,185 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig as LeaveRequestCalendarFeedConfig;
+use CRM_HRLeaveAndAbsences_Exception_InvalidLeaveRequestCalendarFeedConfigException as InvalidLeaveRequestCalendarFeedConfigException;
+
+/**
+ * Form controller class
+ *
+ * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
+ */
+class CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig extends CRM_Core_Form {
+
+  /**
+   * When in edit mode, this is the ID of the LeaveRequestCalendarFeedConfig being edited
+   *
+   * @var int
+   */
+  protected $_id = null;
+
+  /**
+   * @var array
+   *  Holds the default values for all the fields in this form
+   */
+  private $defaultValues = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setDefaultValues() {
+    if(empty($this->defaultValues)) {
+      if ($this->_id) {
+        $this->defaultValues = LeaveRequestCalendarFeedConfig::getValuesArray($this->_id);
+        $this->defaultValues['_id'] = $this->_id;
+      }
+    }
+
+    return $this->defaultValues;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildQuickForm() {
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->addCalendarFeedConfigFields();
+    $this->addButtons($this->getAvailableButtons());
+    $this->assign('deleteUrl', $this->getDeleteUrl());
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css');
+    parent::buildQuickForm();
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postProcess() {
+    if ($this->_action & (CRM_Core_Action::ADD | CRM_Core_Action::UPDATE)) {
+      // store the submitted values in an array
+      $params = $this->exportValues();
+
+      if ($this->_action & CRM_Core_Action::UPDATE) {
+        $params['id'] = $this->_id;
+      }
+
+      //when a checkbox is not checked, it is not sent on the request
+      //so we check if it wasn't sent and set the param value to 0
+      if(!array_key_exists('is_active', $params)) {
+        $params['is_active'] = 0;
+      }
+
+      $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
+      try {
+        $leaveRequestCalendarFeedConfig = LeaveRequestCalendarFeedConfig::create($params);
+        CRM_Core_Session::setStatus(
+          ts("The calendar feed '%1' has been $actionDescription.", [1 => $leaveRequestCalendarFeedConfig->title]),
+          'Success',
+          'success'
+        );
+      } catch (InvalidLeaveRequestCalendarFeedConfigException $ex) {
+        $message = ts("The calendar feed could not be $actionDescription");
+        $message .= ' ' . $ex->getMessage();
+        CRM_Core_Session::setStatus($message, 'Error', 'error');
+      }
+
+      $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/calendar-feeds', 'reset=1&action=browse');
+      $session = CRM_Core_Session::singleton();
+      $session->replaceUserContext($url);
+    }
+  }
+
+  /**
+   * Adds the form fields for configuring the calendar feed
+   */
+  private function addCalendarFeedConfigFields() {
+    $this->add(
+      'text',
+      'title',
+      ts('Title'),
+      $this->getDAOFieldAttributes('title'),
+      TRUE
+    );
+
+    $this->addSelect(
+      'timezone',
+      [
+        'options' => $this->getTimezonesList(),
+        'multiple' => FALSE,
+        'placeholder' => 'Select a timezone',
+        'label' => 'Timezone',
+      ],
+      true
+    );
+
+    $this->add(
+      'checkbox',
+      'is_active',
+      ts('Enabled')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultEntity() {
+    return 'LeaveRequestCalendarFeedConfig';
+  }
+
+  /**
+   * Returns the timezones list.
+   *
+   * @return array
+   */
+  private function getTimezonesList() {
+    $timeZones = DateTimeZone::listIdentifiers(DateTimeZone::ALL);
+
+    return array_combine($timeZones, $timeZones);
+  }
+
+  /**
+   * Gets the attributes for the given field from the DAO metadata
+   *
+   * @param string $field
+   *
+   * @return array
+   */
+  private function getDAOFieldAttributes($field) {
+    $dao = 'CRM_HRLeaveAndAbsences_DAO_LeaveRequestCalendarFeedConfig';
+    return CRM_Core_DAO::getAttribute($dao, $field);
+  }
+
+  /**
+   * Returns the action URL used to delete a Absence Type
+   *
+   * @return string
+   */
+  private function getDeleteUrl() {
+    return CRM_Utils_System::url(
+      'civicrm/admin/leaveandabsences/calendar-feeds',
+      "action=delete&id={$this->_id}&reset=1",
+      false,
+      null,
+      false
+    );
+  }
+
+  /**
+   * Returns a list of buttons available on this form.
+   *
+   * @return array
+   */
+  private function getAvailableButtons() {
+    $buttons = [
+      ['type' => 'next', 'name' => ts('Save'), 'isDefault' => TRUE],
+      ['type' => 'cancel', 'name' => ts('Cancel')],
+    ];
+
+    if (($this->_action & CRM_Core_Action::UPDATE)) {
+      $buttons[] = ['type' => 'delete', 'name' => ts('Delete')];
+    }
+
+    return $buttons;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
@@ -1,0 +1,169 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig as LeaveRequestCalendarFeedConfig;
+
+class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Core_Page_Basic {
+
+  /**
+   * A list of links available as actions to the items on the page list
+   *
+   * @var array
+   */
+  private $links = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function run() {
+    CRM_Utils_System::setTitle(ts('Calendar Feeds'));
+    parent::run();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function browse() {
+    $object = new LeaveRequestCalendarFeedConfig();
+    $object->orderBy('created_date');
+    $object->find();
+    $rows = [];
+    while($object->fetch()) {
+      $rows[$object->id] = array();
+
+      CRM_Core_DAO::storeValues($object, $rows[$object->id]);
+
+      $rows[$object->id]['action'] = CRM_Core_Action::formLink(
+        $this->links(),
+        $this->calculateLinksMask($object),
+        ['id' => $object->id]
+      );
+    }
+
+    $returnURL = CRM_Utils_System::url($this->userContext(), 'reset=1');
+    CRM_Utils_Weight::addOrder($rows, 'CRM_HRLeaveAndAbsences_DAO_LeaveRequestCalendarFeedConfig', 'id', $returnURL);
+
+    CRM_Core_Resources::singleton()->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css');
+    CRM_Core_Resources::singleton()->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/crm/hrleaveandabsences.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    CRM_Core_Resources::singleton()->addScriptFile('civicrm', 'js/jquery/jquery.crmEditable.js', CRM_Core_Resources::DEFAULT_WEIGHT, 'html-header');
+    $this->assign('rows', $rows);
+  }
+
+  /**
+   * an array of action links
+   *
+   * @return array (reference)
+   */
+  public function &links() {
+    if(empty($this->links)) {
+      $this->links = [
+        CRM_Core_Action::UPDATE  => [
+          'name'  => ts('Edit'),
+          'url'   => $this->userContext(),
+          'qs'    => 'action=update&id=%%id%%&reset=1',
+          'title' => ts('Edit Calendar Feed'),
+        ],
+        CRM_Core_Action::BASIC => [
+          'name' => ts('View Feed Link'),
+          'class' => '',
+          'title' => ts('View Feed Link')
+        ],
+        CRM_Core_Action::DISABLE => [
+          'name'  => ts('Disable'),
+          'class' => 'crm-enable-disable',
+          'title' => ts('Disable Calendar Feed'),
+        ],
+        CRM_Core_Action::ENABLE  => [
+          'name'  => ts('Enable'),
+          'class' => 'crm-enable-disable',
+          'title' => ts('Enable Calendar Feed'),
+        ],
+        CRM_Core_Action::DELETE  => [
+          'name'  => ts('Delete'),
+          'class' => 'civihr-delete',
+          'title' => ts('Delete Calendar Feed'),
+        ],
+      ];
+    }
+
+    return $this->links;
+  }
+
+  /**
+   * Name of the edit form class
+   *
+   * @return string
+   */
+  public function editForm() {
+    return 'CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function editName() {
+    return 'Calendar Feeds';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userContext($mode = null) {
+    return 'civicrm/admin/leaveandabsences/calendar-feeds';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBAOName() {
+    return 'CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function edit($action, $id = NULL, $imageUpload = FALSE, $pushUserContext = TRUE) {
+    if($action & CRM_Core_Action::DELETE) {
+      $this->delete($id);
+    } else {
+      parent::edit($action, $id, $imageUpload, $pushUserContext);
+    }
+  }
+
+  /**
+   * Function for deleting a given LeaveRequestCalendarFeedConfig
+   * with the id.
+   *
+   * @param int $id
+   */
+  public function delete($id) {
+    try {
+      civicrm_api3('LeaveRequestCalendarFeedConfig', 'delete', ['id' => $id]);
+      CRM_Core_Session::setStatus(ts('The Calendar Feed was deleted'), 'Success', 'success');
+    } catch(Exception $ex) {
+      $message = ts('Error deleting the Calendar feed.') . ' ' . $ex->getMessage();
+      CRM_Core_Session::setStatus($message, 'Error', 'error');
+    }
+
+    $url = CRM_Utils_System::url($this->userContext(), 'reset=1&action=browse');
+    CRM_Utils_System::redirect($url);
+  }
+
+  /**
+   * Calculates the links bitmask for the items on the list page
+   *
+   * @param LeaveRequestCalendarFeedConfig $leaveCalendarFeedConfig
+   *
+   * @return float|int
+   */
+  private function calculateLinksMask($leaveCalendarFeedConfig) {
+    $mask = array_sum(array_keys($this->links()));
+
+    if($leaveCalendarFeedConfig->is_active) {
+      $mask -= CRM_Core_Action::ENABLE;
+    } else {
+      $mask -= CRM_Core_Action::DISABLE;
+    }
+
+    return $mask;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -36,6 +36,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1028;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1029;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1030;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1031;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1031.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1031.php
@@ -1,0 +1,37 @@
+<?php
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1031 {
+
+  /**
+   * Adds the Calendar Feeds menu.
+   *
+   * @return bool
+   */
+  public function upgrade_1031() {
+    $result = civicrm_api3('Navigation', 'get', ['name' => 'leave_and_absence_calendar_feeds']);
+
+    if ($result['count'] > 0) {
+      return TRUE;
+    }
+
+    $leaveAndAbsenceNav = civicrm_api3('Navigation', 'get', ['name' => 'leave_and_absences']);
+
+    if (empty($leaveAndAbsenceNav['id'])) {
+      return TRUE;
+    }
+
+    $weight = CRM_Core_BAO_Navigation::calculateWeight($leaveAndAbsenceNav['id']);
+
+    civicrm_api3('Navigation', 'create', [
+      'label' => ts('Calendar Feeds'),
+      'name' => 'leave_and_absence_calendar_feeds',
+      'url' => 'civicrm/admin/leaveandabsences/calendar-feeds',
+      'permission' => 'can administer calendar feeds',
+      'parent_id' => $leaveAndAbsenceNav['id'],
+      'weight' => $weight,
+      'is_active' => 1
+    ]);
+
+    return TRUE;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.civix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.civix.php
@@ -269,10 +269,10 @@ function _hrleaveandabsences_civix_civicrm_managed(&$entities) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -503,6 +503,12 @@ function _hrleaveandabsences_civix_civicrm_entityTypes(&$entityTypes) {
       'name' => 'LeaveRequest',
       'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveRequest',
       'table' => 'civicrm_hrleaveandabsences_leave_request',
+    ),
+    'CRM_HRLeaveAndAbsences_DAO_LeaveRequestCalendarFeedConfig' => 
+    array (
+      'name' => 'LeaveRequestCalendarFeedConfig',
+      'class' => 'CRM_HRLeaveAndAbsences_DAO_LeaveRequestCalendarFeedConfig',
+      'table' => 'civicrm_hrleaveandabsences_calendar_feed_config',
     ),
     'CRM_HRLeaveAndAbsences_DAO_LeaveRequestDate' => 
     array (

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
@@ -1,0 +1,61 @@
+<div id="bootstrap-theme">
+  <div class="panel panel-default crm-form-block crm-absence_type-form-block crm-leave-and-absences-form-block">
+    <div class="panel-heading">
+      <h1 class="panel-title">
+        {if $action eq 1}{ts}Add a New Calendar Feed{/ts}
+        {elseif $action eq 2}{ts}Edit Calendar Feed{/ts}{/if}
+      </h1>
+    </div>
+
+    <div class="panel-body">
+      {if $action neq 8}
+        <div class="form-group row">
+          <div class="col-sm-3">{$form.title.label}</div>
+          <div class="col-sm-9">{$form.title.html}</div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-3">{$form.timezone.label}</div>
+          <div class="col-sm-9">{$form.timezone.html}</div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-3">{$form.is_active.label}</div>
+          <div class="col-sm-9">{$form.is_active.html}</div>
+        </div>
+      </div>
+      {literal}
+        <script type="text/javascript">
+          CRM.$(function($) {
+            $(document).ready(function() {
+              initDeleteButton();
+            });
+
+            function initDeleteButton() {
+              $('.crm-button-type-delete').on('click', function(e) {
+                e.preventDefault();
+                CRM.confirm({
+                  title: ts('Delete Calendar Feed'),
+                  message: ts('Are you sure you want to delete this Calendar Feed?'),
+                  options: {
+                    yes: ts('Yes'),
+                    no: ts('No')
+                  }
+                }).on('crmConfirm:yes', deleteCallback);
+              });
+            }
+
+            function deleteCallback() {
+              {/literal}
+              window.location = "{$deleteUrl}";
+              {literal}
+            }
+          });
+        </script>
+      {/literal}
+    {/if}
+    <div class="panel-footer clearfix">
+      <div class="pull-right">
+        {include file="CRM/common/formButtons.tpl" location="bottom"}
+      </div>
+    </div>
+  </div>
+</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.tpl
@@ -1,0 +1,60 @@
+{if $action eq 1 or $action eq 2 or $action eq 8}
+  {include file="CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl"}
+{else}
+  {if $rows}
+    <div id="bootstrap-theme" class="crm-leave-and-absences-list-block">
+      <div class="alert alert-info">
+        {ts}All Calendar feeds make some or all of your staff leave data public to the internet.
+          Anyone with the appropriate feed link will be able to view the data available on the feed.
+          This may include former employees or any other persons who your employee may share the calendar feed link with.
+          Please consider carefully whether this will be suitable for your organisation.{/ts}
+      </div>
+      <div class="panel panel-default">
+        {strip}
+          {include file="CRM/common/enableDisableApi.tpl"}
+          <table cellpadding="0" cellspacing="0" border="0" class="table table-responsive hrleaveandabsences-entity-list">
+            <thead class="sticky">
+            <th>{ts}Title{/ts}</th>
+            <th>{ts}Timezone{/ts}</th>
+            <th>{ts}Status{/ts}</th>
+            <th>{ts}Actions{/ts}</th>
+            <th>&nbsp;</th>
+            </thead>
+            {foreach from=$rows item=row}
+              <tr id="LeaveRequestCalendarFeedConfig-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
+                <td data-field="title">{$row.title|escape}</td>
+                <td>{$row.timezone}</td>
+                <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
+                <td>{$row.action|replace:'xx':$row.id}</td>
+              </tr>
+            {/foreach}
+          </table>
+        {/strip}
+
+        {if $action ne 1 and $action ne 2}
+          <div class="panel-footer clearfix">
+            <div class="pull-right">
+              <a href="{crmURL q="action=add&reset=1"}" class="button btn btn-primary pull-right">
+                <i class="fa fa-plus"></i>
+                <span>{ts}Add Calendar Feed{/ts}</span>
+              </a>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {literal}
+    <script type="text/javascript">
+      CRM.$(function () {
+        var listPage = new CRM.HRLeaveAndAbsencesApp.ListPage(CRM.$('.hrleaveandabsences-entity-list'));
+      });
+    </script>
+  {/literal}
+  {else}
+    <div class="alert alert-info">
+      <div class="icon inform-icon"></div>
+      {capture assign=crmURL}{crmURL q="action=add&reset=1"}{/capture}
+      {ts 1=$crmURL}There are no Calendar Feeds entered. You can <a href='%1'>add one</a>.{/ts}
+    </div>
+  {/if}
+{/if}

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfigTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfigTest.php
@@ -93,4 +93,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfigTest extends Base
 
     $this->assertNotNull($leaveFeedConfig2->id);
   }
+
+  public function testGetValuesArrayShouldReturnLeaveRequestCalendarFeedConfigValues() {
+    $params = [
+      'title' => 'Feed 1',
+      'is_active' => 1,
+      'timezone' => 'America/Monterrey',
+    ];
+
+    $entity = LeaveRequestCalendarFeedConfig::create($params);
+    $values = LeaveRequestCalendarFeedConfig::getValuesArray($entity->id);
+    foreach ($params as $field => $value) {
+      $this->assertEquals($value, $values[$field]);
+    }
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/xml/Menu/hrleaveandabsences.xml
@@ -54,4 +54,10 @@
     <title>Dashboard</title>
     <access_arguments>administer leave and absences</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/leaveandabsences/calendar-feeds</path>
+    <page_callback>CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig</page_callback>
+    <title>LeaveRequestCalendarFeedConfig</title>
+    <access_arguments>can administer calendar feeds</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR adds the functionality to list, create, update and delete a calendar feed configuration and also adds the configuration link to the menu using the LeaveRequestCalendarFeedConfig Entity added here #2707 

## Before
- There was no way to administer a calendar feed.

## After
- The functionality to list, create, update and delete a calendar feed configuration is now available.
- An upgrader was added to insert the Calendar Feeds menu.

![calendarfeed](https://user-images.githubusercontent.com/6951813/41918441-40f06c5a-7954-11e8-9745-0642d0ec1008.gif)

## Technical Details
- The form and page templates reuse the classes and Javascript scripts used by other Admin configuration pages.


