### PR TITLE
PCHR-4003: Hide Recruitment Menu on Admin Portal

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -28,7 +28,8 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1019;
   use CRM_HRCore_Upgrader_Steps_1020;
-use CRM_HRCore_Upgrader_Steps_1021;
+  use CRM_HRCore_Upgrader_Steps_1021;
+  use CRM_HRCore_Upgrader_Steps_1022;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -28,7 +28,6 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1019;
   use CRM_HRCore_Upgrader_Steps_1020;
-  use CRM_HRCore_Upgrader_Steps_1021;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -28,6 +28,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1018;
   use CRM_HRCore_Upgrader_Steps_1019;
   use CRM_HRCore_Upgrader_Steps_1020;
+use CRM_HRCore_Upgrader_Steps_1021;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
@@ -1,0 +1,37 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1022 {
+
+  /**
+   * Removes Recruitment menu item
+   *
+   * @return bool
+   */
+  public function upgrade_1022() {
+    $this->up1022_removeRecruitmentMenuItem('Recruitment');
+    $this->up1022_disableAndUninstallRecruitment();
+
+    return TRUE;
+  }
+
+  /**
+   * Removes Recruitment menu item, by deleting its entry on the DB
+   */
+  private function up1022_removeRecruitmentMenuItem($label) {
+    civicrm_api3('Navigation', 'get', [
+      'label' => $label,
+      'api.Navigation.delete' => ['id' => '$value.id'],
+    ]);
+  }
+
+  /**
+   * disables and then Uninstalls the Recruitment Extensions
+   */
+  private function up1022_disableAndUninstallRecruitment() {
+    civicrm_api3('Extension', 'disable', [
+      'keys' => 'org.civicrm.hrrecruitment',
+      'api.Extension.uninstall' => ['keys' => 'org.civicrm.hrrecruitment'],
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
This Upgrader removes the Recruitment menu in Admin Portal

## Before
![screenshot from 2018-07-24 16 51 18](https://user-images.githubusercontent.com/1692858/43147118-8fd847a6-8f62-11e8-9c18-d35428d18daf.png)


## After
![screenshot from 2018-07-24 16 56 06](https://user-images.githubusercontent.com/1692858/43147125-9681ea58-8f62-11e8-920c-f27395433f61.png)

## Technical Details
The removal is done by deleting the Menu entry in the civicrm_navigation table on the database. Then,the extension is disabled and uninstalled using CiviCRM Extension API.