### PR TITLE
PCHR-4002: Allow User Who is Own Leave Approver Take Admin Actions on Own Requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -137,13 +137,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
    * @return string
    */
   private function getErrorMessageForInvalidStatusTransition($params) {
-    $leaveStatuses = LeaveRequest::getStatuses();
     $leaveStatusesLabels = LeaveRequest::buildOptions('status_id');
-    $isOwnRequest = CRM_Core_Session::getLoggedInContactID() === $params['contact_id'];
-
-    if ($isOwnRequest && (int)$params['status_id'] === (int)$leaveStatuses['approved']) {
-      return "You can't approve your own leave requests";
-    }
 
     return "You can't change the Leave Request status from \"" .
       $leaveStatusesLabels[$this->getCurrentStatus($params)] . '" to "' .

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
@@ -149,10 +149,10 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix {
     $currentUserID = CRM_Core_Session::getLoggedInContactID();
     $statusMatrix = [];
 
-    if ($currentUserID == $leaveRequestContactID) {
-      $statusMatrix = $this->getStaffStatusMatrix();
-    } elseif ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
+    if ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
       $statusMatrix = $this->getManagerStatusMatrix();
+    } elseif ($currentUserID == $leaveRequestContactID) {
+      $statusMatrix = $this->getStaffStatusMatrix();
     }
 
     return $statusMatrix;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -143,7 +143,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
 
     foreach($nonPossibleTransitions as $transition) {
-      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $adminID
+      ));
     }
   }
 
@@ -154,7 +158,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
 
     foreach($possibleTransitions as $transition) {
-      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $adminID
+      ));
     }
   }
 
@@ -166,7 +174,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
 
     foreach($nonPossibleTransitions as $transition) {
-      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $manager['id']));
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $manager['id']
+      ));
     }
   }
 
@@ -178,7 +190,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
 
     foreach($possibleTransitions as $transition) {
-      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $manager['id']));
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $manager['id']
+      ));
     }
   }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -136,37 +136,50 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     }
   }
 
-  /**
-   * @dataProvider allPossibleStatusTransitionForStaffDataProvider
-   */
-  public function testCanTransitionToReturnsTrueForAllPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
+  public function testCanTransitionToReturnsFalseWhenAdminIsTheLeaveContactForAllNonPossibleManagerTransitionStatuses() {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
+    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
 
-    $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
+    foreach($nonPossibleTransitions as $transition) {
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
+    }
   }
 
-  /**
-   * @dataProvider allNonPossibleStatusTransitionForStaffDataProvider
-   */
-  public function testCanTransitionToReturnsFalseForAllNonPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
+  public function testCanTransitionToReturnsTrueWhenAdminIsTheLeaveContactForAllPossibleManagerTransitionStatuses() {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
+    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
 
-    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
+    foreach($possibleTransitions as $transition) {
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $adminID));
+    }
   }
 
-  /**
-   * @dataProvider getManagerExclusivePossibleStatusTransitionsDataProvider
-   */
-  public function testCanTransitionToReturnsFalseForPossibleManagerExclusiveStatusTransitionsWhenAdminIsTheLeaveContact($fromStatus, $toStatus) {
-    $adminID = 5;
-    $this->registerCurrentLoggedInContactInSession($adminID);
-    $this->setPermissions(['administer leave and absences']);
+  public function testCanTransitionToReturnsFalseWhenUserIsTheLeaveContactAndOwnApproverForAllNonPossibleManagerTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $manager);
 
-    $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($fromStatus, $toStatus, $adminID));
+    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
+
+    foreach($nonPossibleTransitions as $transition) {
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $manager['id']));
+    }
+  }
+
+  public function testCanTransitionToReturnsTrueWhenUserIsTheLeaveContactAndOwnApproverForAllPossibleManagerTransitionStatuses() {
+    $manager = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($manager['id']);
+    $this->setContactAsLeaveApproverOf($manager, $manager);
+
+    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
+
+    foreach($possibleTransitions as $transition) {
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo($transition[0], $transition[1], $manager['id']));
+    }
   }
 
   public function allPossibleStatusTransitionForStaffDataProvider() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -328,23 +328,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
   }
 
