### PR TITLE
PCHR-3345: Unable to Create User Account for Restored Contact

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -44,7 +44,13 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
     $contactsToCreate = $this->getValidContactsForCreation();
 
     foreach ($contactsToCreate as $contact) {
-      $this->createAccount($contact, $roles);
+      $user = $this->drupalUserService->findUserByEmail($contact['email']);
+      if (!$user) {
+        $this->createAccount($contact, $roles);
+      }
+      else {
+        $this->restoreAccount($user, $roles, $contact['id']);
+      }
     }
 
     $haveAccount = $this->getContactsWithAccount();
@@ -218,4 +224,21 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
     return empty($errors) ? TRUE : $errors;
   }
 
+  /**
+   * Restores user account and update roles after delete.
+   * Deleting user account does not remove drupal account.
+   * The user account is just unlinked in the UF match civi table
+   *
+   * @param object $user
+   * @param array $roles
+   * @param int $contactId
+   */
+  public function restoreAccount($user, $roles, $contactId) {
+    $this->drupalUserService->addRoles($user->mail, $roles);
+
+    $ufMatch['uf_id'] = $user->uid;
+    $ufMatch['contact_id'] = $contactId;
+    $ufMatch['uf_name'] = $user->mail;
+    civicrm_api3('UFMatch', 'create', $ufMatch);
+  }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -225,7 +225,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
   }
 
   /**
-   * Restores user account and update roles after delete.
+   * Restores user account and set role(s) after delete.
    * Deleting user account does not remove drupal account.
    * The user account is just unlinked in the UF match civi table
    *
@@ -234,7 +234,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    * @param int $contactId
    */
   public function restoreAccount($user, $roles, $contactId) {
-    $this->drupalUserService->addRoles($user->mail, $roles);
+    $this->drupalUserService->setRoles($user->mail, $roles);
 
     $ufMatch['uf_id'] = $user->uid;
     $ufMatch['contact_id'] = $contactId;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
@@ -90,6 +90,19 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
+   * Defaults user's role to supplied role(s)
+   *
+   * @param string $email
+   * @param array $roles
+   */
+  public function setRoles($email, $roles) {
+    $user = user_load_by_mail($email);
+    $roles = $this->roleService->getRoleIds($roles);
+
+    user_save($user, ['roles' => $roles]);
+  }
+
+  /**
    * @param string $name
    *
    * @return bool

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/DrupalUserService.php
@@ -52,6 +52,17 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
+   * Checks if user record exist for email
+   *
+   * @param string $email
+   *
+   * @return object | boolean
+   */
+  public function findUserByEmail($email) {
+    return user_load_by_mail($email);
+  }
+
+  /**
    * @param $email
    */
   public function sendActivationMail($email) {
@@ -64,6 +75,8 @@ class CRM_HRCore_Service_DrupalUserService {
   }
 
   /**
+   * Adds role(s) to user account
+   *
    * @param string $email
    * @param array $roles
    */

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/DrupalUserServiceTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/DrupalUserServiceTest.php
@@ -53,6 +53,22 @@ class CRM_HRCore_Service_DrupalUserServiceTest extends CRM_HRCore_Test_BaseHeadl
     $this->assertArrayHasKey(8, $user->roles);
   }
 
+  public function testFindUserByEmailReturnsUserObjectWhenUserEmailExist() {
+    $roleService = $this->prophesize(DrupalRoleService::class);
+    $drupalUserService = new DrupalUserService($roleService->reveal());
+    $user = $drupalUserService->findUserByEmail('johndoe@test.com');
+
+    $this->assertInstanceOf(\stdClass::class, $user);
+  }
+
+  public function testFindUserByEmailReturnsFalseWhenUserEmailDoesNotExist() {
+    $roleService = $this->prophesize(DrupalRoleService::class);
+    $drupalUserService = new DrupalUserService($roleService->reveal());
+    $userAccount = $drupalUserService->findUserByEmail('test@email.com');
+
+    $this->assertFalse($userAccount);
+  }
+
   protected function cleanup() {
     $user = user_load_by_mail($this->testEmail);
     if ($user) {

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/drupal_function_mocks.php
@@ -10,7 +10,14 @@ function drupal_anonymous_user() {}
 
 function user_password() {}
 
-function user_load_by_mail($email) {}
+function user_load_by_mail($email) {
+  if ($email === 'johndoe@test.com') {
+    return new stdClass();
+  }
+  else {
+    return FALSE;
+  }
+}
 
 function user_roles() {
   return [1 => 'Fake Role'];


### PR DESCRIPTION
## Overview
This PR fixes issues with creating user account for restored contact.

## Before
Creating user account results in an error, indicating duplicate emails address

![restoreerror](https://user-images.githubusercontent.com/1507645/43001452-31b8411e-8c1d-11e8-8e27-c031ee8592f1.PNG)

## After
![after_restored](https://user-images.githubusercontent.com/1507645/43002400-8233f1b2-8c20-11e8-89a3-599dbb939211.gif)


## Technical Details
Creating user account attempts to create a new user record which is not needed for restored account. User account is therefore checked before processing request.
```php
$user = $this->drupalUserService->findUserByEmail($contact['email']);
 if (!$user) {
   $this->createAccount($contact, $roles);
 }
 else {
   $this->restoreAccount($user, $roles, $contact['id']);
 }
```

When user accounts are deleted, their UFID also gets deleted in the process. When restored, the UFID do not get re-created. Only the account was set to active once again. After checking and updating existing account, new UFID was generated.
```php
public function restoreAccount($user, $roles, $contactId) {
  $this->drupalUserService->setRoles($user->mail, $roles);

  $ufMatch['uf_id'] = $user->uid;
  $ufMatch['contact_id'] = $contactId;
  $ufMatch['uf_name'] = $user->mail;
  civicrm_api3('UFMatch', 'create', $ufMatch);
}
```

Existing roles are ignored while creating the account. They are untouched after initial record removal. User may select an entirely new role, thereby assigning multiple role to account.
```
public function setRoles($email, $roles) {
  $user = user_load_by_mail($email);
  $roles = $this->roleService->getRoleIds($roles);

  user_save($user, ['roles' => $roles]);
}
```