### PR TITLE
PCHR-3929: Fix JS console error if datalayer drupal module is not present/enabled

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/js/hrcore.js
+++ b/uk.co.compucorp.civicrm.hrcore/js/hrcore.js
@@ -12,7 +12,13 @@
    * directly on the tab
    */
   function trackContactTabVirtualPageviews () {
-    var contactPagePath = window.location.pathname + '?reset=1&cid=' + CRM.contactId;
+    var contactPagePath;
+
+    if (!dataLayer) {
+      return;
+    }
+
+    contactPagePath = window.location.pathname + '?reset=1&cid=' + CRM.contactId;
 
     CRM.$('#mainTabContainer').on('tabsactivate', function (event, ui) {
       var tabName = ui.newTab[0].id.replace('tab_', '');
@@ -23,4 +29,4 @@
       });
     });
   }
-}(window, CRM, dataLayer));
+}(window, CRM, (typeof dataLayer !== 'undefined' ? dataLayer : null)));


### PR DESCRIPTION
## Overview
If the [datalayer](https://www.drupal.org/project/datalayer) module is not present/enabled on a site, an error gets thrown by a script in the `hrcore` extension that is trying to use the `dataLayer` global object that that module provides

## Before
<img width="700" alt="before" src="https://user-images.githubusercontent.com/6400898/42269752-49d6cd74-7f7f-11e8-992e-abc7681a3b75.png">

## After
<img width="700" alt="after" src="https://user-images.githubusercontent.com/6400898/42269770-59831624-7f7f-11e8-9f29-1723f73ec1b9.png">