### PR TITLE
PCHR-3999: Hide all Civicrm System Notifications

### DIFF
--- a/hrui/templates/CRM/common/footer.tpl
+++ b/hrui/templates/CRM/common/footer.tpl
@@ -32,7 +32,7 @@
   <div class="crm-footer" id="civicrm-footer">
     {* PCHR-1323 - Display CiviHR version info. *}
     {ts}Powered by CiviHR {/ts} {civihrVersion}.
-    {if call_user_func(array('CRM_Core_Permission','check'), 'view system status on footer')}
+    {if call_user_func(array('CRM_Core_Permission','check'), 'view system notifications')}
       {if !empty($footer_status_severity)}
         <span class="status{if $footer_status_severity gt 3} crm-error{elseif $footer_status_severity gt 2} crm-warning{else} crm-ok{/if}">
           <a target="_blank" href="{crmURL p='civicrm/a/#/status'}">{$footer_status_message}</a>.

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -344,6 +344,15 @@ function hrcore_civicrm_permission(&$permissions) {
 }
 
 /**
+ * Removes system notifications for all users
+ *
+ * @param $messages
+ */
+function hrcore_civicrm_check(&$messages) {
+  $messages = [];
+}
+
+/**
  * Renames a menu with the given new label
  *
  * @param array $params

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -340,16 +340,19 @@ function hrcore_civicrm_permission(&$permissions) {
   $prefix = ts('CiviHR') . ': ';
   $permissions['access CiviCRM developer menu and tools'] = ts('Access CiviCRM developer menu and tools');
   $permissions['access root menu items and configurations'] = $prefix . ts('Access root menu items and configurations');
-  $permissions['view system status on footer'] = $prefix . ts('View System Status on Footer');
+  $permissions['view system notifications'] = $prefix . ts('View System Notifications');
 }
 
 /**
- * Removes system notifications for all users
+ * Removes system notifications for users without permission
  *
- * @param $messages
+ * @param array $messages
  */
 function hrcore_civicrm_check(&$messages) {
-  $messages = [];
+  $canViewSystemNotifications = CRM_Core_Permission::check('view system notifications');
+  if (!$canViewSystemNotifications) {
+    $messages = [];
+  }
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR hides System Notifications for non root users.

## Before
![before_notification](https://user-images.githubusercontent.com/1507645/43092365-e826006a-8ea4-11e8-8b0c-dd1ba937b33d.gif)


## After
![after_notification](https://user-images.githubusercontent.com/1507645/43092289-9bbc84ec-8ea4-11e8-96b1-24ec8af425f1.gif)


## Technical Details
System notification is disabled for all non root users by implementing `hook_civicrm_check` and clearing the messages.

```
$messages = [];
```
This also implies no system notification will be rendered in the `/civicrm/a/#/status` page.

An existing `view system status in footer` has also been [renamed](https://github.com/compucorp/civihr-employee-portal/pull/524) to `view system notifications` since they both serve similar purpose of restricting access to system notification by non root users.