### PR TITLE
PCHR-3975: Disable Prefer Not To Say Gender Option

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -232,10 +232,10 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
    */
   private function makeAllCurrenciesAvailable() {
     $result = civicrm_api3('OptionValue', 'get', [
-      'return' => ['name'],
+      'return' => ['value'],
       'option_group_id' => 'currencies_enabled',
     ]);
-    $enabledCurrencies = array_column($result['values'], 'name');
+    $enabledCurrencies = array_column($result['values'], 'value');
 
     $dao = CRM_Core_DAO::executeQuery('SELECT * from civicrm_currency');
     while ($dao->fetch()) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
@@ -45,8 +45,7 @@ trait CRM_HRCore_Upgrader_Steps_1000 {
 
   /**
    * Updates the default localization settings which includes :
-   *   1- setting the default currency to GBP and adding it to
-   *      enabled currencies list.
+   *   1- setting the default currency to GBP
    *   2- setting the default date formats
    *   3- setting the default country to UK
    *   4- setting the system language to UK english (en_GB)
@@ -72,20 +71,6 @@ trait CRM_HRCore_Upgrader_Steps_1000 {
     }
 
     civicrm_api3('Setting', 'create', $settings);
-
-    $currenciesToEnable = [
-      ['EUR (€)','EUR', 0],
-    ];
-
-    foreach ($currenciesToEnable as $currency) {
-      civicrm_api3('OptionValue', 'create', [
-        'option_group_id' => 'currencies_enabled',
-        'label' => $currency[0],
-        'value' => $currency[1],
-        'is_default' => $currency[2],
-        'is_active' => 1,
-      ]);
-    }
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
@@ -7,6 +7,7 @@ trait CRM_HRCore_Upgrader_Steps_1021 {
    */
   public function upgrade_1021() {
     $this->up1021_setDefaultGenderOptions();
+    $this->up1021_disableDefaultGenderOptions('Prefer not to say');
 
     return TRUE;
   }
@@ -39,6 +40,14 @@ trait CRM_HRCore_Upgrader_Steps_1021 {
         'weight' => $newWeight,
       ]);
     }
+  }
+
+  private function up1021_disableDefaultGenderOptions($genderOption) {
+    civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'gender',
+      'name' => $genderOption,
+      'api.OptionValue.create' => ['id' => '$value.id', 'is_active' => 0],
+    ]);
   }
 
 }


### PR DESCRIPTION
## Overview
This PR add a function to  disable 'Prefer Not to Say' Gender Option on an existing Upgrader.
## Before
The Prefer Not to Say option was active by default

## After
The Prefer Not to Say Option will be disabled by this Upgrader