### PR TITLE
PCHR-3607: Delete Default Groups and Hides One of Them

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -33,6 +33,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1023;
   use CRM_HRCore_Upgrader_Steps_1024;
   use CRM_HRCore_Upgrader_Steps_1025;
+  use CRM_HRCore_Upgrader_Steps_1026;
 
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1026.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1026.php
@@ -28,14 +28,8 @@ trait CRM_HRCore_Upgrader_Steps_1026 {
   private function up1026_deleteDefaultGroups($groupsToDelete) {
     $groups = civicrm_api3('Group', 'get', [
       'name' => ['IN' => $groupsToDelete],
+      'api.Group.delete' => ['id' => '$value.id'],
     ]);
-
-    $groups = $groups['values'];
-    foreach ($groups as $groupId => $group) {
-      civicrm_api3('Group', 'delete', [
-        'id' => $groupId,
-      ]);
-    }
   }
 
   /**
@@ -46,12 +40,11 @@ trait CRM_HRCore_Upgrader_Steps_1026 {
   private function up1026_disableAndHideDefaultGroup($groupToHide) {
     $group = civicrm_api3('Group', 'get', [
       'name' => $groupToHide,
-    ]);
-
-    civicrm_api3('Group', 'create', [
-      'id' => $group['id'],
-      'is_hidden' => 1,
-      'is_active' => 0,
+      'api.Group.create' => [
+        'id' => '$value.id',
+        'is_hidden' => 1,
+        'is_active' => 0,
+      ],
     ]);
   }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1026.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1026.php
@@ -1,0 +1,58 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1026 {
+
+  /**
+   * Deletes Default Groups
+   *
+   * @return bool
+   */
+  public function upgrade_1026() {
+    $this->up1026_deleteDefaultGroups([
+      'Advisory board',
+      'Newsletter Subscribers',
+      'Summer Program Volunteers',
+      'Administrators',
+    ]);
+
+    $this->up1026_disableAndHideDefaultGroup('Case_Resources');
+
+    return TRUE;
+  }
+
+  /**
+   * Deletes the Groups passed by params
+   *
+   * @param array $groupsToDelete
+   */
+  private function up1026_deleteDefaultGroups($groupsToDelete) {
+    $groups = civicrm_api3('Group', 'get', [
+      'name' => ['IN' => $groupsToDelete],
+    ]);
+
+    $groups = $groups['values'];
+    foreach ($groups as $groupId => $group) {
+      civicrm_api3('Group', 'delete', [
+        'id' => $groupId,
+      ]);
+    }
+  }
+
+  /**
+   * Disable and Hide Groups Passed By Params
+   *
+   * @param string $groupToHide
+   */
+  private function up1026_disableAndHideDefaultGroup($groupToHide) {
+    $group = civicrm_api3('Group', 'get', [
+      'name' => $groupToHide,
+    ]);
+
+    civicrm_api3('Group', 'create', [
+      'id' => $group['id'],
+      'is_hidden' => 1,
+      'is_active' => 0,
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
Deletes some default groups and hide one of them. 

## Before
All Groups  existed on default installation and with demo data
![selection_003](https://user-images.githubusercontent.com/1692858/42564676-b2e02afe-8501-11e8-8fe0-fbb19d538c1d.png)


## After
After this upgrade, no group will be visible by normal users
![selection_004](https://user-images.githubusercontent.com/1692858/42564687-b74b87c8-8501-11e8-86fa-80354a15806b.png)


## Technical Steps
Figured out that deleting Administrators group does not cause any problem, because it is not even created in default installation, only when  using sample data.  

Case resources is created on default installation, so i disabled and hide it for safety