### PR TITLE
PCHR-3558: Fixed Regression Issue with Adding New End Reason

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1348,7 +1348,8 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'name' => 'hrjc_contract_end_reason',
       'api.OptionGroup.create' => [
         'id' => '$value.id',
-        'title' => 'Contract End Reasons'
+        'title' => 'Contract End Reasons',
+        'is_active' => 1
       ],
     ]);
     


### PR DESCRIPTION
## Overview
This PR fixes issues with `Job Contract End Reason` management after the [previous](https://github.com/compucorp/civihr/pull/2717) upgrade.

## Before
![before_end_reasons](https://user-images.githubusercontent.com/1507645/42170340-2e5305c6-7e0e-11e8-97d4-06e21bb7e018.gif)


## After
![after_end_reasons](https://user-images.githubusercontent.com/1507645/42170384-4700ea0c-7e0e-11e8-91b0-58503ffb0cbf.gif)


## Technical Details
Updating `option_group` [requires](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/OptionGroup.php#L95) setting the `is_active` attribute as it defaults to `false` if not set. 