### PR TITLE
PCHR-3903: Implement Visibility Logic for LeaveRequestCalendarFeedConfig.get API

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
@@ -66,6 +66,7 @@ class CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect {
     $customQuery = CRM_Utils_SQL_Select::from(HRJobRoles::getTableName() . ' as a');
 
     $this->addJoins($customQuery);
+    $this->addWhere($customQuery);
 
     $this->query = $this->buildSelectQuery('ContactHrJobRoles');
     $this->query->merge($customQuery);
@@ -111,6 +112,23 @@ class CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect {
     $joins[] = 'INNER JOIN ' . HRJobContract::getTableName() . ' jc ON jc.id = a.job_contract_id';
 
     $query->join(null, $joins);
+  }
+
+  /**
+   * Adds where conditions to the query.
+   * The contact_id parameter is not an actual Entity field of the HRJobRoles and
+   * if passed will actually cause an error. So here, if the contact_id is present, the
+   * condition is added to filter by this field on the job contract table and then the
+   * parameter is unset.
+   *
+   * @param \CRM_Utils_SQL_Select $customQuery
+   */
+  private function addWhere(CRM_Utils_SQL_Select $customQuery) {
+    if (!empty($this->params['contact_id'])) {
+      $conditions[] = 'jc.contact_id IN (' . implode(',' , $this->params['contact_id']) . ')';
+      $customQuery->where($conditions);
+      unset($this->params['contact_id']);
+    }
   }
 
   /**

--- a/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
+++ b/com.civicrm.hrjobroles/api/v3/ContactHrJobRoles.php
@@ -10,6 +10,10 @@
  * @throws API_Exception
  */
 function civicrm_api3_contact_hr_job_roles_get($params) {
+  if (!empty($params['contact_id'])) {
+    $params['contact_id'] = _civicrm_api3_contact_hr_job_roles_get_contacts_from_params($params);
+  }
+
   $query = new CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect($params);
 
   return civicrm_api3_create_success($query->run(), $params, 'ContactHrJobRoles', 'get');
@@ -26,4 +30,23 @@ function civicrm_api3_contact_hr_job_roles_get($params) {
  */
 function _civicrm_api3_contact_hr_job_roles_DAO() {
   return CRM_Hrjobroles_BAO_ContactHrJobRoles::class;
+}
+
+/**
+ * Extracts the list of contactID's from the $params array
+ *
+ * @param array $params
+ *
+ * @return array
+ */
+function _civicrm_api3_contact_hr_job_roles_get_contacts_from_params($params) {
+  if (!is_array($params['contact_id'])) {
+    return [$params['contact_id']];
+  }
+
+  if (!array_key_exists('IN', $params['contact_id'])) {
+    throw new InvalidArgumentException('The contact_id parameter only supports the IN operator');
+  }
+
+  return $params['contact_id']['IN'];
 }

--- a/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
@@ -128,13 +128,13 @@ class api_v3_ContactHRJobRoleTest extends CRM_Hrjobroles_Test_BaseHeadlessTest {
     civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => [$operator => [1]]]);
   }
 
-  public function testGeDoesNotThrowExceptionWhenUsingTheINOperatorForTheContactIdParameter() {
+  public function testGetDoesNotThrowExceptionWhenUsingTheINOperatorForTheContactIdParameter() {
     $values = civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => ['IN' => [1]]]);
 
     $this->assertEquals(0, $values['is_error']);
   }
 
-  public function testGeDoesNotThrowExceptionWhenUsingTheEqualsToOperatorForTheContactIdParameter() {
+  public function testGetDoesNotThrowExceptionWhenUsingTheEqualsToOperatorForTheContactIdParameter() {
     $values = civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => 1]);
 
     $this->assertEquals(0, $values['is_error']);