-  public function testCreateThrowsAnExceptionWhenAttemptingToApproveOwnLeaveRequest() {
-    $params = $this->getDefaultParams();
-    $leaveRequestStatuses = LeaveRequest::getStatuses();
-
-    $params['status_id'] = $leaveRequestStatuses['awaiting_approval'];
-
-    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
-
-    $this->setExpectedException(
-      'RuntimeException', "You can't approve your own leave requests");
-
-    $params['id'] = $leaveRequest->id;
-    $params['status_id'] = $leaveRequestStatuses['approved'];
-
-    $this->getLeaveRequestServiceWhenStatusTransitionIsNotAllowed()->create($params, false);
-  }
-
   /**
    * @expectedException RuntimeException
    * @expectedExceptionMessage You are not allowed to change the request dates

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -2962,6 +2962,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testToilCanBeAccruedWhenToilIsInHoursAndToilToAccrueValueIsNotAValidToilAmountOptionValue() {
+    $this->setPermissions();
     $contactID = 1;
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
@@ -3221,6 +3222,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   public function testCreateAlsoCreatesTheBalanceChangesForTheLeaveRequest() {
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
     $startDate = new DateTime();
     $endDate = new DateTime('+5 days');
 
@@ -4847,6 +4849,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $toDate = new DateTime('2016-01-10');
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => $fromDate->format('YmdHis'),
@@ -4895,6 +4898,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $toDate = new DateTime('2016-01-10 12:34:56');
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => $fromDate->format('YmdHis'),
@@ -4939,6 +4943,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
 
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
     $startDate = new DateTime();
     $endDate = new DateTime('+5 days');
 
@@ -4980,6 +4985,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
   public function testCreateReturnsTrueForFromEmailParameterWhenFromEmailIsConfigured() {
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
     $startDate = new DateTime();
     $endDate = new DateTime('+5 days');
 
@@ -5027,6 +5033,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 1;
     $absenceType = AbsenceTypeFabricator::fabricate(['calculation_unit' => 2]);
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => $fromDate->format('YmdHis'),
@@ -5070,6 +5077,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     $toDate = new DateTime('2016-01-10 15:45:00');
     $contactID = 1;
     $this->registerCurrentLoggedInContactInSession($contactID);
+    $this->setPermissions();
 
     $period = AbsencePeriodFabricator::fabricate([
       'start_date' => $fromDate->format('YmdHis'),


### PR DESCRIPTION
## Overview
Sequel to #2780, which allows a user to be assigned as own leave approver irrespective of the role of the user, This PR makes some changes in the way a user interacts with own requests especially when such a user is its own leave approver.
These changes allow a user irrespective of the role to assume the role of a leave manager on own request when the user is own leave approver. For example a Staff that is own leave approver can now cancel, approve and perform the same actions a leave manager can on a leave request for own request.
The new changes are summarised as follows
- An Admin can manage own requests irrespective of whether he is own leave approver or not
- A Staff can manage own request only if the staff is own leave approver
- A Manager can manage own request only if the manager is own leave approver

## Before
- A user cannot manage own requests, i.e the user is treated as a staff when dealing with own request (even if staff is Admin or Manager) and as such cannot perform admin actions, such as approving the request and moving the request to statuses that is allowed for a manger.

## After
- A user can now manage own requests when the user is own Leave approver, i.e the user can approve the request and move the request to statuses that a manager can move requests to.
An Admin can manage own requests irrespective of whether he is own leave approver or not.

## Technical Details
- Once a current user is the leave contact, the `getStatusMatrixForCurrentUser` of the leave request class would always return a Staff status transition matrix for the user even if the user is an Admin, this method is modified such that it returns the Manager status transition matrix for an Admin and for a user that is the leave contact and is own leave approver instead of returning the Staff status transition matrix.

```php
  private function getStatusMatrixForCurrentUser($leaveRequestContactID) {
    $currentUserID = CRM_Core_Session::getLoggedInContactID();
    $statusMatrix = [];

    if ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
      $statusMatrix = $this->getManagerStatusMatrix();
    } elseif ($currentUserID == $leaveRequestContactID) {
      $statusMatrix = $this->getStaffStatusMatrix();
    }

    return $statusMatrix;
  }
```