### PR TITLE
PCHR-3605: Delete Instant Messenger Options

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -32,6 +32,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1022;
   use CRM_HRCore_Upgrader_Steps_1023;
   use CRM_HRCore_Upgrader_Steps_1024;
+  use CRM_HRCore_Upgrader_Steps_1025;
 
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1025.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1025.php
@@ -1,0 +1,47 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1025 {
+
+  /**
+   * Removes Instant Messenger options
+   */
+  public function upgrade_1025() {
+    $this->up1025_removeInstantMessengerOptions([
+      'Yahoo',
+      'MSN',
+      'AIM',
+      'Jabber',
+    ]);
+
+    return TRUE;
+  }
+
+  /**
+   * Removes some instant messenger options if not used, and disable it if used
+   */
+  private function up1025_removeInstantMessengerOptions($accounts) {
+    $socialAccounts = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'instant_messenger_service',
+      'name' => ['IN' => $accounts],
+    ]);
+
+    $socialAccounts = $socialAccounts['values'];
+    foreach ($socialAccounts as $optionValueId => $optionValue) {
+      $socialAccountIsUsed = civicrm_api3('Im', 'get', [
+        'provider_id' => $optionValue['name'],
+      ]);
+      if ($socialAccountIsUsed['count'] == 0) {
+        civicrm_api3('OptionValue', 'delete', [
+          'id' => $optionValueId,
+        ]);
+      }
+      else {
+        civicrm_api3('OptionValue', 'create', [
+          'id' => $optionValueId,
+          'is_active' => 0,
+        ]);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
This Upgrader deletes some instant messenger options if they are not used, and disables it if they are used on given installation.

## Before
![screenshot from 2018-07-02 10 56 44](https://user-images.githubusercontent.com/1692858/42154697-b846ca24-7de6-11e8-89a6-6e8dfae0073f.png)


## After
![screenshot from 2018-07-02 10 55 59](https://user-images.githubusercontent.com/1692858/42154710-bf336f40-7de6-11e8-826c-903ca667f6a4.png)