### PR TITLE
PCHR-4054: Allow Own Leave Approver Edit Leave Dates For Own Request.

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -181,6 +181,29 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   /**
+   * @dataProvider leaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsTrueForAnyRequestTypeWhenCurrentUserIsOwnLeaveApproverIrrespectiveOfStatusPassed($status) {
+    $contactID = 2;
+    $this->registerCurrentLoggedInContactInSession($contactID);
+    $managerRightsService = $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser();
+
+    $this->assertTrue(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_LEAVE)
+    );
+
+    $this->assertTrue(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_SICKNESS)
+    );
+
+    $this->assertTrue(
+      $managerRightsService->canChangeDatesFor($contactID, $status, LeaveRequest::REQUEST_TYPE_TOIL)
+    );
+
+    $this->unregisterCurrentLoggedInContactFromSession();
+  }
+
+  /**
    * @dataProvider openLeaveRequestStatusesDataProvider
    */
   public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsLeaveContactAndTheLeaveRequestIsOpen($status) {


### PR DESCRIPTION
## Overview
Currently only the Admin can edit leave dates irrespective of the leave type and leave status, while other users like the staff and leave managers are bound by some rules which determine whether they can edit the leave dates or not. This PR makes it possible for Own leave approvers to be treated like an Admin for own requests and allowing such users edit the leave dates of their request irrespective of the status of the leave request or the leave request type.

## Before
- Only Admins can edit dates of a leave request irrespective of the status of the leave request or the leave request type.

## After
- Own Leave approvers now have admin capabilities when editing their own requests as they can now edit the dates irrespective of the status of the leave request or the leave request type.

## Technical Details

The `canChangeDatesFor` method of the LeaveRequestRights Service is what determines the if the current user can edit the leave dates or not, this method was refactored to accommodate the new change required in this PR:

```php
 public function canChangeDatesFor($contactID, $statusID, $requestType) {
    if ($this->currentUserIsAdmin()) {
      return TRUE;
    }

    $leaveRequestStatuses = self::getLeaveRequestStatuses();
    $openStatuses = [
      $leaveRequestStatuses['awaiting_approval'],
      $leaveRequestStatuses['more_information_required']
    ];

    $isOpenLeaveRequest = in_array($statusID, $openStatuses);
    $currentUserIsLeaveContact = $this->currentUserIsLeaveContact($contactID);

    if ($currentUserIsLeaveContact && $isOpenLeaveRequest) {
      return TRUE;
    }

    $currentUserIsLeaveManager = $this->currentUserIsLeaveManagerOf($contactID);
    $isOwnLeaveApprover = $currentUserIsLeaveManager && $currentUserIsLeaveContact;
    $isSicknessRequest = $requestType === LeaveRequest::REQUEST_TYPE_SICKNESS;

    return $isOwnLeaveApprover || ($isSicknessRequest && $currentUserIsLeaveManager);
  }
```