### PR TITLE
PCHR-3608: Makes Contract Length Read Only

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1268,23 +1268,15 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1037() {
-    $customField = civicrm_api3('CustomField', 'get', [
+    civicrm_api3('CustomField', 'get', [
       'name' => 'Length_Of_Service',
+      'api.CustomField.create' => ['id' => '$value.id', 'is_view' => 1],
     ]);
-    civicrm_api3('CustomField', 'create', [
-        'id' => $customField['id'],
-        'is_view' => 1,
-      ]
-    );
 
-    $customGroup = civicrm_api3('CustomGroup', 'get', [
+    civicrm_api3('CustomGroup', 'get', [
       'name' => 'Contact_Length_Of_Service',
+      'api.CustomGroup.create' => ['id' => '$value.id', 'is_active' => 0],
     ]);
-    civicrm_api3('CustomGroup', 'create', [
-        'id' => $customGroup['id'],
-        'is_active' => 0,
-      ]
-    );
 
     return TRUE;
   }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -515,6 +515,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1034();
     $this->upgrade_1035();
     $this->upgrade_1036();
+    $this->upgrade_1037();
   }
 
   function upgrade_1001() {
@@ -1192,7 +1193,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       'HRJob_Summary',
       'HRJobContract_Summary'
     ];
-    
+
     $result = civicrm_api3('CustomGroup', 'get', [
       'return' => ['id', 'name'],
       'name' => ['IN' => $customGroups],
@@ -1257,6 +1258,33 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     foreach ($childLinks as $itemName => $link) {
       $this->createNavItem($itemName, $permission, $parentId, ['url' => $link]);
     }
+
+    return TRUE;
+  }
+
+  /**
+   * Updates the custom field to view only and disables the custom group
+   *
+   * @return bool
+   */
+  public function upgrade_1037() {
+    $customField = civicrm_api3('CustomField', 'get', [
+      'name' => 'Length_Of_Service',
+    ]);
+    civicrm_api3('CustomField', 'create', [
+        'id' => $customField['id'],
+        'is_view' => 1,
+      ]
+    );
+
+    $customGroup = civicrm_api3('CustomGroup', 'get', [
+      'name' => 'Contact_Length_Of_Service',
+    ]);
+    civicrm_api3('CustomGroup', 'create', [
+        'id' => $customGroup['id'],
+        'is_active' => 0,
+      ]
+    );
 
     return TRUE;
   }

--- a/hrjobcontract/xml/length_of_service.xml
+++ b/hrjobcontract/xml/length_of_service.xml
@@ -19,23 +19,5 @@
     </CustomGroup>
   </CustomGroups>
   <CustomFields>
-    <CustomField>
-      <name>Length_Of_Service</name>
-      <label>Length of Service</label>
-      <data_type>Int</data_type>
-      <html_type>Text</html_type>
-      <is_required>0</is_required>
-      <is_searchable>1</is_searchable>
-      <is_search_range>0</is_search_range>
-      <weight>1</weight>
-      <is_active>1</is_active>
-      <is_view>0</is_view>
-      <text_length>16</text_length>
-      <note_columns>60</note_columns>
-      <note_rows>4</note_rows>
-      <column_name>length_of_service</column_name>
-      <custom_group_name>Contact_Length_Of_Service</custom_group_name>
-      <in_selector>1</in_selector>
-    </CustomField>
   </CustomFields>
 </CustomData>

--- a/hrjobcontract/xml/length_of_service.xml
+++ b/hrjobcontract/xml/length_of_service.xml
@@ -19,5 +19,23 @@
     </CustomGroup>
   </CustomGroups>
   <CustomFields>
+    <CustomField>
+      <name>Length_Of_Service</name>
+      <label>Length of Service</label>
+      <data_type>Int</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>1</weight>
+      <is_active>1</is_active>
+      <is_view>1</is_view>
+      <text_length>16</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>length_of_service</column_name>
+      <custom_group_name>Contact_Length_Of_Service</custom_group_name>
+      <in_selector>1</in_selector>
+    </CustomField>
   </CustomFields>
 </CustomData>


### PR DESCRIPTION
## Overview
 Makes contract length read only and hides it from Personal Details Screen

## Before
![screenshot from 2018-07-04 15 21 22](https://user-images.githubusercontent.com/1692858/42279479-2f0a73f0-7f9e-11e8-8247-f8c0edc62e9b.png)

## After
![screenshot from 2018-07-04 15 20 20](https://user-images.githubusercontent.com/1692858/42279489-34f14bf4-7f9e-11e8-973d-bb2d46a36e25.png)


## Technical Details
To hide the field just changed the 'is_active' field of CustomGroup to 0