### PR TITLE
PCHR-4001: Allow Contact to Be own Leave Approver When Assigning Leave Approver  Relationship

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -434,24 +434,6 @@ function hrleaveandabsences_hrcomments_selectWhereClause(&$conditions, $params) 
   $conditions = array_merge($conditions, $commentsWhereClause->get());
 }
 
-
-/**
- * Implementation of the hook_civicrm_validateForm.
- *
- * @param string $formName
- * @param array $fields
- * @param array $files
- * @param object $form
- * @param array $errors
- */
-function hrleaveandabsences_civicrm_validateForm($formName, &$fields, &$files, &$form, &$errors) {
-  if($formName == 'CRM_Contact_Form_Relationship') {
-    if(_hrleaveandabsences_contact_is_being_assigned_as_its_own_leave_approver($form, $fields)){
-      $errors['relationship_type_id'] = ts('You cannot assign a contact as its own leave approver');
-    }
-  }
-}
-
 /**
  * Implementation of the hook_civicrm_apiWrappers hook
  *
@@ -805,25 +787,4 @@ function _hrleaveandabsences_set_has_leave_approved_by_as_default_relationship_t
       [$relationshipType['id']]
     );
   }
-}
-
-/**
- * A helper function that checks whether a contact being set as its own Leave
- * Approver based on the leave approver relationships defined on L&A general settings page.
- *
- * @param object $form
- * @param array $fields
- *
- * @return bool
- */
-function _hrleaveandabsences_contact_is_being_assigned_as_its_own_leave_approver($form, $fields) {
-  if($fields['related_contact_id'] == $form->_contactId) {
-    $leaveApproverRelationships = Civi::service('hrleaveandabsences.settings_manager')
-      ->get('relationship_types_allowed_to_approve_leave');
-    if(in_array($form->_relationshipTypeId, $leaveApproverRelationships)) {
-      return true;
-    }
-  }
-
-  return false;
 }


### PR DESCRIPTION
## Overview
Currently, it is impossible for a contact to have a Leave approver relationship with itself because of a restriction to do this.

## Before
- A contact cannot have a leave approver relationship with itself

![beforeleaveapprover](https://user-images.githubusercontent.com/6951813/43010193-b4aa4db4-8c37-11e8-91c6-ff334f7227d9.gif)


## After
- A contact can have a leave approver relationship with itself

![afterleaveapprover](https://user-images.githubusercontent.com/6951813/43010207-bddb7df4-8c37-11e8-8713-333557fc64eb.gif)


## Technical Details
The implementation of the `hook_civicrm_validateForm` for the `CRM_Contact_Form_Relationship` in Leave and absences extension prevents a contact from being assigned as own leave approver. This code was removed altogether since there is no more need for it.
