### PR TITLE
PCHR-3410: Change labels for Case Type's default assignee options

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -31,6 +31,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1021;
   use CRM_HRCore_Upgrader_Steps_1022;
   use CRM_HRCore_Upgrader_Steps_1023;
+  use CRM_HRCore_Upgrader_Steps_1024;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1024.php
@@ -1,0 +1,35 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1024 {
+
+  /**
+   * Changes the labels for some of the Case Type's default assignee options.
+   *
+   * @return bool
+   */
+  public function upgrade_1024() {
+    $newLabels = [
+      'BY_RELATIONSHIP' => 'By relationship to target staff member',
+      'USER_CREATING_THE_CASE' => 'User who starts the workflow',
+    ];
+
+    $names = array_keys($newLabels);
+
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'name' => ['IN' => $names],
+      'option_group_id' => 'activity_default_assignee',
+    ]);
+
+    foreach ($optionValues['values'] as $optionValue) {
+      $newLabel = $newLabels[$optionValue['name']];
+
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $optionValue['id'],
+        'label' => $newLabel,
+      ]);
+    }
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR changes some of the labels for the Case Type's default assignee options:

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>By relationship to workflow client</td>
    <td>By relationship to target staff member</td>
  </tr>
  <tr>
    <td>User creating the case</td>
    <td>User who starts the workflow</td>
  </tr>
</table>

## Technical details

A new upgrader was created that stores a key-value pair using the original option name, for lookup, and the new label to use for the option:

```php
<?php

trait CRM_HRCore_Upgrader_Steps_1024 {

  public function upgrade_1024() {
    $newLabels = [
      'BY_RELATIONSHIP' => 'By relationship to target staff member',
      'USER_CREATING_THE_CASE' => 'User who starts the workflow',
    ];

    $names = array_keys($newLabels);

    $optionValues = civicrm_api3('OptionValue', 'get', [
      'name' => ['IN' => $names],
      'option_group_id' => 'activity_default_assignee',
    ]);

    foreach ($optionValues['values'] as $optionValue) {
      $newLabel = $newLabels[$optionValue['name']];

      civicrm_api3('OptionValue', 'create', [
        'id' => $optionValue['id'],
        'label' => $newLabel,
      ]);
    }

    return TRUE;
  }

}
```
