### PR TITLE
PCHR-3868: Fix js tests

### DIFF
--- a/contactsummary/js/karma.conf.js
+++ b/contactsummary/js/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function (config) {
       civihrPath + 'org.civicrm.reqangular/dist/reqangular.min.js',
 
       // External extensions files
-      { pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/*.js', included: false },
+      { pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/!(*.spec).js', included: false },
 
       // the application modules
       { pattern: extPath + 'js/src/contact-summary/**/*.js', included: false },

--- a/hrjobcontract/js/karma.conf.js
+++ b/hrjobcontract/js/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function (config) {
       civihrPath + 'org.civicrm.reqangular/dist/reqangular.mocks.min.js',
 
       // External extensions files
-      { pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/*.js', included: false },
+      { pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/!(*.spec).js', included: false },
       { pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/test/mocks/**/*.js', included: false },
 
       // the application modules

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/karma.conf.js
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
       { pattern: extPath + 'js/angular/test/**/*.spec.js', included: false },
 
       // angular templates
-      extPath + 'views/**/*.html',
+      extPath + '**/*.html',
 
       // the requireJS config file that bootstraps the whole test suite
       extPath + 'js/angular/test/test-main.js'
@@ -53,7 +53,7 @@ module.exports = function (config) {
     ],
     // Used to transform angular templates in JS strings
     preprocessors: (function (obj) {
-      obj[extPath + 'views/**/*.html'] = ['ng-html2js'];
+      obj[extPath + '**/*.html'] = ['ng-html2js'];
       return obj;
     })({}),
     ngHtml2JsPreprocessor: {


### PR DESCRIPTION
## Overview
This PR fixes failing JS tests due to the introduction of these PRs:

* https://github.com/compucorp/civihr/pull/2705 - introduces modules and allows spec files to be included in source folder.
* https://github.com/compucorp/civihr/pull/2712 - introduces the specific spec files inside source folder for the first time.

## Before
![jenkins-before](https://user-images.githubusercontent.com/1642119/41946903-97be1374-7982-11e8-9a64-978477b2ae33.png)

## After
![jenkins-after](https://user-images.githubusercontent.com/1642119/41947089-9b64b6ee-7983-11e8-83fa-8babb78a7e5a.png)

## Technical Details

### Including test files form L&A:

The issue is that the ContactSummary and JobContract include files from the source folder in the L&A extension. These reference files are needed when sharing code between extensions, such as models and components from L&A.

The issue is that when Karma finds spec files inside L&A's source folder, it includes them, and run the tests as if they are part of the extension under test. To avoid this, spec files are skipped from being included:

```js
// Before
{ pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/*.js', included: false },

// After
{ pattern: civihrPath + 'uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/**/!(*.spec).js', included: false },
```

### Missing karma changes for L&A

Some Karma changes were not included in this PR: https://github.com/compucorp/civihr/pull/2712 . Specifically the change to allow Karma to include template files from the source folder. This was fixed by changing the path for templates:

```js
// ###### Before
// angular templates
extPath + 'views/**/*.html',

// Used to transform angular templates in JS strings
preprocessors: (function (obj) {
  obj[extPath + 'views/**/*.html'] = ['ng-html2js'];
  return obj;
})({}),

// ###### After
// angular templates
extPath + '**/*.html',

// Used to transform angular templates in JS strings
preprocessors: (function (obj) {
  obj[extPath + '**/*.html'] = ['ng-html2js'];
  return obj;
})({}),
```