--- a/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
@@ -118,6 +118,64 @@ class api_v3_ContactHRJobRoleTest extends CRM_Hrjobroles_Test_BaseHeadlessTest {
     $this->assertEquals($expectedJobRole3, $contactJobRoles[$jobRole3['id']]);
   }
 
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage The contact_id parameter only supports the IN operator
+   *
+   * @dataProvider invalidGetContactIdOperators
+   */
+  public function testGetThrowsExceptionForOperatorThatIsNotTheINOperatorForContactIDParameter($operator) {
+    civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => [$operator => [1]]]);
+  }
+
+  public function testGeDoesNotThrowExceptionWhenUsingTheINOperatorForTheContactIdParameter() {
+    $values = civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => ['IN' => [1]]]);
+
+    $this->assertEquals(0, $values['is_error']);
+  }
+
+  public function testGeDoesNotThrowExceptionWhenUsingTheEqualsToOperatorForTheContactIdParameter() {
+    $values = civicrm_api3('ContactHrJobRoles', 'get', ['contact_id' => 1]);
+
+    $this->assertEquals(0, $values['is_error']);
+  }
+
+  public function testGetReturnsJobRolesForPassedInContacts() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+    $contract2 = HRJobContractFabricator::fabricate(['contact_id' => $contact2['id']]);
+    $contract3 = HRJobContractFabricator::fabricate(['contact_id' => $contact3['id']]);
+    $jobRole1 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id']]);
+    $jobRole2 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract2['id']]);
+    $jobRole3 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract3['id']]);
+
+    //Get Jobroles for contact1 and contact3
+    $contactJobRoles = civicrm_api3($this->entity, $this->action, [
+      'contact_id' => ['IN' => [$contact1['id'], $contact3['id']]]
+    ])['values'];
+
+    $this->assertCount(2, $contactJobRoles);
+
+    // The CiviCRM only returns non-empty fields. Since we only set the job
+    // contract id, only the ID and the contact_id fields will be returned
+    $expectedJobRole1 = ['id' => $jobRole1['id'], 'contact_id' => $contact1['id']];
+    $expectedJobRole3 = ['id' => $jobRole3['id'], 'contact_id' => $contact3['id']];
+
+    $this->assertEquals($expectedJobRole1, $contactJobRoles[$jobRole1['id']]);
+    $this->assertEquals($expectedJobRole3, $contactJobRoles[$jobRole3['id']]);
+
+    //Get Jobroles for contact2 only
+    $contactJobRoles = civicrm_api3($this->entity, $this->action, [
+      'contact_id' => $contact2['id']
+    ])['values'];
+
+    $this->assertCount(1, $contactJobRoles);
+    $expectedJobRole2 = ['id' => $jobRole2['id'], 'contact_id' => $contact2['id']];
+    $this->assertEquals($expectedJobRole2, $contactJobRoles[$jobRole2['id']]);
+  }
+
   private function setExpectedApiPermissionException($permission) {
     $message = "API permission check failed for {$this->entity}/{$this->action} call; insufficient permission: require {$permission}";
     $this->setExpectedException('CiviCRM_API3_Exception', $message);
@@ -126,5 +184,23 @@ class api_v3_ContactHRJobRoleTest extends CRM_Hrjobroles_Test_BaseHeadlessTest {
   private function registerCurrentLoggedInContactInSession($contactID) {
     $session = CRM_Core_Session::singleton();
     $session->set('userID', $contactID);
+  }
+
+  public function invalidGetContactIdOperators() {
+    return [
+      ['>'],
+      ['>='],
+      ['<='],
+      ['<'],
+      ['<>'],
+      ['!='],
+      ['BETWEEN'],
+      ['NOT BETWEEN'],
+      ['LIKE'],
+      ['NOT LIKE'],
+      ['NOT IN'],
+      ['IS NULL'],
+      ['IS NOT NULL'],
+    ];
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
@@ -251,14 +251,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
       return;
     }
 
-    $accessibleDepartments = $this->getAccessibleDepartmentsForLoggedInContact();
-    $accessibleLocations = $this->getAccessibleLocationsForLoggedInContact();
-
-    $inaccessibleFeedConfigs = $this->getNotAccessibleFeedConfigs(
-      $limitedVisibilityFeedConfigs,
-      $accessibleDepartments,
-      $accessibleLocations
-    );
+    $inaccessibleFeedConfigs = $this->getInAccessibleFeedConfigsForCurrentUser($limitedVisibilityFeedConfigs);
 
     if (empty($inaccessibleFeedConfigs)) {
       return;
@@ -271,6 +264,26 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
     return $clauses;
   }
 
+  /**
+   * Gets the ids of the feeds that are not accessible to the current user from the
+   * list of feed configs passed in.
+   *
+   * @param array $limitedVisibilityFeedConfigs
+   *
+   * @return array
+   */
+  private function getInAccessibleFeedConfigsForCurrentUser($limitedVisibilityFeedConfigs) {
+    $accessibleDepartments = $this->getAccessibleDepartmentsForLoggedInContact();
+    $accessibleLocations = $this->getAccessibleLocationsForLoggedInContact();
+
+    $inaccessibleFeedConfigs = $this->getInAccessibleFeedConfigs(
+      $limitedVisibilityFeedConfigs,
+      $accessibleDepartments,
+      $accessibleLocations
+    );
+
+    return $inaccessibleFeedConfigs;
+  }
   /**
    * Returns feeds that have limited visibility i.e feeds
    * that do not have 'viewable by all' set for it. viewable by
@@ -344,6 +357,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
    */
   private function getAccessibleDepartmentsForLoggedInContact() {
     $departments = $this->getDepartmentsList();
+
     return $this->getLoggedInContactJobRoleAccessFor('department', $departments);
   }
 
@@ -355,6 +369,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
    */
   private function getAccessibleLocationsForLoggedInContact() {
     $locations = $this->getLocationsList();
+
     return $this->getLoggedInContactJobRoleAccessFor('location', $locations);
   }
 
@@ -390,7 +405,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
    *
    * @return array
    */
-  public function getNotAccessibleFeedConfigs($limitedVisibilityFeedConfigs, $accessibleDepartments, $accessibleLocations) {
+  public function getInAccessibleFeedConfigs(
+    $limitedVisibilityFeedConfigs,
+    $accessibleDepartments,
+    $accessibleLocations
+  ) {
     $inaccessibleFeeds = [];
     foreach ($limitedVisibilityFeedConfigs as $feedId => $feedVisibility) {
       $hasDepartmentAccess = $hasLocationAccess = FALSE;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
@@ -251,7 +251,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
       return;
     }
 
-    $inaccessibleFeedConfigs = $this->getInAccessibleFeedConfigsForCurrentUser($limitedVisibilityFeedConfigs);
+    $inaccessibleFeedConfigs = $this->getInaccessibleFeedConfigIDsForCurrentUser($limitedVisibilityFeedConfigs);
 
     if (empty($inaccessibleFeedConfigs)) {
       return;
@@ -272,17 +272,15 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
    *
    * @return array
    */
-  private function getInAccessibleFeedConfigsForCurrentUser($limitedVisibilityFeedConfigs) {
+  private function getInaccessibleFeedConfigIDsForCurrentUser($limitedVisibilityFeedConfigs) {
     $accessibleDepartments = $this->getAccessibleDepartmentsForLoggedInContact();
     $accessibleLocations = $this->getAccessibleLocationsForLoggedInContact();
 
-    $inaccessibleFeedConfigs = $this->getInAccessibleFeedConfigs(
+    return $this->getInaccessibleFeedConfigs(
       $limitedVisibilityFeedConfigs,
       $accessibleDepartments,
       $accessibleLocations
     );
-
-    return $inaccessibleFeedConfigs;
   }
   /**
    * Returns feeds that have limited visibility i.e feeds
@@ -405,7 +403,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
    *
    * @return array
    */
-  public function getInAccessibleFeedConfigs(
+  public function getInaccessibleFeedConfigs(
     $limitedVisibilityFeedConfigs,
     $accessibleDepartments,
     $accessibleLocations

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequestCalendarFeedConfig.php
@@ -232,4 +232,185 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig extends CRM_HRLe
       return [];
     }
   }
+
+  /**
+   * Implementation of the addSelectWhereClause:
+   * This ensures that the administrator (user with 'can administer calendar feeds')
+   * permission can access all feed configs while users without this permission can
+   * only access feed configs which they have visibility access to. i.e if they belong
+   * to any of the department or location visibility set  for a feed config.
+   */
+  public function addSelectWhereClause() {
+    if (CRM_Core_Permission::check([['can administer calendar feeds']])) {
+      return;
+    }
+
+    $limitedVisibilityFeedConfigs = $this->getLimitedVisibilityFeedConfigs();
+
+    if (empty($limitedVisibilityFeedConfigs)) {
+      return;
+    }
+
+    $accessibleDepartments = $this->getAccessibleDepartmentsForLoggedInContact();
+    $accessibleLocations = $this->getAccessibleLocationsForLoggedInContact();
+
+    $inaccessibleFeedConfigs = $this->getNotAccessibleFeedConfigs(
+      $limitedVisibilityFeedConfigs,
+      $accessibleDepartments,
+      $accessibleLocations
+    );
+
+    if (empty($inaccessibleFeedConfigs)) {
+      return;
+    }
+
+    $clauses['id'] = 'NOT IN (' . implode(',', $inaccessibleFeedConfigs) . ')';
+
+    CRM_Utils_Hook::selectWhereClause($this, $clauses);
+
+    return $clauses;
+  }
+
+  /**
+   * Returns feeds that have limited visibility i.e feeds
+   * that do not have 'viewable by all' set for it. viewable by
+   * all means the visible_to field has an empty array value.
+   * The feed configs are returned in an array of the visibility
+   * settings indexed by the feed config Id.
+   *
+   * @return array
+   */
+  private function getLimitedVisibilityFeedConfigs() {
+    $feedConfig = new self();
+    $feedConfig->addWhere('visible_to !=' . serialize([]));
+    $feedConfig->find();
+
+    $results = [];
+    while($feedConfig->fetch()) {
+      $visibleTo = unserialize($feedConfig->visible_to);
+      if (!empty($visibleTo['department'])){
+        $results[$feedConfig->id]['department'] = $visibleTo['department'];
+      }
+      if (!empty($visibleTo['location'])){
+        $results[$feedConfig->id]['location'] = $visibleTo['location'];
+      }
+    }
+
+    return $results;
+  }
+
+  /**
+   * Returns the departments list.
+   *
+   * @return array
+   */
+  private function getDepartmentsList() {
+    return $this->getOptionValuesList('hrjc_department');
+  }
+
+  /**
+   * Returns the locations list.
+   *
+   * @return array
+   */
+  private function getLocationsList() {
+    return $this->getOptionValuesList('hrjc_location');
+  }
+
+  /**
+   * Returns the values for an option group formatted
+   * as an array.
+   *
+   * @param array $optionGroupName
+   *
+   * @return array
+   */
+  private function getOptionValuesList($optionGroupName) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'return' => ['value'],
+      'option_group_id' => $optionGroupName,
+      'is_active' => 1,
+    ]);
+
+    return array_column($result['values'], 'value');
+  }
+
+
+  /**
+   * Gets the departments the logged in user has access to from the list of
+   * active departments.
+   *
+   * @return array
+   */
+  private function getAccessibleDepartmentsForLoggedInContact() {
+    $departments = $this->getDepartmentsList();
+    return $this->getLoggedInContactJobRoleAccessFor('department', $departments);
+  }
+
+  /**
+   * Gets the locations the logged in user has access to from the list of
+   * active locations.
+   *
+   * @return array
+   */
+  private function getAccessibleLocationsForLoggedInContact() {
+    $locations = $this->getLocationsList();
+    return $this->getLoggedInContactJobRoleAccessFor('location', $locations);
+  }
+
+  /**
+   * Gets the options the logged in user has access to based on the field
+   * to search by on the HRJobRoles entity and the options given.
+   *
+   * @param string $field
+   * @param array $options
+   *
+   * @return array
+   */
+  private function getLoggedInContactJobRoleAccessFor($field, $options) {
+    if (empty($options)) {
+      return [];
+    }
+
+    $result = civicrm_api3('ContactHrJobRoles', 'get', [
+      $field => ['IN' => $options],
+      'contact_id' => CRM_Core_Session::getLoggedInContactID(),
+    ]);
+
+    return array_unique(array_column($result['values'], $field));
+  }
+
+  /**
+   * Returns the Feed Configs that the logged in user does not have visibility
+   * access to based on the given parameters.
+   *
+   * @param array $limitedVisibilityFeedConfigs
+   * @param array $accessibleDepartments
+   * @param array $accessibleLocations
+   *
+   * @return array
+   */
+  public function getNotAccessibleFeedConfigs($limitedVisibilityFeedConfigs, $accessibleDepartments, $accessibleLocations) {
+    $inaccessibleFeeds = [];
+    foreach ($limitedVisibilityFeedConfigs as $feedId => $feedVisibility) {
+      $hasDepartmentAccess = $hasLocationAccess = FALSE;
+      if (!empty($feedVisibility['department'])) {
+        if (array_intersect($feedVisibility['department'], $accessibleDepartments)) {
+          $hasDepartmentAccess = TRUE;
+        }
+      }
+
+      if (!empty($feedVisibility['location'])) {
+        if (array_intersect($feedVisibility['location'], $accessibleLocations)) {
+          $hasLocationAccess = TRUE;
+        }
+      }
+
+      if (!$hasDepartmentAccess && !$hasLocationAccess) {
+        $inaccessibleFeeds[] = $feedId;
+      }
+    }
+
+    return $inaccessibleFeeds;
+  }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/BaseHeadlessTest.php
@@ -10,6 +10,7 @@ abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements
     return \Civi\Test::headless()
       ->install('uk.co.compucorp.civicrm.hrcore')
       ->install('org.civicrm.hrjobcontract')
+      ->install('com.civicrm.hrjobroles')
       ->install('uk.co.compucorp.civicrm.hrcomments')
       ->install('uk.co.compucorp.civicrm.hrcontactactionsmenu')
       ->installMe(__DIR__)

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestCalendarFeedConfigTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestCalendarFeedConfigTest.php
@@ -1,6 +1,19 @@
 <?php
 
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_Hrjobroles_Test_Fabricator_HrJobRoles as HRJobRolesFabricator;
+use CRM_HRCore_Test_Fabricator_OptionValue as OptionValueFabricator;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequestCalendarFeedConfig as LeaveRequestCalendarFeedConfig;
+
+/**
+ * Class api_v3_LeaveRequestCalendarFeedConfigTest
+ *
+ * @group headless
+ */
 class api_v3_LeaveRequestCalendarFeedConfigTest extends BaseHeadlessTest {
+
+  use CRM_HRLeaveAndAbsences_SessionHelpersTrait;
 
   public function testGetReturnsUnSerializedValuesForFilterFields() {
     $visibleTo = [
@@ -26,5 +39,289 @@ class api_v3_LeaveRequestCalendarFeedConfigTest extends BaseHeadlessTest {
     $calendarFeedConfig = array_shift($calendarFeedConfig['values']);
     $this->assertEquals($visibleTo, $calendarFeedConfig['visible_to']);
     $this->assertEquals($composedOf, $calendarFeedConfig['composed_of']);
+  }
+
+  public function testGetReturnsAllFeedsForCalendarFeedAdmin() {
+    $adminId = 2;
+    $this->setPermissions(['access AJAX API', 'can administer calendar feeds']);
+    $this->registerCurrentLoggedInContactInSession($adminId);
+    $feedConfig1 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 1',
+      'visible_to' => [
+        'location' => ['Sample Location1'],
+        'department' => ['Sample Department1']
+      ]
+    ]);
+
+    $feedConfig2 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 2',
+      'visible_to' => [
+        'location' => ['Sample Location2'],
+        'department' => ['Sample Department2']
+      ]
+    ]);
+
+    $feedConfig3 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 3',
+      'visible_to' => []
+    ]);
+
+    $results = civicrm_api3('LeaveRequestCalendarFeedConfig', 'get', [
+      'check_permissions' => TRUE,
+      'sequential' => 1
+    ]);
+
+    //Admin has access to all feeds
+    $this->assertEquals(3, $results['count']);
+    $this->assertEquals($feedConfig1->id, $results['values'][0]['id']);
+    $this->assertEquals($feedConfig2->id, $results['values'][1]['id']);
+    $this->assertEquals($feedConfig3->id, $results['values'][2]['id']);
+
+    $this->setPermissions([]);
+  }
+
+  public function testGetReturnsTheFeedsStaffHasLocationAccessTo() {
+    $contact1 = ContactFabricator::fabricate();
+    $this->setPermissions(['access AJAX API']);
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+
+    $location1 = $this->createLocation('location1');
+    $location2 = $this->createLocation('location2');
+    $department1 = $this->createDepartment('department1');
+
+    //Assign the contact to a job role with access to location1
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'location' => $location1['value']
+    ]);
+
+    $feedConfig1 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 1',
+      'visible_to' => [
+        'location' => [$location1['value']],
+        'department' => [$department1['value']]
+      ]
+    ]);
+
+    $feedConfig2 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 2',
+      'visible_to' => [
+        'location' => [$location2['value']],
+        'department' => [$department1['value']]
+      ]
+    ]);
+
+    //A feed with an empty array as its visible_to filter means it is accessible to all locations
+    // and departments.
+    $feedConfig3 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 3',
+      'visible_to' => []
+    ]);
+
+    $results = civicrm_api3('LeaveRequestCalendarFeedConfig', 'get', [
+      'check_permissions' => TRUE,
+      'sequential' => 1
+    ]);
+
+    //Contact1 has access to feed 1 which has visibility for the location he belongs to
+    //and feed3 which has visibility for all departments and locations.
+    $this->assertEquals(2, $results['count']);
+    $this->assertEquals($feedConfig1->id, $results['values'][0]['id']);
+    $this->assertEquals($feedConfig3->id, $results['values'][1]['id']);
+    $this->setPermissions([]);
+  }
+
+  public function testGetReturnsTheFeedsStaffHasDepartmentAccessTo() {
+    $contact1 = ContactFabricator::fabricate();
+    $this->setPermissions(['access AJAX API']);
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+
+    $location1 = $this->createLocation('location1');
+    $department1 = $this->createDepartment('department1');
+    $department2 = $this->createDepartment('department2');
+
+    //Assign the contact to a job role with access to department
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'department' => $department1['value']
+    ]);
+
+    $feedConfig1 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 1',
+      'visible_to' => [
+        'location' => [$location1['value']],
+        'department' => [$department2['value']]
+      ]
+    ]);
+
+    $feedConfig2 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 2',
+      'visible_to' => [
+        'location' => [$location1['value']],
+        'department' => [$department1['value']]
+      ]
+    ]);
+
+    //A feed with an empty array as its visible_to filter means it is accessible to all locations
+    //and departments.
+    $feedConfig3 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 3',
+      'visible_to' => []
+    ]);
+
+    $results = civicrm_api3('LeaveRequestCalendarFeedConfig', 'get', [
+      'check_permissions' => TRUE,
+      'sequential' => 1
+    ]);
+
+    //Contact1 has access to feed 2 which has visibility for the department he belongs to
+    //and feed3 which has visibility for all department and locations.
+    $this->assertEquals(2, $results['count']);
+    $this->assertEquals($feedConfig2->id, $results['values'][0]['id']);
+    $this->assertEquals($feedConfig3->id, $results['values'][1]['id']);
+    $this->setPermissions([]);
+  }
+
+  public function testGetReturnsTheFeedsStaffHasBothLocationAndDepartmentAccessTo() {
+    $contact1 = ContactFabricator::fabricate();
+    $this->setPermissions(['access AJAX API']);
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+
+    $location1 = $this->createLocation('location1');
+    $location2 = $this->createLocation('location2');
+    $department1 = $this->createDepartment('department1');
+    $department2 = $this->createDepartment('department2');
+
+    //Assign the contact to a job role with access to department
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'department' => $department1['value'],
+      'location' => $location1['value']
+    ]);
+
+    $feedConfig1 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 1',
+      'visible_to' => [
+        'location' => [$location1['value']],
+        'department' => [$department1['value']]
+      ]
+    ]);
+
+    $feedConfig2 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 2',
+      'visible_to' => [
+        'location' => [$location2['value']],
+        'department' => [$department2['value']]
+      ]
+    ]);
+
+    //A feed with an empty array as its visible_to filter means it is accessible to all locations
+    //and departments.
+    $feedConfig3 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 3',
+      'visible_to' => []
+    ]);
+
+    $results = civicrm_api3('LeaveRequestCalendarFeedConfig', 'get', [
+      'check_permissions' => TRUE,
+      'sequential' => 1
+    ]);
+
+    //Contact1 has access to feed1 which has visibility for the department and location he belongs to
+    //and feed3 which has visibility for all department and locations.
+    $this->assertEquals(2, $results['count']);
+    $this->assertEquals($feedConfig1->id, $results['values'][0]['id']);
+    $this->assertEquals($feedConfig3->id, $results['values'][1]['id']);
+    $this->setPermissions([]);
+  }
+
+  public function testGetDoesNotReturnResultsWhenThereAreNoFeedsStaffHasLocationOrDepartmentAccessTo() {
+    $contact1 = ContactFabricator::fabricate();
+    $this->setPermissions(['access AJAX API']);
+    $this->registerCurrentLoggedInContactInSession($contact1['id']);
+
+    $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
+
+    $location1 = $this->createLocation('location1');
+    $location2 = $this->createLocation('location2');
+    $department1 = $this->createDepartment('department1');
+    $department2 = $this->createDepartment('department2');
+
+    //Assign the contact to a job role with access to department
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'department' => $department1['value'],
+      'location' => $location1['value']
+    ]);
+
+    $feedConfig1 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 1',
+      'visible_to' => [
+        'location' => [$location2['value']],
+        'department' => [$department2['value']]
+      ]
+    ]);
+
+    $feedConfig2 = $this->createLeaveCalendarFeedConfig([
+      'title' => 'Feed 2',
+      'visible_to' => [
+        'department' => [$department2['value']]
+      ]
+    ]);
+
+    $results = civicrm_api3('LeaveRequestCalendarFeedConfig', 'get', [
+      'check_permissions' => TRUE,
+      'sequential' => 1
+    ]);
+
+    $this->assertEquals(0, $results['count']);
+    $this->setPermissions([]);
+  }
+
+  private function createLeaveCalendarFeedConfig($params) {
+    $defaultParameters = [
+      'title' => 'Feed 1',
+      'timezone' => 'America/Monterrey',
+      'composed_of' => [
+        'leave_type' => [1],
+        'department' => [3],
+        'location' => [3]
+      ],
+      'visible_to' => [
+        'department' => [1,2],
+        'location' => [1]
+      ]
+    ];
+
+    $params = array_merge($defaultParameters, $params);
+    return LeaveRequestCalendarFeedConfig::create($params);
+  }
+
+  private function createDepartment($departmentName) {
+    $department = OptionValueFabricator::fabricate([
+      'option_group_id' => 'hrjc_department',
+      'name' => $departmentName,
+      'value' => $departmentName,
+      'label' => $departmentName,
+    ]);
+
+    return $department;
+  }
+
+  private function createLocation($locationName) {
+    $location = OptionValueFabricator::fabricate([
+      'option_group_id' => 'hrjc_location',
+      'name' => $locationName,
+      'value' => $locationName,
+      'label' => $locationName,
+    ]);
+
+    return $location;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestCalendarFeedConfigTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestCalendarFeedConfigTest.php
@@ -300,6 +300,7 @@ class api_v3_LeaveRequestCalendarFeedConfigTest extends BaseHeadlessTest {
     ];
 
     $params = array_merge($defaultParameters, $params);
+
     return LeaveRequestCalendarFeedConfig::create($params);
   }
 


