### PR TITLE
PCHR-4040: Allow user who is own Leave Approver to delete own requet

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -85,7 +85,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
   }
 
   /**
-   * Checks whether the current user has permissions to delete the leave request
+   * Checks whether the current user has permissions to delete the leave request.
+   * Currently only allows the admin and a user who is own leave approver and its
+   * own request to delete a leave request.
    *
    * @param int $contactID
    *   The contactID of the leave request
@@ -93,7 +95,15 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canDeleteFor($contactID) {
-    return $this->currentUserIsAdmin();
+    if ($this->currentUserIsAdmin()) {
+      return TRUE;
+    }
+
+    if (!$this->currentUserIsLeaveContact($contactID)) {
+      return FALSE;
+    }
+
+    return $this->currentUserIsLeaveManagerOf($contactID);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -37,11 +37,20 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   public function testCanDeleteForReturnsFalseWhenCurrentUserIsLeaveManager() {
+    $managerId = 5;
+    $this->registerCurrentLoggedInContactInSession($managerId);
     $this->assertFalse($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canDeleteFor($this->leaveContact));
+    $this->unregisterCurrentLoggedInContactFromSession();
   }
 
   public function testCanDeleteForReturnsTrueWhenCurrentUserIsAdmin() {
     $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canDeleteFor($this->leaveContact));
+  }
+
+  public function testCanDeleteForReturnsTrueWhenCurrentUserIsOwnLeaveApproverAndIsOwnRequest() {
+    $this->registerCurrentLoggedInContactInSession($this->leaveContact);
+    $this->assertTrue($this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canDeleteFor($this->leaveContact));
+    $this->unregisterCurrentLoggedInContactFromSession();
   }
 
   /**


### PR DESCRIPTION
## Overview
Previously, Only an Admin can delete a leave request. This PR allows users that are their own leave approvers to delete their own leave requests.

## Before
- Only Admins can delete leave requets

## After
- Admins can delete all leave requests while users that are their own leave approvers can delete their own leave requests.

## Technical Details
 The `canDeleteFor` method of the LeaveRequestRights Service was modified to accommodate for the new change.

```php
  public function canDeleteFor($contactID) {
    if ($this->currentUserIsAdmin()) {
      return TRUE;
    }

    if (!$this->currentUserIsLeaveContact($contactID)) {
      return FALSE;
    }

    return $this->currentUserIsLeaveManagerOf($contactID);
  }

```