### PR TITLE
PCHR-4003: Hide Recruitment Menu in Admin Portal

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -29,6 +29,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1019;
   use CRM_HRCore_Upgrader_Steps_1020;
   use CRM_HRCore_Upgrader_Steps_1021;
+  use CRM_HRCore_Upgrader_Steps_1022;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1022.php
@@ -1,0 +1,26 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1022 {
+
+  /**
+   * Disables and Uninstall the Recruitment Extension
+   *
+   * @return bool
+   */
+  public function upgrade_1022() {
+    $this->up1022_disableAndUninstallRecruitment();
+
+    return TRUE;
+  }
+
+  /**
+   * disables and then Uninstalls the Recruitment Extensions
+   */
+  private function up1022_disableAndUninstallRecruitment() {
+    civicrm_api3('Extension', 'disable', [
+      'keys' => 'org.civicrm.hrrecruitment',
+      'api.Extension.uninstall' => ['keys' => 'org.civicrm.hrrecruitment'],
+    ]);
+  }
+
+}


### PR DESCRIPTION
## Overview
This Upgrader disables and uninstalls the HR Recruitment extension.

## Before
The HR Recruitment was active and there was a "Recruitment" menu in Admin portal

## After
The HR Recruitment will be disabled and uninstalled, so there won't be a "Recruitment" menu in Admin Portal

## Comments

- The extensions folder need to be removed after this task is released to the clients
- This upgrader will also remove all data created by the extension