### PR TITLE
PCHR-3559: Delete Cost Centre Other Option

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -139,7 +139,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
       'name' => 'Other',
     ]);
     
-    return ($result['id'])? $result['id'] : null;
+    return isset($result['id'])? $result['id'] : null;
   }
 
   /**

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -82,7 +82,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
   }
   
   /**
-   * Deletes cost centre "other" option value or disable it if not in use
+   * Deletes cost centre "other" option value if not in use
    *
    * @return bool
    */
@@ -90,6 +90,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     $jobRoles = civicrm_api3('HrJobRoles', 'get');
     if ($jobRoles['count'] == 0) {
       $this->deleteCostCentreOther();
+      return TRUE;
     }
     
     $otherId = $this->retrieveCostCentreOtherId();
@@ -106,12 +107,8 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
       }
     }
     
-    if (!$inUse) { // disables cost centre other
-      civicrm_api3('OptionValue', 'get', [
-        'option_group_id' => 'cost_centres',
-        'name' => 'Other',
-        'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => 0],
-      ]);
+    if (!$inUse) {
+      $this->deleteCostCentreOther();
     }
     
     return TRUE;

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -93,6 +93,9 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     }
     
     $otherId = $this->retrieveCostCentreOtherId();
+    if ($otherId == null) {
+      return FALSE;
+    }
     $inUse = FALSE;
     $roles = $jobRoles['values'];
     $pattern = '/\|' . $otherId . '\|/';
@@ -120,10 +123,8 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
   private function deleteCostCentreOther() {
     civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'cost_centres',
-      'api.OptionValue.delete' => [
-        'id' => '$value.id',
-        'name' => 'Other'
-      ],
+      'name' => 'Other',
+      'api.OptionValue.delete' => ['id' => '$value.id'],
     ]);
   }
   
@@ -138,7 +139,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
       'name' => 'Other',
     ]);
     
-    return $result['id'];
+    return ($result['id'])? $result['id'] : null;
   }
 
   /**

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -95,7 +95,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     
     $otherId = $this->retrieveCostCentreOtherId();
     if ($otherId == null) {
-      return FALSE;
+      return TRUE;
     }
     $inUse = FALSE;
     $roles = $jobRoles['values'];
@@ -136,7 +136,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
       'name' => 'Other',
     ]);
     
-    return isset($result['id'])? $result['id'] : null;
+    return isset($result['id']) ? $result['id'] : null;
   }
 
   /**

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1355,7 +1355,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
   
   /**
-   * Deletes cost centre other option value or disable it if not in use
+   * Deletes cost centre "other" option value or disable it if not in use
    *
    * @return bool
    */
@@ -1368,7 +1368,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $otherId = $this->retrieveCostCentreOtherId();
     $inUse = FALSE;
     $roles = $jobRoles['values'];
-    $pattern = '/(\|' . $otherId . '\|)/';
+    $pattern = '/\|' . $otherId . '\|/';
     foreach ($roles as $role) {
       if (preg_match($pattern, $role['cost_center'])) {
         $inUse = TRUE;
@@ -1376,7 +1376,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       }
     }
     
-    if (! $inUse) { // disables cost centre other
+    if (!$inUse) { // disables cost centre other
       civicrm_api3('OptionValue', 'get', [
         'option_group_id' => 'cost_centres',
         'name' => 'Other',
@@ -1388,7 +1388,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
   
   /**
-   * Deletes cost centre option value with name other
+   * Deletes cost centre option value with name "other"
    */
   private function deleteCostCentreOther() {
     civicrm_api3('OptionValue', 'get', [
@@ -1401,7 +1401,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
   }
   
   /**
-   * Fetches the id of cost center other option value
+   * Fetches the id of cost center "other" option value
    *
    * @return int
    */

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -520,7 +520,6 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1039();
     $this->upgrade_1040();
     $this->upgrade_1041();
-    $this->upgrade_1042();
   }
 
   function upgrade_1001() {
@@ -1352,66 +1351,6 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     ]);
     
     return TRUE;
-  }
-  
-  /**
-   * Deletes cost centre "other" option value or disable it if not in use
-   *
-   * @return bool
-   */
-  public function upgrade_1042() {
-    $jobRoles = civicrm_api3('HrJobRoles', 'get');
-    if ($jobRoles['count'] == 0) {
-      $this->deleteCostCentreOther();
-    }
-  
-    $otherId = $this->retrieveCostCentreOtherId();
-    $inUse = FALSE;
-    $roles = $jobRoles['values'];
-    $pattern = '/\|' . $otherId . '\|/';
-    foreach ($roles as $role) {
-      if (preg_match($pattern, $role['cost_center'])) {
-        $inUse = TRUE;
-        break;
-      }
-    }
-    
-    if (!$inUse) { // disables cost centre other
-      civicrm_api3('OptionValue', 'get', [
-        'option_group_id' => 'cost_centres',
-        'name' => 'Other',
-        'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => 0],
-      ]);
-    }
-    
-    return TRUE;
-  }
-  
-  /**
-   * Deletes cost centre option value with name "other"
-   */
-  private function deleteCostCentreOther() {
-    civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'cost_centres',
-      'api.OptionValue.delete' => [
-        'id' => '$value.id',
-        'name' => 'Other'
-      ],
-    ]);
-  }
-  
-  /**
-   * Fetches the id of cost center "other" option value
-   *
-   * @return int
-   */
-  private function retrieveCostCentreOtherId() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'cost_centres',
-      'name' => 'Other',
-    ]);
-    
-    return $result['id'];
   }
   
   /**


### PR DESCRIPTION
## Overview
This PR deletes `Other` option value from option group cost centre for new site. In existing setups, the value is deleted if not in use.

## Before
The option value `Other` is created by default on the system.

## After
The option value is either removed based on job roles status

## Technical Details
The system is first checked for existence of job roles data
```php
$jobRoles = civicrm_api3('HrJobRoles', 'get');
```
after which `Other` option is deleted if no record exist.
```php
civicrm_api3('OptionValue', 'get', [
  'option_group_id' => 'cost_centres',
  'api.OptionValue.delete' => [
    'id' => '$value.id',
    'name' => 'Other'
  ],
]);
```
For systems with job roles data, `other` option is deleted when not in use
```php
if (! $inUse) { // disables cost centre other
  $this->deleteCostCentreOther()
 }
```
