### PR TITLE
PCHR-4017: Move Case Type Category Upgraders

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -184,6 +184,32 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   }
 
   /**
+   * Updates current case types so they have a category assigned. All case types
+   * are assigned the Workflow category by default except for the Application case
+   * type, which gets the Vacancy category.
+   *
+   * @return bool
+   */
+  public function upgrade_1432() {
+    $categoryFieldId = CRM_Core_BAO_CustomField::getCustomFieldID('category', 'case_type_category');
+    $categoryFieldName = 'custom_' . $categoryFieldId;
+    $caseTypes = civicrm_api3('CaseType', 'get', [
+      'options' => [ 'limit' => 0 ]
+    ]);
+
+    foreach ($caseTypes['values'] as $caseType) {
+      $category = $caseType['name'] === 'Application' ? 'Vacancy' : 'Workflow';
+
+      civicrm_api3('CaseType', 'create', [
+        'id' => $caseType['id'],
+        $categoryFieldName => $category,
+      ]);
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Replaces (Case) keyword and (Open Case) keyword with (Assignment) keyword
    * and (Created New Assignment) keyword respectively and vise versa for
    * civicrm default activity types labels when installing/uninstalling the extension.

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -30,6 +30,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1020;
   use CRM_HRCore_Upgrader_Steps_1021;
   use CRM_HRCore_Upgrader_Steps_1022;
+  use CRM_HRCore_Upgrader_Steps_1023;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1023.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1023.php
@@ -1,0 +1,132 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1023 {
+
+  /**
+   * Sets up option values, custom group and custom field
+   * for case type categorization
+   *
+   * @return bool
+   */
+  public function upgrade_1023() {
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_case_type'
+    ]);
+    if ($optionValues['count'] == 0) {
+      $params = [
+        'option_group_id' => 'cg_extend_objects',
+        'name' => 'civicrm_case_type',
+        'label' => ts('Case Type'),
+        'value' => 'CaseType',
+      ];
+      $this->createOptionValue($params);
+    }
+
+    $customGroups = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'CaseType',
+      'name' => 'case_type_category',
+    ]);
+    if ($customGroups['count'] == 0) {
+      $this->createCaseTypeCategoryCustomGroup();
+    }
+
+    $customFields = civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => 'case_type_category',
+    ]);
+    if ($customFields['count'] == 0) {
+      $optionGroupId = $this->createCaseTypeCategoryOptionValues();
+      if ($optionGroupId == null) {
+        return FALSE;
+      }
+
+      $this->createCaseTypeCategoryCustomField($optionGroupId);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Creates option group
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function createOptionGroup($params) {
+    return civicrm_api3('OptionGroup', 'create', $params);
+  }
+
+  /**
+   * Creates option value
+   *
+   * @param array $params
+   */
+  private function createOptionValue($params) {
+    civicrm_api3('OptionValue', 'create', $params);
+  }
+
+  /**
+   * Creates case type category custom group
+   */
+  private function createCaseTypeCategoryCustomGroup() {
+    civicrm_api3('CustomGroup', 'create', [
+      'title' => ts('Case Type Category'),
+      'extends' => 'CaseType',
+      'name' => 'case_type_category',
+      'table_name' => 'civicrm_value_case_type_category'
+    ]);
+  }
+
+  /**
+   * Sets up option group and values used for case type category custom field
+   *
+   * @return null
+   */
+  private function createCaseTypeCategoryOptionValues() {
+    $result = civicrm_api3('OptionGroup', 'get', [
+      'name' => 'case_type_category',
+    ]);
+    if ($result['count'] == 0) {
+      $optionValues = ['Workflow', 'Vacancy'];
+      $groupParams = [
+        'name' => 'case_type_category',
+        'title' => 'Category',
+      ];
+
+      $optionGroupResult = $this->createOptionGroup($groupParams);
+      foreach ($optionValues as $optionValue) {
+        $valueParams = [
+          'option_group_id' => 'case_type_category',
+          'label' => $optionValue,
+          'name' => $optionValue,
+          'value' => $optionValue
+        ];
+        $this->createOptionValue($valueParams);
+      }
+
+      return $optionGroupResult['id'];
+    }
+
+    return null;
+  }
+
+  /**
+   * Creates category custom field for case type category custom group
+   *
+   * @param int $optionGroupId
+   */
+  private function createCaseTypeCategoryCustomField($optionGroupId) {
+    civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => 'case_type_category',
+      'label' => 'Category',
+      'name' => 'category',
+      'data_type' => 'String',
+      'html_type' => 'Select',
+      'is_required' => 1,
+      'column_name' => 'category',
+      'option_group_id' => $optionGroupId,
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR moves the upgraders for creating the Case Type Category custom field and the upgrader for assigning categories to Case Types. The upgraders were moved from the Tasks and Workflow extension to the HRCore and HRCase extensions.

The reason for moving the upgraders is because assigning a category to Case Types only works for existing installations.  For new installations, the upgraders were running before the default case types were being created since they are created in the HRCase and HRRecruitment extensions.

The PR that removes the upgraders from the Tasks and Workflows extension is this one:
https://github.com/compucorp/civihr-tasks-assignments/pull/400

### Technical details

The creation of the category custom field was moved to HRCore because this field is generic, independent of the Case Type or extensions that extend or use Case Types.

```php
<?php

trait CRM_HRCore_Upgrader_Steps_1023 {

  public function upgrade_1023() {
    $optionValues = civicrm_api3('OptionValue', 'get', [
      'option_group_id' => 'cg_extend_objects',
      'name' => 'civicrm_case_type'
    ]);

    if ($optionValues['count'] == 0) {
      $params = [
        'option_group_id' => 'cg_extend_objects',
        'name' => 'civicrm_case_type',
        'label' => ts('Case Type'),
        'value' => 'CaseType',
      ];
      $this->createOptionValue($params);
    }

    $customGroups = civicrm_api3('CustomGroup', 'get', [
      'extends' => 'CaseType',
      'name' => 'case_type_category',
    ]);

    if ($customGroups['count'] == 0) {
      $this->createCaseTypeCategoryCustomGroup();
    }

    $customFields = civicrm_api3('CustomField', 'get', [
      'custom_group_id' => 'case_type_category',
    ]);

    if ($customFields['count'] == 0) {
      $optionGroupId = $this->createCaseTypeCategoryOptionValues();
  
      if ($optionGroupId == null) {
        return FALSE;
      }

      $this->createCaseTypeCategoryCustomField($optionGroupId);
    }

    return TRUE;
  }

  private function createOptionGroup($params) {
    return civicrm_api3('OptionGroup', 'create', $params);
  }

  private function createOptionValue($params) {
    civicrm_api3('OptionValue', 'create', $params);
  }

  private function createCaseTypeCategoryCustomGroup() {
    civicrm_api3('CustomGroup', 'create', [
      'title' => ts('Case Type Category'),
      'extends' => 'CaseType',
      'name' => 'case_type_category',
      'table_name' => 'civicrm_value_case_type_category'
    ]);
  }

  private function createCaseTypeCategoryOptionValues() {
    $result = civicrm_api3('OptionGroup', 'get', [
      'name' => 'case_type_category',
    ]);

    if ($result['count'] == 0) {
      $optionValues = ['Workflow', 'Vacancy'];
      $groupParams = [
        'name' => 'case_type_category',
        'title' => 'Category',
      ];

      $optionGroupResult = $this->createOptionGroup($groupParams);

      foreach ($optionValues as $optionValue) {
        $valueParams = [
          'option_group_id' => 'case_type_category',
          'label' => $optionValue,
          'name' => $optionValue,
          'value' => $optionValue
        ];

        $this->createOptionValue($valueParams);
      }

      return $optionGroupResult['id'];
    }

    return null;
  }

  private function createCaseTypeCategoryCustomField($optionGroupId) {
    civicrm_api3('CustomField', 'create', [
      'custom_group_id' => 'case_type_category',
      'label' => 'Category',
      'name' => 'category',
      'data_type' => 'String',
      'html_type' => 'Select',
      'is_required' => 1,
      'column_name' => 'category',
      'option_group_id' => $optionGroupId,
    ]);
  }

}

```
(For the original upgrader PR please refer to https://github.com/compucorp/civihr-tasks-assignments/pull/379)

For assigning categories to case types, the upgrader introduced in this PR https://github.com/compucorp/civihr-tasks-assignments/pull/386/files#diff-ba2bb50d26fab0ecbb18fc02628c8caf was moved to HRCase so it runs after all default Case Types have been created:

```php
public function upgrade_1432() {
  $categoryFieldId = CRM_Core_BAO_CustomField::getCustomFieldID('category', 'case_type_category');
  $categoryFieldName = 'custom_' . $categoryFieldId;
  $caseTypes = civicrm_api3('CaseType', 'get', [
    'options' => [ 'limit' => 0 ]
  ]);

  foreach ($caseTypes['values'] as $caseType) {
    $category = $caseType['name'] === 'Application' ? 'Vacancy' : 'Workflow';

    civicrm_api3('CaseType', 'create', [
      'id' => $caseType['id'],
      $categoryFieldName => $category,
    ]);
  }

  return TRUE;
}
```

## Results

### Fresh installation

```json
{

    "is_error": 0,
    "version": 3,
    "count": 5,
    "values": [
        {
            "id": "2",
            "name": "adult_day_care_referral",
            "custom_7": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "5",
            "name": "Application",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "3",
            "name": "Exiting",
            "custom_7": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "1",
            "name": "housing_support",
            "custom_7": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "4",
            "name": "Joining",
            "custom_7": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        }
    ]
}
```

### Upgrading an existing installation

```json
{

    "is_error": 0,
    "version": 3,
    "count": 5,
    "values": [
        {
            "id": "2",
            "name": "adult_day_care_referral",
            "custom_81": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "5",
            "name": "Application",
            "custom_81": "Vacancy",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "3",
            "name": "Exiting",
            "custom_81": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "1",
            "name": "housing_support",
            "custom_81": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "4",
            "name": "Joining",
            "custom_81": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        }
    ]
}
```

Please note that `custom_###` refers to the category custom field. This is a CiviCRM feature. The difference in number is because the number is incremental and depends on how many other custom fields have been created before the upgrader runs.

The only difference between a new installation VS an existing one is that the "Application" case type does not have any category for new installations and has the "Vacancy" category for existing ones. As discussed in PCHR-3930 (please refer to the ticket) this is not an issue because A) the HRRecruitment extension (where the Application Case Type is created) might be removed in the near future, and B) even if it's not, the important thing is not to assign the "Workflow" category to the "Application" case type as per requirements of this epic (Please refer to the wiki of PCHR-3369 for more information)
