### PR TITLE
SHOR-22: Remove extra PHP code for appending contact image - covered under shoreditch

### DIFF
--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -753,10 +753,6 @@ function _hrui_contactSummaryDOMScript($data) {
   $script .= "CRM.$(function($) {";
   $script .= "$('#contactname-block.crm-summary-block').wrap('<div class=\"crm-summary-block-wrap\" />');";
 
-  if (!empty($data['contact']['image_URL'])) {
-    $script .= "$('.crm-summary-contactname-block').prepend('<img class=\"crm-summary-contactphoto\" src=" . $data['contact']['image_URL'] . " />');";
-  }
-
   if (empty($data['current_contract'])) {
     $script .= "$('.crm-summary-contactname-block').addClass('crm-summary-contactname-block-without-contract');";
   }
@@ -804,7 +800,7 @@ function _hrui_updateContactSummaryUI() {
   try {
     $contactDetails = civicrm_api3('Contact', 'getsingle', array(
       'sequential' => 1,
-      'return' => array("phone", "email", "image_URL"),
+      'return' => array("phone", "email"),
       'id' => $contact_id,
     ));
 


### PR DESCRIPTION
## Overview
HRUI component enforces a feature which actually fetch the image URL and appends it near the contact title. If we see Plain CiviCRM the Image is already appearing in the DOM we just need to move it to the position.

Since this change is required in CiviCRM too we have moved this feature to shoreditch - refer - https://github.com/civicrm/org.civicrm.shoreditch/pull/264

## Before
<img width="1618" alt="civihr - before" src="https://user-images.githubusercontent.com/3340537/43526785-a559c8c8-95c2-11e8-9410-75ec8bb54799.png">

## After
<img width="1668" alt="civihr - after" src="https://user-images.githubusercontent.com/3340537/43526803-aead54bc-95c2-11e8-95f8-22b8b237f401.png">