### PR TITLE
PCHR-3555: Fixed Regression Issue with Adding New Benefit

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1293,7 +1293,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'name' => 'hrjc_benefit_name',
       'api.OptionGroup.create' => [
         'id' => '$value.id',
-        'title' => 'Benefits'
+        'title' => 'Benefits',
+        'is_active' => 1
       ],
     ]);
     


### PR DESCRIPTION
## Overview
This PR fixes issues with Job Contract Benefit management after the [previous](https://github.com/compucorp/civihr/pull/2714) upgrade.

## Before
![before_benefits](https://user-images.githubusercontent.com/1507645/42163504-cc23db5e-7dfa-11e8-8213-b94933349007.gif)


## After
![after_benefits](https://user-images.githubusercontent.com/1507645/42163509-d1cc60bc-7dfa-11e8-990f-7d4afce0c8af.gif)


## Technical Details
Updating `option_group` [requires](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/OptionGroup.php#L95) setting the `is_active` attribute as it defaults to `false` if not set. 