### PR TITLE
PCHR-4076: Fix Filters on Admin Leave - Leave Requests and Calendar Tab

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php
@@ -126,9 +126,14 @@ class CRM_Hrjobroles_API_Query_ContactHrJobRolesSelect {
   private function addWhere(CRM_Utils_SQL_Select $customQuery) {
     if (!empty($this->params['contact_id'])) {
       $conditions[] = 'jc.contact_id IN (' . implode(',' , $this->params['contact_id']) . ')';
-      $customQuery->where($conditions);
       unset($this->params['contact_id']);
     }
+
+    $today = date('Y-m-d H:i:s');
+    $dateRestriction = 'a.start_date <= "' . $today . '"';
+    $dateRestriction .= ' AND (a.end_date >= "' . $today . '" OR a.end_date IS NULL)';
+    $conditions[] = $dateRestriction;
+    $customQuery->where($conditions);
   }
 
   /**

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Test/Fabricator/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Test/Fabricator/HrJobRoles.php
@@ -16,6 +16,10 @@ class CRM_Hrjobroles_Test_Fabricator_HrJobRoles {
    * @throws \Exception
    */
   public static function fabricate($params) {
+    if (empty($params['start_date'])) {
+      $params['start_date'] = date('Y-m-d H:i:s');
+    }
+
     $result = civicrm_api3(
       'HrJobRoles',
       'create',

--- a/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
+++ b/com.civicrm.hrjobroles/tests/phpunit/api/v3/ContactHRJobRoleTest.php
@@ -99,9 +99,9 @@ class api_v3_ContactHRJobRoleTest extends CRM_Hrjobroles_Test_BaseHeadlessTest {
     $contact2 = ContactFabricator::fabricate();
     $contract1 = HRJobContractFabricator::fabricate(['contact_id' => $contact1['id']]);
     $contract2 = HRJobContractFabricator::fabricate(['contact_id' => $contact2['id']]);
-    $jobRole1 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id'],]);
-    $jobRole2 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id'],]);
-    $jobRole3 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract2['id'],]);
+    $jobRole1 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id']]);
+    $jobRole2 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract1['id']]);
+    $jobRole3 = HRJobRolesFabricator::fabricate(['job_contract_id' => $contract2['id']]);
 
     $contactJobRoles = civicrm_api3($this->entity, $this->action)['values'];
 


### PR DESCRIPTION
## Overview
When filtering leave by admin on leave requests and calendar tab, records for staff whose job role are out of active date are returned. This PR fixes this by ensuring that date of filtering falls within staff job roles start and end date.

## Before
Filter result includes staff records whose job role start date is more than filter date or end date is less than the filtering date.

## After
Filter result no longer include staff records whose job role start date is more than filter date or end date is less than the filtering date.

## Technical Details
Date filtering was [applied](https://github.com/compucorp/civihr/blob/staging/com.civicrm.hrjobroles/CRM/Hrjobroles/API/Query/ContactHrJobRolesSelect.php#L126) to the filter query to ensure job role start and end date are put into consideration.
```
$today = date('Y-m-d H:i:s');
$dateRestriction = 'a.start_date <= "' . $today . '"';
$dateRestriction .= ' AND (a.end_date >= "'. $today . '" OR a.end_date IS NULL)';
```