### PR TITLE
PCHR-3998: Fix Missing Log Tables

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -28,6 +28,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1019;
   use CRM_HRCore_Upgrader_Steps_1020;
+  use CRM_HRCore_Upgrader_Steps_1021;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1021.php
@@ -1,0 +1,21 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1021 {
+
+  /**
+   * Creates the Missing Log Tables after CiviCRM Upgrade
+   */
+  public function upgrade_1021() {
+    $this->up1021_fixMissingLogTables();
+
+    return TRUE;
+  }
+
+  /**
+   * Fixes the Missing Log Tables
+   */
+  private function up1021_fixMissingLogTables() {
+    civicrm_api3('System', 'createmissinglogtables');
+  }
+
+}


### PR DESCRIPTION
## Overview
This Upgrader Fixes the 'Missing Log Tables' issue on some installation after CiviCRM upgrade to 1.7.8

## Before
![image-2018-07-19-15-40-38-680 1](https://user-images.githubusercontent.com/1692858/43073948-b7e56360-8e7b-11e8-9f5c-edc13c4a412c.png)

## After
This error is not shown anymore.
