### PR TITLE
PCHR-3897: Remove unnecessary permissions export

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/Dashboard.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/Dashboard.php
@@ -8,13 +8,6 @@ class CRM_HRLeaveAndAbsences_Page_Dashboard extends CRM_Core_Page {
     CRM_Utils_System::setTitle(ts('Dashboard'));
 
     CRM_Core_Resources::singleton()
-      ->addPermissions([
-        'access leave and absences',
-        'administer leave and absences',
-        'access leave and absences in ssp',
-        'manage leave and absences in ssp',
-        'can administer calendar feeds'
-      ])
       ->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css')
       ->addScriptFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'js/angular/dist/admin-dashboard.min.js', 1010)
       ->addVars('leaveAndAbsences', [


### PR DESCRIPTION
## Overview

This PR removes unnecessary permissions export on the Admin Dashboard.

## Technical Details

The permissions were added globally in the whole CiviHR (CiviCRM pages) here https://github.com/compucorp/civihr-employee-portal/pull/503.

So we simply remove permissions exports from the Dashboard:

```php
CRM_Core_Resources::singleton()
  /*->addPermissions([
    'access leave and absences',
    'administer leave and absences',
    'access leave and absences in ssp',
    'manage leave and absences in ssp',
    'can administer calendar feeds'
  ])*/ // not needed anymore
  ->addStyleFile('uk.co.compucorp.civicrm.hrleaveandabsences', 'css/leaveandabsence.css')
```

----

It was manually tested that the Admin Dashboard still has all needed permissions to work with.

![image](https://user-images.githubusercontent.com/3973243/42315084-71e9fee8-803e-11e8-9da9-8b93ce785706.png)

