### PR TITLE
PCHR-3537: Add correspondence to the list of phone types to migrate

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1018.php
@@ -66,6 +66,7 @@ trait CRM_HRCore_Upgrader_Steps_1018 {
       'Home' => 'Personal',
       'Main' => 'Personal',
       'Other' => 'Personal',
+      'Correspondence' => 'Personal',
     ];
     $locationTypeMap = $this->up1018_convertLocationNamesToIds($locationTypeMap);
 


### PR DESCRIPTION
## Overview

We encountered an issue when trying to migrate clients that used the "Correspondence" phone types. This fixes it.

## Before

Correspondence was missing from the list of phone types to migrate, this caused an error when trying to delete it when records existed that used it.

## After

Correspondence phone type is migrated to Personal before it is deleted.