### PR TITLE
PCHR-3972: Uncheck Some Contact Editing Options

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -35,6 +35,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1025;
   use CRM_HRCore_Upgrader_Steps_1026;
   use CRM_HRCore_Upgrader_Steps_1027;
+  use CRM_HRCore_Upgrader_Steps_1028;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1028.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1028.php
@@ -1,0 +1,63 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1028 {
+
+  /**
+   * Relabel Line Manager Relationship
+   */
+  public function upgrade_1028() {
+    $this->up1028_uncheckSomeContactEditingOptions();
+
+    return TRUE;
+  }
+
+  /**
+   * ReLabeling Line Manager Relationship
+   */
+  private function up1028_uncheckSomeContactEditingOptions() {
+    $contactEditOptions = Civi::settings()->get('contact_edit_options');
+    $contactEditOptions = explode(CRM_CORE_DAO::VALUE_SEPARATOR, $contactEditOptions);
+
+    $contactEditOptions = $this->up1028_uncheckSuffix($contactEditOptions, 17);
+    $contactEditOptions = $this->up1028_uncheckInstantMessenger($contactEditOptions, 9);
+    $contactEditOptions = $this->up1028_uncheckSocialAccounts($contactEditOptions, 11);
+
+    $finalEditionOptions = implode(CRM_CORE_DAO::VALUE_SEPARATOR, $contactEditOptions);
+
+    Civi::settings()->set('contact_edit_options', $finalEditionOptions);
+  }
+
+  private function up1028_uncheckSuffix(&$contactEditingOptions, $settingNumber) {
+    $contacts = $result = civicrm_api3('Contact', 'get', [
+      'suffix_id' => ['IS NOT NULL' => 1],
+    ]);
+    if ($contacts['count'] != 0) {
+      return $contactEditingOptions;
+    }
+
+    return array_diff($contactEditingOptions, [$settingNumber]);
+
+  }
+
+  private function up1028_uncheckInstantMessenger(&$contactEditingOptions, $settingNumber) {
+    $result = civicrm_api3('Im', 'get', [
+    ]);
+    if ($result['count'] != 0) {
+      return $contactEditingOptions;
+    }
+
+    return array_diff($contactEditingOptions, [$settingNumber]);
+  }
+
+  private function up1028_uncheckSocialAccounts(&$contactEditingOptions, $settingNumber) {
+    $result = civicrm_api3('Website', 'get', [
+    ]);
+    if ($result['count'] != 0) {
+      return $contactEditingOptions;
+    }
+    return array_diff($contactEditingOptions, [$settingNumber]);
+
+  }
+
+
+}


### PR DESCRIPTION
## Overview
This PR unchecks the following contact editing options if they are not used:
- Suffix
- Instant Messenger
- Social Accounts


## Before
![screenshot from 2018-07-16 18 12 18](https://user-images.githubusercontent.com/1692858/42769887-d63af238-8923-11e8-8c66-2c55c352aa0c.png)


## After
![screenshot from 2018-07-16 18 10 38](https://user-images.githubusercontent.com/1692858/42769831-a8e70bd2-8923-11e8-8bbf-c0b6479afd58.png)
Note that in this screenshot Social Accounts is being used, so was not unchecked

## Technical Details
I used Civi::settings()->set() and Civi::settings()->get() instead of the API to fetch and set Setting data because i did not find a easy way to update Setting  using the API.