### PR TITLE
PCHR-3922: Make the Calendar Feed Administration Support Contact and Leave Types Filters

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
@@ -184,7 +184,7 @@ class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Cor
     foreach($filterParams as $field => $value) {
       if ($field == 'department') {
         $departmentNames = $this->getOptionValuesList('hrjc_department', $value);
-        $displayText .= 'Department: '. implode(', ' , $departmentNames) . '. ';
+        $displayText .= 'Department: ' . implode(', ' , $departmentNames) . '. ';
       }
 
       if ($field == 'location') {
@@ -192,7 +192,7 @@ class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Cor
         if ($displayText) {
           $displayText .= '<br/>';
         }
-        $displayText .= 'Location: '. implode(', ' , $locationNames) . '.';
+        $displayText .= 'Location: ' . implode(', ' , $locationNames) . '.';
       }
     }
 
@@ -211,7 +211,7 @@ class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Cor
     $displayText = '';
 
     foreach($filterFields as $field => $value) {
-      if ($field == 'leave_type') {
+      if ($field === 'leave_type') {
         $leaveTypeNames = $this->getAbsenceTypesList($value);
         $displayText .= implode(', ' , $leaveTypeNames);
       }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig as LeaveRequestCalendarFeedConfig;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Core_Page_Basic {
 
@@ -31,6 +32,9 @@ class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Cor
       $rows[$object->id] = array();
 
       CRM_Core_DAO::storeValues($object, $rows[$object->id]);
+      $rows[$object->id]['leave_type_display'] = $this->getLeaveTypeDisplayText(unserialize($rows[$object->id]['composed_of']));
+      $rows[$object->id]['composed_of_display'] = $this->getFilterDisplayText(unserialize($rows[$object->id]['composed_of']));
+      $rows[$object->id]['visible_to_display'] = $this->getFilterDisplayText(unserialize($rows[$object->id]['visible_to']));
 
       $rows[$object->id]['action'] = CRM_Core_Action::formLink(
         $this->links(),
@@ -165,5 +169,94 @@ class CRM_HRLeaveAndAbsences_Page_LeaveRequestCalendarFeedConfig extends CRM_Cor
     }
 
     return $mask;
+  }
+
+  /**
+   * Returns the text to be displayed for the composed_of or visible_to
+   * filter fields in the calendar feed listing table.
+   *
+   * @param array $filterParams
+   *
+   * @return string
+   */
+  private function getFilterDisplayText($filterParams) {
+    $displayText = '';
+    foreach($filterParams as $field => $value) {
+      if ($field == 'department') {
+        $departmentNames = $this->getOptionValuesList('hrjc_department', $value);
+        $displayText .= 'Department: '. implode(', ' , $departmentNames) . '. ';
+      }
+
+      if ($field == 'location') {
+        $locationNames = $this->getOptionValuesList('hrjc_location', $value);
+        if ($displayText) {
+          $displayText .= '<br/>';
+        }
+        $displayText .= 'Location: '. implode(', ' , $locationNames) . '.';
+      }
+    }
+
+    return $displayText ? $displayText : 'All Staff';
+  }
+
+  /**
+   * Returns the text to be displayed for the leave_type filter field of the
+   * composed_of filter in the calendar feed listing table.
+   *
+   * @param array $filterFields
+   *
+   * @return string
+   */
+  private function getLeaveTypeDisplayText($filterFields) {
+    $displayText = '';
+
+    foreach($filterFields as $field => $value) {
+      if ($field == 'leave_type') {
+        $leaveTypeNames = $this->getAbsenceTypesList($value);
+        $displayText .= implode(', ' , $leaveTypeNames);
+      }
+    }
+
+    return $displayText;
+  }
+
+  /**
+   * Returns the value/label for option values of an option group in an array
+   * for the given values.
+   *
+   * @param string $values
+   * @param array $optionGroupName
+   *
+   * @return array
+   */
+  private function getOptionValuesList($optionGroupName, $values) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'return' => ['label', 'value'],
+      'option_group_id' => $optionGroupName,
+      'value' => ['IN' => $values],
+      'is_active' => 1,
+    ]);
+
+    return array_column($result['values'], 'label', 'value');
+  }
+
+  /**
+   * Returns enabled absence types for the given type ID's
+   *
+   * @param array $typeId
+   *
+   * @return array
+   */
+  private function getAbsenceTypesList($typeId) {
+    $absenceTypes = AbsenceType::getEnabledAbsenceTypes();
+    $absenceTypesList = [];
+
+    foreach ($absenceTypes as $absenceType) {
+      if (in_array($absenceType->id, $typeId)) {
+        $absenceTypesList[$absenceType->id] = $absenceType->title;
+      }
+    }
+
+    return $absenceTypesList;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
@@ -13,6 +13,34 @@
           <div class="col-sm-3">{$form.title.label}</div>
           <div class="col-sm-9">{$form.title.html}</div>
         </div>
+      <div class="form-group row composed_of_department">
+        <div class="col-sm-3">{$form.composed_of_department.label}</div>
+        <div class="col-sm-9">{$form.composed_of_department.html}</div>
+      </div>
+      <div class="form-group row composed_of_location">
+        <div class="col-sm-3">{$form.composed_of_location.label}</div>
+        <div class="col-sm-9">{$form.composed_of_location.html}</div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-9 pull-left composed_of_help_text"></div>
+      </div>
+      <div class="form-group row visible_to_department">
+        <div class="col-sm-3">{$form.visible_to_department.label}</div>
+        <div class="col-sm-9">{$form.visible_to_department.html}</div>
+      </div>
+      <div class="form-group row visible_to_location">
+        <div class="col-sm-3">{$form.visible_to_location.label}</div>
+        <div class="col-sm-9">{$form.visible_to_location.html}</div>
+      </div>
+      <div class="form-group row">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-9 pull-left visible_to_help_text"></div>
+      </div>
+      <div class="form-group row composed_of_leave_type">
+        <div class="col-sm-3">{$form.composed_of_leave_type.label}</div>
+        <div class="col-sm-9">{$form.composed_of_leave_type.html}</div>
+      </div>
         <div class="form-group row">
           <div class="col-sm-3">{$form.timezone.label}</div>
           <div class="col-sm-9">{$form.timezone.html}</div>
@@ -27,6 +55,9 @@
           CRM.$(function($) {
             $(document).ready(function() {
               initDeleteButton();
+              setComposedOfHelpText();
+              setVisibleToHelpText();
+              initFilterFieldsHelpText();
             });
 
             function initDeleteButton() {
@@ -47,6 +78,66 @@
               {/literal}
               window.location = "{$deleteUrl}";
               {literal}
+            }
+
+            function initFilterFieldsHelpText() {
+              $('.composed_of_department select').on('change', function(e) {
+                setComposedOfHelpText();
+              });
+
+              $('.composed_of_location select').on('change', function(e) {
+                setComposedOfHelpText();
+              });
+
+              $('.visible_to_department select').on('change', function(e) {
+                setVisibleToHelpText();
+              });
+
+              $('.visible_to_location select').on('change', function(e) {
+                setVisibleToHelpText();
+              });
+            }
+
+            function setComposedOfHelpText() {
+              var helpMessage = {
+                'default' : 'All staff will be included',
+                'department_only' : 'Only staff from the selected departments will be included',
+                'location_only' : 'Only staff from the selected locations will be included',
+                'department_and_location' : 'Only staff from the selected departments plus the selected locations will be included'
+              };
+
+              setHelpText('composed_of', helpMessage);
+            }
+
+            function setVisibleToHelpText() {
+              var helpMessage = {
+                'default' : 'The feed will be shown to all staff',
+                'department_only' : 'The feed will be shown to the staff from the selected departments only',
+                'location_only' : 'The feed will be shown to the staff from the selected locations only',
+                'department_and_location' : 'The feed will be shown to the staff from the selected departments plus the selected locations'
+              };
+
+              setHelpText('visible_to', helpMessage);
+            }
+
+            function setHelpText(filterName, helpMessage) {
+              var departmentValue = $('.' + filterName + '_department select option:selected').val();
+              var locationValue = $('.' + filterName + '_location select option:selected').val();
+              var helpText = helpMessage.default;
+
+              if (!departmentValue && locationValue) {
+                helpText = helpMessage.location_only;
+              }
+
+              if (departmentValue && !locationValue) {
+                helpText = helpMessage.department_only;
+              }
+
+              if (departmentValue && locationValue) {
+                helpText = helpMessage.department_and_location;
+              }
+
+              $('.' + filterName + '_help_text').text(helpText);
             }
           });
         </script>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/LeaveRequestCalendarFeedConfig.tpl
@@ -15,6 +15,9 @@
           <table cellpadding="0" cellspacing="0" border="0" class="table table-responsive hrleaveandabsences-entity-list">
             <thead class="sticky">
             <th>{ts}Title{/ts}</th>
+            <th>{ts}Staff displayed{/ts}</th>
+            <th>{ts}Leave types displayed{/ts}</th>
+            <th>{ts}Link visible to{/ts}</th>
             <th>{ts}Timezone{/ts}</th>
             <th>{ts}Status{/ts}</th>
             <th>{ts}Actions{/ts}</th>
@@ -23,6 +26,9 @@
             {foreach from=$rows item=row}
               <tr id="LeaveRequestCalendarFeedConfig-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
                 <td data-field="title">{$row.title|escape}</td>
+                <td>{$row.composed_of_display}</td>
+                <td>{$row.leave_type_display}</td>
+                <td>{$row.visible_to_display}</td>
                 <td>{$row.timezone}</td>
                 <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
                 <td>{$row.action|replace:'xx':$row.id}</td>


### PR DESCRIPTION
## Overview
Sequel to #2724 that added the `visible_to` and `composed_of` filter fields to the LeaveRequestCalendarFeedConfig Entity. This PR allows the create/edit page for administering calendar feed configurations to support these filter fields and also display the values of these fields on the calendar feed listing page.

## Before
- The calendar field administration does not support Contact and Leave type filters

## After
-  The calendar field administration now supports Contact and Leave type filters. In essence, an administrator can set what contacts a leave feed is to be composed of by setting the department and locations the contacts should belong to and also the contacts that are allowed to view the feed link on the SSP by setting the department and locations these contacts can belong to. Also the Leave types that the feed is to be composed of.

![calendarfeedform](https://user-images.githubusercontent.com/6951813/42219933-5ea3fa3e-7ec5-11e8-9769-858b25dc2fd8.gif)


