### PR TITLE
PCHR-3936: Open Add Feed form in the same tab

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/calendar-feeds/dropdown-button/components/calendar-feeds-dropdown-button.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/angular/src/leave-absences/calendar-feeds/dropdown-button/components/calendar-feeds-dropdown-button.html
@@ -16,8 +16,7 @@
     </li>
     <li role="separator" class="divider" ng-if="dropdownButton.canCreateNewFeed"></li>
     <li ng-if="dropdownButton.canCreateNewFeed">
-      <a href="/civicrm/admin/leaveandabsences/calendar-feeds?action=add&reset=1"
-        target="_blank">
+      <a href="/civicrm/admin/leaveandabsences/calendar-feeds?action=add&reset=1">
         <i class="fa fa-plus"></i> Add new feed
       </a>
     </li>


### PR DESCRIPTION
## Overview

This PR makes the Calendar Feed Dropdown Button "Add new feed" button open the Add Calendar Feed form in the same tab.

## Before

![1](https://user-images.githubusercontent.com/3973243/42327616-0d39c624-8064-11e8-937f-462a2b36a6ce.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/42327376-75abc3d4-8063-11e8-8e32-3168c8f76df3.gif)

## Technical Details

Just remove the `target="_blank"` attribute from the `<a>` element.

----
Tested manually.