### PR TITLE
PCHR-4049: Fix gulp tasks

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/gulp/tasks/requirejs.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulp/tasks/requirejs.js
@@ -71,7 +71,7 @@ function extensionDependenciesTask (cb) {
       return utils.spawnTaskForExtension('requirejs', requireJsTask, extension);
     });
 
-  sequence.length ? gulp.series.apply(null, sequence)(function () {
+  sequence.length ? gulp.series(sequence)(function () {
     // Restore the original extension (used in the CLI) as the current extension
     // before marking the task as done
     utils.setCurrentExtension(originalExtension);
@@ -205,7 +205,7 @@ function requireJsTask (cb) {
       );
     }
 
-    gulp.series.apply(null, sequence)(cb);
+    gulp.series(sequence)(cb);
   } else {
     console.log('Not eligible for this task, skipping...');
     cb();

--- a/uk.co.compucorp.civicrm.hrcore/gulp/tasks/sass.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulp/tasks/sass.js
@@ -19,7 +19,7 @@ module.exports = [
           utils.spawnTaskForExtension('sass:main', mainTask)
         ], 'sass');
 
-        gulp.series.apply(null, sequence)(cb);
+        gulp.series(sequence)(cb);
       } else {
         console.log('Not eligible for this task, skipping...');
         cb();

--- a/uk.co.compucorp.civicrm.hrcore/gulp/tasks/test.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulp/tasks/test.js
@@ -14,7 +14,7 @@ module.exports = [
           utils.spawnTaskForExtension('test:main', mainTask)
         ], 'test');
 
-        gulp.series.apply(null, sequence)(cb);
+        gulp.series(sequence)(cb);
       } else {
         console.log('Not eligible for this task, skipping...');
         cb();

--- a/uk.co.compucorp.civicrm.hrcore/gulp/utils.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulp/utils.js
@@ -306,11 +306,15 @@ function setCurrentExtension (extension) {
  * Spawns a task for an extension on the fly, using the name and function provided
  * The extension specified is set as the current extension before executing the task fn
  *
- * @param {String} taskName
- * @param {Function} taskFn
- * @param {String} extension If undefined, the current extension is used
+ * @param  {String} taskName
+ * @param  {Function} taskFn
+ * @param  {String} [extension] if omitted, the current extension is used
+ * @param  {Function} [callback] if ommited, no callback will be called
+ * @return {String} updated task name as per the selected extension
  */
-function spawnTaskForExtension (taskName, taskFn, extension) {
+function spawnTaskForExtension (taskName, taskFn, extension, callback) {
+  var taskExecution;
+
   extension = extension || getCurrentExtension();
   taskName += ' (' + extension + ')';
 
@@ -319,6 +323,10 @@ function spawnTaskForExtension (taskName, taskFn, extension) {
 
     return taskFn(cb);
   });
+
+  taskExecution = gulp.series([taskName]);
+
+  (callback) && taskExecution(callback);
 
   return taskName;
 }

--- a/uk.co.compucorp.civicrm.hrcore/gulp/utils.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulp/utils.js
@@ -309,12 +309,9 @@ function setCurrentExtension (extension) {
  * @param  {String} taskName
  * @param  {Function} taskFn
  * @param  {String} [extension] if omitted, the current extension is used
- * @param  {Function} [callback] if ommited, no callback will be called
  * @return {String} updated task name as per the selected extension
  */
-function spawnTaskForExtension (taskName, taskFn, extension, callback) {
-  var taskExecution;
-
+function spawnTaskForExtension (taskName, taskFn, extension) {
   extension = extension || getCurrentExtension();
   taskName += ' (' + extension + ')';
 
@@ -323,10 +320,6 @@ function spawnTaskForExtension (taskName, taskFn, extension, callback) {
 
     return taskFn(cb);
   });
-
-  taskExecution = gulp.series([taskName]);
-
-  (callback) && taskExecution(callback);
 
   return taskName;
 }

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -5,25 +5,31 @@ var gulp = require('gulp');
 var utils = require('./gulp/utils');
 var tasks = getMainTasks();
 
-var watcherPromises = buildTaskPromises(['sass:watch', 'requirejs:watch', 'test:watch']);
-var builderPromises = buildTaskPromises(['sass', 'requirejs', 'test']);
+var watcherTasks = createTasksArray(['sass:watch', 'requirejs:watch', 'test:watch']);
+var builderTasks = createTasksArray(['sass', 'requirejs', 'test']);
 
 _.each(tasks, function (fn, name) {
   gulp.task(name, fn);
 });
 
-gulp.task('watch', gulp.series(watcherPromises));
-gulp.task('build', gulp.series(builderPromises));
+gulp.task('watch', gulp.parallel(watcherTasks));
+gulp.task('build', gulp.series(builderTasks));
 
 /**
- * Builds extension tasks promises
+ * Builds extension tasks functions collection
  *
  * @param  {Array} taskNames
- * @return {Array} of task promises
+ * @return {Array} of task functions
  */
-function buildTaskPromises (taskNames) {
+function createTasksArray (taskNames) {
   return taskNames.map(function (taskName) {
-    return utils.spawnTaskForExtension(taskName, tasks[taskName]);
+    var fn = function (cb) {
+      utils.spawnTaskForExtension(taskName, tasks[taskName], null, cb);
+    };
+
+    fn.displayName = taskName;
+
+    return fn;
   });
 }
 

--- a/uk.co.compucorp.civicrm.hrcore/gulpfile.js
+++ b/uk.co.compucorp.civicrm.hrcore/gulpfile.js
@@ -5,33 +5,20 @@ var gulp = require('gulp');
 var utils = require('./gulp/utils');
 var tasks = getMainTasks();
 
-var watcherTasks = createTasksArray(['sass:watch', 'requirejs:watch', 'test:watch']);
-var builderTasks = createTasksArray(['sass', 'requirejs', 'test']);
-
 _.each(tasks, function (fn, name) {
   gulp.task(name, fn);
 });
 
-gulp.task('watch', gulp.parallel(watcherTasks));
-gulp.task('build', gulp.series(builderTasks));
+gulp.task('watch', function (cb) {
+  var watchTasksNames = spawnTasks(['sass:watch', 'requirejs:watch', 'test:watch']);
 
-/**
- * Builds extension tasks functions collection
- *
- * @param  {Array} taskNames
- * @return {Array} of task functions
- */
-function createTasksArray (taskNames) {
-  return taskNames.map(function (taskName) {
-    var fn = function (cb) {
-      utils.spawnTaskForExtension(taskName, tasks[taskName], null, cb);
-    };
+  gulp.parallel(watchTasksNames)(cb);
+});
+gulp.task('build', function (cb) {
+  var buildTasksNames = spawnTasks(['sass', 'requirejs', 'test']);
 
-    fn.displayName = taskName;
-
-    return fn;
-  });
-}
+  gulp.series(buildTasksNames)(cb);
+});
 
 /**
  * Gets all the task listed in the files under the gulp/task folder
@@ -49,4 +36,16 @@ function getMainTasks () {
     })
     .fromPairs()
     .value();
+}
+
+/**
+ * Spawns tasks for the selected extension
+ *
+ * @param  {Array} taskNames
+ * @return {Array} of updated tasks names as per the selected extension
+ */
+function spawnTasks (taskNames) {
+  return taskNames.map(function (taskName) {
+    return utils.spawnTaskForExtension(taskName, tasks[taskName]);
+  });
 }


### PR DESCRIPTION
## Overview

After https://github.com/compucorp/civihr/pull/2804 `gulp backstopjs:reference` stopped working. This PR fixes this issue. 

## Technical Details

### Wrapping tasks in functions

The initial problem was that the "extension related" tasks (like "test", "watch" and "requirejs") were initiated even if just BackstopJS task was execution was asked. Thus, they checked for provided extension, which we never provide when running BackstopJS.

So, in order to avoid this issue we need to wrap these tasks inside functions with callbacks.

```js
gulp.task('build', function (cb) {
  var buildTasksNames = spawnTasks(['sass', 'requirejs', 'test']);
  gulp.series(buildTasksNames)(cb);
// and similar for "watch"

// ...

function spawnTasks (taskNames) {
  return taskNames.map(function (taskName) {
    return utils.spawnTaskForExtension(taskName, tasks[taskName]);
  });
}
```

### Getting rid of ".apply"

`gulp.series` accepts an array of tasks, so this is correct:

```js
gulp.series(sequence);
// where sequence is [task1, task2, task3...]
```

### Parallelising watcher

There is no need to execute watching commands in sequence, watchers may spawn in any order and the faster - the better.

```js
gulp.task('watch', function (cb) {
  var watchTasksNames = spawnTasks(['sass:watch', 'requirejs:watch', 'test:watch']);
  gulp.parallel(watchTasksNames)(cb);
```
----
✅Manual Tests - passed
⏹Jasmine Tests - N/A
⏹JS distributive files - N/A
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed