### PR TITLE
PCHR-3556: Fixed Regression Issue with Adding Deduction

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1311,7 +1311,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'name' => 'hrjc_deduction_name',
       'api.OptionGroup.create' => [
         'id' => '$value.id',
-        'title' => 'Deductions'
+        'title' => 'Deductions',
+        'is_active' => 1
       ],
     ]);
     


### PR DESCRIPTION
## Overview
This PR fixes issues with Job Contract Deduction page management after the [previous](https://github.com/compucorp/civihr/pull/2716) upgrade.

## Before
![before_deductions](https://user-images.githubusercontent.com/1507645/42165408-d30c2de0-7dff-11e8-904c-55d96e2d0ede.gif)


## After
![after_deductions](https://user-images.githubusercontent.com/1507645/42165424-dde4f350-7dff-11e8-8212-82456b620d8b.gif)


## Technical Details
Updating `option_group` [requires](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/OptionGroup.php#L95) setting the `is_active` attribute as it defaults to `false` if not set. 
