### PR TITLE
PCHR-4101: Remove Recruitment Submenus

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -38,6 +38,8 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1028;
   use CRM_HRCore_Upgrader_Steps_1029;
   use CRM_HRCore_Upgrader_Steps_1030;
+  use CRM_HRCore_Upgrader_Steps_1031;
+  use CRM_HRCore_Upgrader_Steps_1032;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -1,0 +1,33 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1032 {
+
+  /**
+   * Deletes some of vacancy submenu
+   *
+   * @return bool
+   */
+  public function upgrade_1032() {
+    $this->up1032_removeRecruitmentSubmenus([
+      'Search by Application Form Fields',
+      'Search by Evaluation Criteria',
+    ]);
+
+    return TRUE;
+  }
+
+  /**
+   * Deletes some of vacancy submenu left after uninstalling the extension
+   *
+   * @param array $menusToRemove
+   */
+  private function up1032_removeRecruitmentSubmenus($menusToRemove) {
+    foreach ($menusToRemove as $submenuLabel) {
+      civicrm_api3('Navigation', 'get', [
+        'label' => $submenuLabel,
+        'api.Navigation.delete' => ['id' => '$value.id'],
+      ]);
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
After uninstalling the Recruitment extensions, some of it's submenus were left on the Database. This upgrader just removes them.

## Before
There were some submenus left on the navigation table after uninstalling the extension.

## After
The submenus will be deleted from the database by this upgrader

## Comments
Removing these submenus does not prevent the pages from being accessible directly via URL, as these pages belongs to another extensions. It's just for cleanup purposes.