### PR TITLE
PCHR-3839: Select Send Welcome Email by Default

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -11,7 +11,8 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
   public function buildQuickForm() {
     CRM_Utils_System::setTitle(ts('Create User Account(s)'));
     $this->addDefaultButtons(ts('Create'));
-    $this->add('advcheckbox', 'sendEmail', ts('Send welcome email?'));
+    $element = $this->add('advcheckbox', 'sendEmail', ts('Send welcome email?'));
+    $element->setChecked(TRUE);
 
     foreach ($this->getAssignableRoles() as $role) {
       $this->add('advcheckbox', sprintf('roles[%s]', $role), $role);


### PR DESCRIPTION
## Overview
When adding new user account, `Send Welcome Email` was not checked by default. This PR changes the display by setting it to checked by default.

## Before
<img width="656" alt="before_welcome_email" src="https://user-images.githubusercontent.com/1507645/42585069-95f89a04-852c-11e8-9c9c-9573887f067d.png">


## After
<img width="655" alt="after_welcome_email" src="https://user-images.githubusercontent.com/1507645/42585071-98aa7ed4-852c-11e8-9ab5-da3a48b07479.png">


## Technical Details
The checked value of the element was set to checked
```php
$element->setChecked(TRUE);
```
