### PR TITLE
PCHR-3956: Enabled is active field by default

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -74,15 +74,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
         $params['id'] = $this->_id;
       }
 
-      //when a checkbox is not checked, it is not sent on the request
-      //so we check if it wasn't sent and set the param value to 0
-      $checkboxFields = ['is_default', 'is_active', 'allow_accruals_request', 'allow_carry_forward', 'hide_label'];
-      foreach ($checkboxFields as $field) {
-        if(!array_key_exists($field, $params)) {
-          $params[$field] = 0;
-        }
-      }
-
       if(!empty($params['notification_receivers_ids'])) {
         $params['notification_receivers_ids'] = explode(',', $params['notification_receivers_ids']);
       }
@@ -133,18 +124,18 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
       TRUE
     );
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'hide_label',
       ts('Hide leave type label on public calendars and feeds?')
     );
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'is_default',
       ts('Is default leave type')
     );
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $this->add(
-        'checkbox',
+        'advcheckbox',
         'is_reserved',
         ts('Is reserved'),
         FALSE,
@@ -178,7 +169,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
       ts('By default should public holiday be added to the default entitlement? You can always modify this for each staff member on the add/edit job contract screen')
     );
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'is_active',
       ts('Enabled')
     );
@@ -210,7 +201,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
    */
   private function addTOILFields() {
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'allow_accruals_request',
       ts('Allow staff to request to accrue additional leave of this type during the period')
     );
@@ -241,7 +232,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
    */
   private function addCarryForwardFields() {
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'allow_carry_forward',
       ts('Allow leave of this type to be carried forward from one period to another?')
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
@@ -35,6 +35,8 @@ class CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig extends CRM_Cor
         $this->setDefaultFilterFieldValues('visible_to', $results);
         $this->defaultValues = $results;
         $this->defaultValues['_id'] = $this->_id;
+      } else {
+        $this->defaultValues['is_active'] = TRUE;
       }
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/LeaveRequestCalendarFeedConfig.php
@@ -67,12 +67,6 @@ class CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig extends CRM_Cor
         $params['id'] = $this->_id;
       }
 
-      //when a checkbox is not checked, it is not sent on the request
-      //so we check if it wasn't sent and set the param value to 0
-      if(!array_key_exists('is_active', $params)) {
-        $params['is_active'] = 0;
-      }
-
       $composedOfValues = $this->extractFromFormValues('composed_of', $params);
       $visibleToValues = $this->extractFromFormValues('visible_to', $params);
       $params = array_merge($params, $composedOfValues, $visibleToValues);
@@ -157,7 +151,7 @@ class CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig extends CRM_Cor
         'placeholder' => 'Select leave types',
         'label' => 'Leave types to include',
       ],
-      true
+      TRUE
     );
 
     $this->addSelect(
@@ -168,11 +162,11 @@ class CRM_HRLeaveAndAbsences_Form_LeaveRequestCalendarFeedConfig extends CRM_Cor
         'placeholder' => 'Select a timezone',
         'label' => 'Timezone',
       ],
-      true
+      TRUE
     );
 
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'is_active',
       ts('Enabled')
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/PublicHoliday.php
@@ -60,15 +60,6 @@ class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
             $params['id'] = $this->_id;
         }
 
-        //when a checkbox is not checked, it is not sent on the request
-        //so we check if it wasn't sent and set the param value to 0
-        $checkboxFields = ['is_active'];
-        foreach ($checkboxFields as $field) {
-            if(!array_key_exists($field, $params)) {
-                $params[$field] = 0;
-            }
-        }
-
         $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
         try {
             $publicHoliday = CRM_HRLeaveAndAbsences_BAO_PublicHoliday::create($params);
@@ -112,7 +103,7 @@ class CRM_HRLeaveAndAbsences_Form_PublicHoliday extends CRM_Core_Form {
       ['time' => false]
     );
     $this->add(
-      'checkbox',
+      'advcheckbox',
       'is_active',
       ts('Enabled')
     );

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/WorkPattern.php
@@ -109,15 +109,6 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
                 $params['id'] = $this->_id;
             }
 
-            //when a checkbox is not checked, it is not sent on the request
-            //so we check if it wasn't sent and set the param value to 0
-            $checkboxFields = ['is_default', 'is_active'];
-            foreach ($checkboxFields as $field) {
-                if(!array_key_exists($field, $params)) {
-                    $params[$field] = 0;
-                }
-            }
-
             $actionDescription = ($this->_action & CRM_Core_Action::UPDATE) ? 'updated' : 'created';
             try {
                 $workPattern = WorkPattern::create($params);
@@ -153,12 +144,12 @@ class CRM_HRLeaveAndAbsences_Form_WorkPattern extends CRM_Core_Form
             $this->getDAOFieldAttributes('description')
         );
         $this->add(
-            'checkbox',
+            'advcheckbox',
             'is_active',
             ts('Enabled')
         );
         $this->add(
-            'checkbox',
+            'advcheckbox',
             'is_default',
             ts('Is default')
         );


### PR DESCRIPTION
## Overview

This PR ticks the Calendar Feed **Enabled** checkbox by default.

## Before

![image](https://user-images.githubusercontent.com/3973243/42511870-f70bcd9e-844a-11e8-95b5-321773f11286.png)

## After

![image](https://user-images.githubusercontent.com/3973243/42511504-f0bda936-8449-11e8-94c3-911c5f437980.png)

## Technical Details

```php
public function setDefaultValues() {
  if(empty($this->defaultValues)) {
    if ($this->_id) { // if editing
      // ...
    } else { // if creating a new feed
      $this->defaultValues['is_active'] = TRUE; // <<<
```

## Comments

The code is also a bit refactored, the `checkbox` input type was changes to `advcheckbox` to avoid unnecessary post-processors such as:

```php
$checkboxFields = ['is_default', 'is_active', 'allow_accruals_request', ... ];
  foreach ($checkboxFields as $field) {
    if(!array_key_exists($field, $params)) { // if checkbox is not checked
      $params[$field] = 0; // set value to 0
```

`advcheckbox` makes such post-processing out of the box (see https://docs.civicrm.org/dev/en/latest/framework/quickform/):

![image](https://user-images.githubusercontent.com/3973243/42511836-e24f53c6-844a-11e8-8a84-50420fc2f754.png)

ℹ️The `checkbox` was changed to `advcheckbox` for both *add* and *edit* modes in the following Forms: 
- AbsenceType
- LeaveRequestCalendarFeedConfig
- PublicHoliday
- WorkPattern
---
✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
✅PHP Unit Tests - passed