### PR TITLE
PCHR-3983: Fix for enabling all currencies in hrcore

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -232,10 +232,10 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
    */
   private function makeAllCurrenciesAvailable() {
     $result = civicrm_api3('OptionValue', 'get', [
-      'return' => ['name'],
+      'return' => ['value'],
       'option_group_id' => 'currencies_enabled',
     ]);
-    $enabledCurrencies = array_column($result['values'], 'name');
+    $enabledCurrencies = array_column($result['values'], 'value');
 
     $dao = CRM_Core_DAO::executeQuery('SELECT * from civicrm_currency');
     while ($dao->fetch()) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1000.php
@@ -45,8 +45,7 @@ trait CRM_HRCore_Upgrader_Steps_1000 {
 
   /**
    * Updates the default localization settings which includes :
-   *   1- setting the default currency to GBP and adding it to
-   *      enabled currencies list.
+   *   1- setting the default currency to GBP
    *   2- setting the default date formats
    *   3- setting the default country to UK
    *   4- setting the system language to UK english (en_GB)
@@ -72,20 +71,6 @@ trait CRM_HRCore_Upgrader_Steps_1000 {
     }
 
     civicrm_api3('Setting', 'create', $settings);
-
-    $currenciesToEnable = [
-      ['EUR (€)','EUR', 0],
-    ];
-
-    foreach ($currenciesToEnable as $currency) {
-      civicrm_api3('OptionValue', 'create', [
-        'option_group_id' => 'currencies_enabled',
-        'label' => $currency[0],
-        'value' => $currency[1],
-        'is_default' => $currency[2],
-        'is_active' => 1,
-      ]);
-    }
   }
 
   /**


### PR DESCRIPTION
## Overview

In https://github.com/compucorp/civihr/pull/2698 the hrcore extension was updated in order for it to automatically enable all the available currencies in CiviCRM.

The solution worked without a problem in CiviCRM 4.7.27, but it stopped working after we upgraded CiviHR to 5.3.0. When trying to install the hrcore in a site using 5.3.0, the installation fails with this error:

```php
Array
(
    [is_error] => 1
    [error_message] => Value already exists in the database
)
```

## Before

It is not possible to install hrcore in a site using CiviCRM 5.3.0

## After

It is now possible to install hrcore in a site using CiviCRM 5.3.0

## Technical Details

In CiviCRM, the list of enabled currencies is stored as Option Values under the `currencies_enabled` Option Group. Each Option Value there represents one enabled currency. The name of the Option Value follows the format "CURRENCY ABBREVIATION (CURRENCY SYMBOL)" (for example "GBP (£)"). The value of only the the Abbrenviation.

The list of available currencies is stored in the `civicrm_currency` table, which has two fields of relevance here: `name` and `symbol`. Name is used to store only the abbreviantion (e.g. GBP).

The code added in hrcore to make all the currencies enabled look like this:

```php
private function makeAllCurrenciesAvailable() {
    $result = civicrm_api3('OptionValue', 'get', [
            'return' => ['name'],
            'option_group_id' => 'currencies_enabled',
    ]);
    $enabledCurrencies = array_column($result['values'], 'name');
    $dao = CRM_Core_DAO::executeQuery('SELECT * from civicrm_currency');
    while ($dao->fetch()) {
        if (!in_array($dao->name, $enabledCurrencies)) {
            civicrm_api3('OptionValue', 'create', [
               'option_group_id' => 'currencies_enabled',
               'label' => $dao->name . ' (' . $dao->symbol . ')',
               'value' => $dao->name,
               'name' => $dao->name . ' (' . $dao->symbol . ')',
            ]);
         }
     }
}
```

As it is possible to see, first it gets a list of the names of all the Option Values representing enabled currencies. Next, to check if a currency is already enabled, it compares that name to the ones returned frrom the `civicrm_currency` table. Unfortunately, as mentioned before, the format of the Option Value name is different from the name what we have in the `civicrm_currency` table (the former has something like "GBP (£)" while the latter has only "GBP"). Since they don't match, the logic thinks the currency is not yet enabled and tries to enable it by creating a new Option Value. 

This worked fine for CiviCRM 4.7.27, but 4.7.28 (https://github.com/civicrm/civicrm-core/pull/11089), it is not possible to have more than one option value with the same value in the same option group. So, when we try to insert a new Option Value to a currency that is already enabled, we end up with that "value already exists in the database" error.

To fix this, I've changed the code that fetches the already enabled currencies to load the Option Value value instead of the name. The value contains only the Abbreviation, which is the same we have in the `civicrm_currency` table and this make the comparison work as expected.

After fixing that, I got a new error still related to enabling currencies. One of the things done by the upgrade step `1000.php`, was to enable the `EUR` currency, but since now this is done by `makeAllCurrenciesAvailable()` it was resulting in the same error of the currency already being enabled. To fix that, I simply removed the code to enable `EUR` from `1000.php`.