### PR TITLE
PCHR-3939: Improve UI for Add Calendar Feed form

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
@@ -13,34 +13,34 @@
           <div class="col-sm-3">{$form.title.label}</div>
           <div class="col-sm-9">{$form.title.html}</div>
         </div>
-      <div class="form-group row composed_of_department">
-        <div class="col-sm-3">{$form.composed_of_department.label}</div>
-        <div class="col-sm-9">{$form.composed_of_department.html}</div>
-      </div>
-      <div class="form-group row composed_of_location">
-        <div class="col-sm-3">{$form.composed_of_location.label}</div>
-        <div class="col-sm-9">{$form.composed_of_location.html}</div>
-      </div>
-      <div class="form-group row">
-        <div class="col-sm-3"></div>
-        <div class="col-sm-9 pull-left composed_of_help_text"></div>
-      </div>
-      <div class="form-group row visible_to_department">
-        <div class="col-sm-3">{$form.visible_to_department.label}</div>
-        <div class="col-sm-9">{$form.visible_to_department.html}</div>
-      </div>
-      <div class="form-group row visible_to_location">
-        <div class="col-sm-3">{$form.visible_to_location.label}</div>
-        <div class="col-sm-9">{$form.visible_to_location.html}</div>
-      </div>
-      <div class="form-group row">
-        <div class="col-sm-3"></div>
-        <div class="col-sm-9 pull-left visible_to_help_text"></div>
-      </div>
-      <div class="form-group row composed_of_leave_type">
-        <div class="col-sm-3">{$form.composed_of_leave_type.label}</div>
-        <div class="col-sm-9">{$form.composed_of_leave_type.html}</div>
-      </div>
+        <div class="form-group row composed_of_department">
+          <div class="col-sm-3">{$form.composed_of_department.label}</div>
+          <div class="col-sm-9">{$form.composed_of_department.html}</div>
+        </div>
+        <div class="form-group row composed_of_location">
+          <div class="col-sm-3">{$form.composed_of_location.label}</div>
+          <div class="col-sm-9">{$form.composed_of_location.html}</div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-3"></div>
+          <div class="col-sm-9 pull-left composed_of_help_text"></div>
+        </div>
+        <div class="form-group row visible_to_department">
+          <div class="col-sm-3">{$form.visible_to_department.label}</div>
+          <div class="col-sm-9">{$form.visible_to_department.html}</div>
+        </div>
+        <div class="form-group row visible_to_location">
+          <div class="col-sm-3">{$form.visible_to_location.label}</div>
+          <div class="col-sm-9">{$form.visible_to_location.html}</div>
+        </div>
+        <div class="form-group row">
+          <div class="col-sm-3"></div>
+          <div class="col-sm-9 pull-left visible_to_help_text"></div>
+        </div>
+        <div class="form-group row composed_of_leave_type">
+          <div class="col-sm-3">{$form.composed_of_leave_type.label}</div>
+          <div class="col-sm-9">{$form.composed_of_leave_type.html}</div>
+        </div>
         <div class="form-group row">
           <div class="col-sm-3">{$form.timezone.label}</div>
           <div class="col-sm-9">{$form.timezone.html}</div>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
@@ -58,75 +58,71 @@
       </div>
       {literal}
         <script type="text/javascript">
