### PR TITLE
PCHR-3606: Remove Some Social Accounts and Reorder the Remaining

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -31,6 +31,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1021;
   use CRM_HRCore_Upgrader_Steps_1022;
   use CRM_HRCore_Upgrader_Steps_1023;
+  use CRM_HRCore_Upgrader_Steps_1024;
 
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
@@ -3,7 +3,7 @@
 trait CRM_HRCore_Upgrader_Steps_1024 {
 
   /**
-   * Remove Social Account Options and reorder de remaining
+   * Removes social account options and reorder the remaining
    */
   public function upgrade_1024() {
     $this->up1024_removeSocialAccountOptions([
@@ -24,7 +24,7 @@ trait CRM_HRCore_Upgrader_Steps_1024 {
   }
 
   /**
-   * Removes Some Social Account Options
+   * Removes some social account options if not used, and disable it if used
    */
   private function up1024_removeSocialAccountOptions($accounts) {
     $socialAccounts = civicrm_api3('OptionValue', 'get', [
@@ -34,9 +34,21 @@ trait CRM_HRCore_Upgrader_Steps_1024 {
 
     $socialAccounts = $socialAccounts['values'];
     foreach ($socialAccounts as $optionValueId => $optionValue) {
-      civicrm_api3('OptionValue', 'delete', [
-        'id' => $optionValueId,
+      $socialAccountIsUsed = civicrm_api3('Website', 'get', [
+        'website_type_id' => $optionValue['name'],
+        'url' => ['IS NOT NULL' => 1],
       ]);
+      if ($socialAccountIsUsed['count'] == 0) {
+        civicrm_api3('OptionValue', 'delete', [
+          'id' => $optionValueId,
+        ]);
+      }
+      else {
+        civicrm_api3('OptionValue', 'create', [
+          'id' => $optionValueId,
+          'is_active' => 0,
+        ]);
+      }
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
@@ -1,0 +1,74 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1024 {
+
+  /**
+   * Remove Social Account Options and reorder de remaining
+   */
+  public function upgrade_1024() {
+    $this->up1024_removeSocialAccountOptions([
+      'Work',
+      'MySpace',
+      'Vine',
+      'Google+',
+      'Snapchat',
+      'Tumblr',
+    ]);
+    $this->up1024_reorderSocialAccountOptions([
+      'LinkedIn',
+      'Twitter',
+      'Facebook',
+    ]);
+
+    return TRUE;
+  }
+
+  /**
+   * Removes Some Social Account Options
+   */
+  private function up1024_removeSocialAccountOptions($accounts) {
+    $socialAccounts = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'website_type',
+      'name' => ['IN' => $accounts],
+    ]);
+
+    $socialAccounts = $socialAccounts['values'];
+    foreach ($socialAccounts as $optionValueId => $optionValue) {
+      civicrm_api3('OptionValue', 'delete', [
+        'id' => $optionValueId,
+      ]);
+    }
+  }
+
+  /**
+   * Reorder Social Accounts
+   */
+  private function up1024_reorderSocialAccountOptions($accounts) {
+    $socialAccounts = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'website_type',
+      'name' => ['IN' => $accounts],
+    ]);
+
+    $socialAccounts = $socialAccounts['values'];
+    foreach ($socialAccounts as $optionValueId => $optionValue) {
+      switch ($optionValue['name']) {
+        case 'LinkedIn':
+          $newWeight = 1;
+          break;
+
+        case 'Twitter':
+          $newWeight = 2;
+          break;
+
+        case 'Facebook':
+          $newWeight = 3;
+          break;
+      }
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $optionValueId,
+        'weight' => $newWeight,
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
Need to remove the following Social Accounts, if not used and disable if used:
Work
MySpace
Vine
Google+
Snapchat
Tumblr

Need to change the Order of the Social Accounts to the Following:
LinkedIn (default)
Twitter
Facebook

The other Social Accounts was left as-is.

## Before
All these social accounts where created by default during installation of CiviHR

## After
Only three social accounts are available for systems with the addition of previously used ones on existing setup