### PR TITLE
PCHR-3557: Fixed Regression Issue with Adding Contract Revision Reason

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1330,7 +1330,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'name' => 'hrjc_revision_change_reason',
       'api.OptionGroup.create' => [
         'id' => '$value.id',
-        'title' => 'Contract Revision Reasons'
+        'title' => 'Contract Revision Reasons',
+        'is_active' => 1
       ]
     ]);
     


### PR DESCRIPTION
## Overview
This PR fixes issues with `Job Contract Revision Reason` management after the [previous](https://github.com/compucorp/civihr/pull/2715) upgrade.

## Before
![before_contract_revision](https://user-images.githubusercontent.com/1507645/42168572-48d915b6-7e09-11e8-9d54-c9728117a858.gif)


## After
![after_contract_revision](https://user-images.githubusercontent.com/1507645/42168584-4fb7e3c6-7e09-11e8-9827-5d4c791d9917.gif)


## Technical Details
Updating `option_group` [requires](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/OptionGroup.php#L95) setting the `is_active` attribute as it defaults to `false` if not set. 