-          CRM.$(function($) {
-            $(document).ready(function() {
+          CRM.$(function ($) {
+            var REDIRECT_AFTER_DELETE_URL = '{/literal}{$deleteUrl}{literal}';
+
+            $(document).ready(function () {
               initDeleteButton();
               setComposedOfHelpText();
               setVisibleToHelpText();
               initFilterFieldsHelpText();
             });
 
-            function initDeleteButton() {
-              $('.crm-button-type-delete').on('click', function(e) {
+            /**
+             * Initiates "Delete" button by adding a click event
+             * with a confirmation dialog
+             */
+            function initDeleteButton () {
+              $('.crm-button-type-delete').on('click', function (e) {
                 e.preventDefault();
-                CRM.confirm({
-                  title: ts('Delete Calendar Feed'),
-                  message: ts('Are you sure you want to delete this Calendar Feed?'),
-                  options: {
-                    yes: ts('Yes'),
-                    no: ts('No')
-                  }
-                }).on('crmConfirm:yes', deleteCallback);
+                CRM
+                  .confirm({
+                    title: ts('Delete Calendar Feed'),
+                    message: ts('Are you sure you want to delete this Calendar Feed?'),
+                    options: {
+                      yes: ts('Yes'),
+                      no: ts('No')
+                    }
+                  })
+                  .on('crmConfirm:yes', function () {
+                    window.location = REDIRECT_AFTER_DELETE_URL;
+                  });
               });
             }
 
-            function deleteCallback() {
-              {/literal}
-              window.location = "{$deleteUrl}";
-              {literal}
+            /**
+             * Initiates filters help texts
+             * by attaching according event handlers to the filter fields
+             */
+            function initFilterFieldsHelpText () {
+              $('.composed_of_department select, .composed_of_location select')
+                .on('change', setComposedOfHelpText);
+
+              $('.visible_to_department select, .visible_to_location select')
+                .on('change', setVisibleToHelpText);
             }
 
-            function initFilterFieldsHelpText() {
-              $('.composed_of_department select').on('change', function(e) {
-                setComposedOfHelpText();
-              });
-
-              $('.composed_of_location select').on('change', function(e) {
-                setComposedOfHelpText();
-              });
-
-              $('.visible_to_department select').on('change', function(e) {
-                setVisibleToHelpText();
-              });
-
-              $('.visible_to_location select').on('change', function(e) {
-                setVisibleToHelpText();
-              });
-            }
-
-            function setComposedOfHelpText() {
+            /**
+             * Sets help text for "Staff to include" group filter
+             */
+            function setComposedOfHelpText () {
               var helpMessage = {
-                'default' : 'All staff will be included',
-                'department_only' : 'Only staff from the selected departments will be included',
-                'location_only' : 'Only staff from the selected locations will be included',
-                'department_and_location' : 'Only staff from the selected departments plus the selected locations will be included'
+                'default': 'All staff will be included',
+                'department_only': 'Only staff from the selected departments will be included',
+                'location_only': 'Only staff from the selected locations will be included',
+                'department_and_location': 'Only staff from the selected departments plus the selected locations will be included'
               };
 
               setHelpText('composed_of', helpMessage);
             }
 
-            function setVisibleToHelpText() {
-              var helpMessage = {
-                'default' : 'The feed will be shown to all staff',
-                'department_only' : 'The feed will be shown to the staff from the selected departments only',
-                'location_only' : 'The feed will be shown to the staff from the selected locations only',
-                'department_and_location' : 'The feed will be shown to the staff from the selected departments plus the selected locations'
-              };
-
-              setHelpText('visible_to', helpMessage);
-            }
-
-            function setHelpText(filterName, helpMessage) {
+            /**
+             * Sets help text for a group filter depending on its state
+             *
+             * @param {String} filterName
+             * @param {String} helpMessage
+             */
+            function setHelpText (filterName, helpMessage) {
               var departmentValue = $('.' + filterName + '_department select option:selected').val();
               var locationValue = $('.' + filterName + '_location select option:selected').val();
               var helpText = helpMessage.default;
@@ -144,6 +140,20 @@
               }
 
               $('.' + filterName + '_help_text').text(helpText);
+            }
+
+            /**
+             * Sets help text for "Share link with" group filter
+             */
+            function setVisibleToHelpText () {
+              var helpMessage = {
+                'default': 'The feed will be shown to all staff',
+                'department_only': 'The feed will be shown to the staff from the selected departments only',
+                'location_only': 'The feed will be shown to the staff from the selected locations only',
+                'department_and_location': 'The feed will be shown to the staff from the selected departments plus the selected locations'
+              };
+
+              setHelpText('visible_to', helpMessage);
             }
           });
         </script>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.tpl
@@ -11,7 +11,7 @@
       {if $action neq 8}
         <div class="form-group row">
           <div class="col-sm-3">{$form.title.label}</div>
-          <div class="col-sm-9">{$form.title.html}</div>
+          <div class="col-sm-9 form-group">{$form.title.html}</div>
         </div>
         <div class="form-group row composed_of_department">
           <div class="col-sm-3">{$form.composed_of_department.label}</div>
@@ -23,7 +23,10 @@
         </div>
         <div class="form-group row">
           <div class="col-sm-3"></div>
-          <div class="col-sm-9 pull-left composed_of_help_text"></div>
+          <div class="col-sm-9 pull-left text-muted form-group">
+            <span>*</span>
+            <span class="composed_of_help_text"></span>
+          </div>
         </div>
         <div class="form-group row visible_to_department">
           <div class="col-sm-3">{$form.visible_to_department.label}</div>
@@ -35,7 +38,10 @@
         </div>
         <div class="form-group row">
           <div class="col-sm-3"></div>
-          <div class="col-sm-9 pull-left visible_to_help_text"></div>
+          <div class="col-sm-9 pull-left text-muted form-group">
+            <span>*</span>
+            <span class="visible_to_help_text"></span>
+          </div>
         </div>
         <div class="form-group row composed_of_leave_type">
           <div class="col-sm-3">{$form.composed_of_leave_type.label}</div>


### PR DESCRIPTION
## Overview

This PR improves the visual representation of the Add Calendar Feed (as well as Edit Calendar Feed) forms.

## Before

![image](https://user-images.githubusercontent.com/3973243/42381226-599651bc-8128-11e8-84e1-21df5b8f270e.png)

## After

- dynamic hints are now muted, contain asterisk
- grouped fields are separated from each other with extra paddings

![image](https://user-images.githubusercontent.com/3973243/42381087-fbe0a16c-8127-11e8-957d-83c61e0ae5f4.png)


## Technical Details

Simply changed the structure and classes of hints:

```html
<div class="col-sm-9 pull-left text-muted form-group">
  <span>*</span>
  <span class="visible_to_help_text"></span>
</div>
```

## Comments

HTML indentation and JS was refactored.

----
This PR was tested manually.