### PR DESCRIPTION
## Overview
Currently, when configuring a LeaveRequestCalendarFeedConfig in the create/update form, you can set who the feed should be visible to based on department and location that the contact should belong to. This PR implements this logic in the LeaveRequestCalendarFeedConfig.get API by checking for the departments and locations that the current user belongs and using this information to determine whether the user has access to fetch a feed configuration or not. Admins (users with the (`can administer calendar feeds` permission) can view all feed configurations, while users without these permissions can only view the feed configuration based on the feed visibility settings.

## Before
- The visibility logic is not implemented for the LeaveRequestCalendarFeedConfig.get API, therefore all users can view all feeds.

## After
- The visibility logic is now implemented for the LeaveRequestCalendarFeedConfig.get API, only users with visibility for a feed configuration can view such while the Admin can view all feed configurations.

## Technical Details
The `addSelectWhereClause` method was implemented in the `LeaveRequestCalendarFeedConfig` BAO to check the the departments and locations the current user has access to. The list of feeds with limited visibility settings is fetched and the ones the current user does not have access to is excluded from the final results.

``` php
public function addSelectWhereClause() {
    if (CRM_Core_Permission::check([['can administer calendar feeds']])) {
      return;
    }

    $limitedVisibilityFeedConfigs = $this->getLimitedVisibilityFeedConfigs();

    if (empty($limitedVisibilityFeedConfigs)) {
      return;
    }

    $accessibleDepartments = $this->getAccessibleDepartmentsForLoggedInContact();
    $accessibleLocations = $this->getAccessibleLocationsForLoggedInContact();

    $inaccessibleFeedConfigs = $this->getNotAccessibleFeedConfigs(
      $limitedVisibilityFeedConfigs,
      $accessibleDepartments,
      $accessibleLocations
    );

    if (empty($inaccessibleFeedConfigs)) {
      return;
    }

    $clauses['id'] = 'NOT IN (' . implode(',', $inaccessibleFeedConfigs) . ')';

    CRM_Utils_Hook::selectWhereClause($this, $clauses);

    return $clauses;
  }
```