### PR TITLE
PCHR-3561: Change Options for Sickness Reason

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -35,6 +35,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1027;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1028;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1029;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1030;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1030.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1030.php
@@ -1,0 +1,105 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1030 {
+  
+  /**
+   * Disables or deletes existing "sickness reason" option values
+   * and added new ones
+   *
+   * @return bool
+   */
+  public function upgrade_1030() {
+    $oldSicknessReasons = civicrm_api3('OptionValue', 'get', [
+      'return' => ['name'],
+      'option_group_id' => 'hrleaveandabsences_sickness_reason',
+    ]);
+  
+    $result = $this->up1030_getLeaveRequestTotal();
+    if ($result == 0) {
+      $this->up1030_deleteOldSicknessReasons($oldSicknessReasons['values']);
+    }
+    else {
+      $this->up1030_disableOldSicknessReasons($oldSicknessReasons['values']);
+    }
+    
+    $this->up1030_addNewSicknessReasons();
+    
+    return TRUE;
+  }
+  
+  /**
+   * Counts the total number of leave requests related to sickness reasons
+   *
+   * @return int
+   */
+  private function up1030_getLeaveRequestTotal() {
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->whereAdd('sickness_reason IS NOT NULL');
+    $leaveRequest->find();
+  
+    // N is Number of rows returned from a query
+    return $leaveRequest->N;
+  }
+  
+  /**
+   * Disables existing "sickness reason" option values
+   *
+   * @param array $sicknessReasons
+   */
+  private function up1030_disableOldSicknessReasons($sicknessReasons) {
+    foreach ($sicknessReasons as $id => $sicknessReason) {
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $id,
+        'is_active' => 0
+      ]);
+    }
+  }
+  
+  /**
+   * Deletes existing "sickness reason" option values
+   *
+   * @param array $sicknessReasons
+   */
+  private function up1030_deleteOldSicknessReasons($sicknessReasons) {
+    foreach ($sicknessReasons as $id => $sicknessReason) {
+      civicrm_api3('OptionValue', 'delete', ['id' => $id]);
+    }
+  }
+  
+  /**
+   * Adds new "sickness reason" option values
+   */
+  public function up1030_addNewSicknessReasons() {
+    $newSicknessOptions = [
+      ['label' => 'Cold, Cough, Flu - Influenza', 'name' => 'cold_cough_flu-influenza'],
+      ['label' => 'Headache/Migraine', 'name' => 'headache_migraine'],
+      ['label' => 'Gastro-intestinal Problems', 'name' => 'gastro_intestinal_problems'],
+      ['label' => 'Back Problems', 'name' => 'back_problems'],
+      ['label' => 'Injury, Fracture', 'name' => 'injury_fracture'],
+      ['label' => 'Dental and Oral Problems', 'name' => 'dental_oral_problems'],
+      ['label' => 'Pregnancy Related', 'name' => 'pregnancy_related'],
+      [
+        'label' => 'Anxiety/Stress/Depression/Other Psychiatric Illnesses',
+        'name' => 'anxiety_stress_depression_psychiatric_illnesses'
+      ],
+      ['label' => 'Chest and Respiratory Problems', 'name' => 'chest_respiratory_problems'],
+      ['label' => 'Ear, Nose, Throat (ENT)', 'name' => 'ent'],
+      ['label' => 'Endocrine/Glandular Problems', 'name' => 'endocrine_glandular_problems'],
+      ['label' => 'Eye Problems', 'name' => 'eye_problems'],
+      [
+        'label' => 'Genitourinary and Gynaecological Disorders',
+        'name' => 'genitourinary_gynaecological_disorders'
+      ],
+      ['label' => 'Other Musculoskeletal Problems', 'name' => 'musculoskeletal_problems'],
+      ['label' => 'Surgery Related', 'name' => 'surgery_related'],
+      ['label' => 'Other', 'name' => 'other']
+    ];
+    
+    foreach ($newSicknessOptions as $sicknessReason) {
+      $sicknessReason['option_group_id'] = 'hrleaveandabsences_sickness_reason';
+      civicrm_api3('OptionValue', 'create', $sicknessReason);
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR adds new set of sickness reason option value after either deleting (for new systems) or disabling (for old systems) the existing option values. The new set of sickness reasons are listed below:
* Cold, Cough, Flu - Influenza
* Headache/Migraine
* Gastro-intestinal Problems
* Back Problems
* Injury, Fracture
* Dental and Oral Problems
* Pregnancy Related
* Anxiety/Stress/Depression/Other Psychiatric Illnesses
* Chest and Respiratory Problems
* Ear, Nose, Throat (ENT)
* Endocrine/Glandular Problems
* Eye Problems
* Genitourinary and Gynaecological Disorders
* Other Musculoskeletal Problems
* Surgery Related
* Other

## Before
Existing option values are available after setup.

## After
After running upgrade, only the newly required options are available for selection.

## Technical Details
Leave request was checked for existing record before deleting or deactivating existing options.
```php
$result = civicrm_api3('LeaveRequest', 'get', [
  'sickness_reason' => ['IS NOT NULL' => 1],
]);
if ($result['count'] == 0) {
  $this->up1030_deleteOldSicknessReasons($oldSicknessReasons['values']);
}
else {
  $this->up1030_disableOldSicknessReasons($oldSicknessReasons['values']);
}
```