### PR TITLE
PCHR-4072: Update help link to lead to freshdesk knowledge base 

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -507,7 +507,7 @@ function _hrcore_createHelpMenu(&$menu) {
 
   _hrcore_civix_insert_navigation_menu($menu, 'Help', [
     'name' => ts('User Guide'),
-    'url' => 'https://sprt.freshdesk.com/support/home',
+    'url' => 'http://userguide.civihr.org/en/latest/',
     'target' => '_blank',
     'permission' => 'access CiviCRM'
   ]);

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -507,7 +507,7 @@ function _hrcore_createHelpMenu(&$menu) {
 
   _hrcore_civix_insert_navigation_menu($menu, 'Help', [
     'name' => ts('User Guide'),
-    'url' => 'http://civihr-documentation.readthedocs.io/en/latest/',
+    'url' => 'https://sprt.freshdesk.com/support/home',
     'target' => '_blank',
     'permission' => 'access CiviCRM'
   ]);


### PR DESCRIPTION
## Overview
This PR changes the link pointed at by `user guide` under the help menu for `HR Admin` to http://userguide.civihr.org/en/latest/

## Before
User guide help menu points to `http://civihr-documentation.readthedocs.io/en/latest/`

## After
User guide help menu points to `http://userguide.civihr.org/en/latest/`

## Technical Details
The civicrm navigation [url](https://github.com/compucorp/civihr/blob/staging/uk.co.compucorp.civicrm.hrcore/hrcore.php#L510] for user guide help menu was updated to `http://userguide.civihr.org/en/latest/`