### PR TITLE
PCHR-3927: Customise error message for approval transition

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -112,9 +112,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
       $this->getCurrentStatus($params), $params['status_id'], $params['contact_id'])
     ) {
       throw new RuntimeException(
-        "You can't change the Leave Request status from ".
-        $this->getCurrentStatus($params). " to {$params['status_id']}"
-      );
+        $this->getErrorMessageForInvalidStatusTransition($params));
     }
 
     $isTOILWithPastDates = LeaveRequest::isTOILWithPastDates($params);
@@ -128,6 +126,27 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     }
 
     return $this->createRequestWithBalanceChanges($params);
+  }
+
+  /**
+   * Return an error message
+   * either for specific invalid status transition cases
+   * or a default generic message
+   *
+   * @param array $params
+   *
+   * @return string
+   */
+  private function getErrorMessageForInvalidStatusTransition($params) {
+    $leaveStatuses = LeaveRequest::getStatuses();
+    $isOwnRequest = CRM_Core_Session::getLoggedInContactID() === $params['contact_id'];
+
+    if ($isOwnRequest && (int)$params['status_id'] === (int)$leaveStatuses['approved']) {
+      return "You can't approve your own leave requests";
+    }
+
+    return "You can't change the Leave Request status from " .
+      $this->getCurrentStatus($params) . " to {$params['status_id']}";
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -129,8 +129,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
   }
 
   /**
-   * Return an error message
-   * either for specific invalid status transition cases
+   * Return an error message either for specific invalid status transition cases
    * or a default generic message
    *
    * @param array $params
@@ -139,14 +138,16 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    */
   private function getErrorMessageForInvalidStatusTransition($params) {
     $leaveStatuses = LeaveRequest::getStatuses();
+    $leaveStatusesLabels = LeaveRequest::buildOptions('status_id');
     $isOwnRequest = CRM_Core_Session::getLoggedInContactID() === $params['contact_id'];
 
     if ($isOwnRequest && (int)$params['status_id'] === (int)$leaveStatuses['approved']) {
       return "You can't approve your own leave requests";
     }
 
-    return "You can't change the Leave Request status from " .
-      $this->getCurrentStatus($params) . " to {$params['status_id']}";
+    return "You can't change the Leave Request status from \"" .
+      $leaveStatusesLabels[$this->getCurrentStatus($params)] . '" to "' .
+      $leaveStatusesLabels[$params['status_id']] . '"';
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -318,8 +318,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $leaveRequestStatuses = LeaveRequest::getStatuses();
 
     $this->setExpectedException(
-      'RuntimeException', "You can't change the Leave Request status from ".
-      $this->getDefaultParams()['status_id']. " to {$leaveRequestStatuses['awaiting_approval']}"
+      'RuntimeException',
+      'You can\'t change the Leave Request status from "Approved" to "Awaiting Approval"'
     );
 
     $params['id'] = $leaveRequest->id;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -328,6 +328,23 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
   }
 
+  public function testCreateThrowsAnExceptionWhenAttemptingToApproveOwnLeaveRequest() {
+    $params = $this->getDefaultParams();
+    $leaveRequestStatuses = LeaveRequest::getStatuses();
+
+    $params['status_id'] = $leaveRequestStatuses['awaiting_approval'];
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
+
+    $this->setExpectedException(
+      'RuntimeException', "You can't approve your own leave requests");
+
+    $params['id'] = $leaveRequest->id;
+    $params['status_id'] = $leaveRequestStatuses['approved'];
+
+    $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
+  }
+
   /**
    * @expectedException RuntimeException
    * @expectedExceptionMessage You are not allowed to change the request dates


### PR DESCRIPTION
## Overview

This PR customises the message for the case when user attempts to approve their own leave request. Currently an admin can attempt to do that and now instead of seeing **You can't change the Leave Request status from 3 to 1** they see **You can't approve your own leave requests**. Also, the **You can't change the Leave Request status from 3 to 1** was transformed to show real labels and not numbers: **You can't change the Leave Request status from "Awaiting Approval" to "Approved"**.

## Before

![1 1](https://user-images.githubusercontent.com/3973243/42335346-fc8dc55a-8077-11e8-8845-fb1feb41ccb3.gif)

![1 2](https://user-images.githubusercontent.com/3973243/42335345-fc79e328-8077-11e8-8df2-6466956502de.gif)

## After

![2 1](https://user-images.githubusercontent.com/3973243/42335368-09324bfa-8078-11e8-9adc-d76987cfae56.gif)

![2 2](https://user-images.githubusercontent.com/3973243/42335366-091d4a98-8078-11e8-967f-0dbac3f4841d.gif)

## Technical Details

Instead of returning a generic error, we now use a function that determines the case for a custom error or returns the default generic one.

```php
private function getErrorMessageForInvalidStatusTransition($params) {
  // if own request and transitioning to "Approved" - custom error message
  if ($isOwnRequest && (int)$params['status_id'] === (int)$leaveStatuses['approved']) {
    return "You can't approve your own leave requests";
  }

  // otherwise, a generic message
  return "You can't change the Leave Request status from \"" .
    $leaveStatusesLabels[$this->getCurrentStatus($params)] . '" to "' .
    $leaveStatusesLabels[$params['status_id']] . '"';
}
```

---
✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
✅PHP Unit Tests - augmented and passed