### PR TITLE
PCHR-3681: Remove unnecessary param in calls to CRM_Utils_Request::retrieve()

### DIFF
--- a/contactsummary/contactsummary.php
+++ b/contactsummary/contactsummary.php
@@ -128,9 +128,9 @@ function contactsummary_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
 function contactsummary_civicrm_pageRun($page) {
   if ($page instanceof CRM_Contact_Page_View_Summary) {
     CRM_Core_Resources::singleton()
-      ->addSetting(array(
-        'tabSettings' => array('active' => CRM_Utils_Request::retrieve('selectedChild', 'String', $this, FALSE, 'contactsummary')),
-      ))
+      ->addSetting([
+        'tabSettings' => ['active' => CRM_Utils_Request::retrieve('selectedChild', 'String') ?: 'contactsummary'],
+      ])
       ->addVars('leaveAndAbsences', [
         'baseURL' => CRM_Core_Resources::singleton()->getUrl('uk.co.compucorp.civicrm.hrleaveandabsences'),
         'attachmentToken' => CRM_Core_Page_AJAX_Attachment::createToken()

--- a/hrcareer/hrcareer.php
+++ b/hrcareer/hrcareer.php
@@ -149,7 +149,7 @@ function hrcareer_getUFGroupID() {
  */
 function hrcareer_civicrm_buildProfile($name) {
   if ($name == 'hrcareer_tab') {
-    $isDialog = ('multiProfileDialog' == CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject));
+    $isDialog = ('multiProfileDialog' == CRM_Utils_Request::retrieve('context', 'String'));
 
     // To fix validation alert issue
     $smarty = CRM_Core_Smarty::singleton();
@@ -167,7 +167,7 @@ function hrcareer_civicrm_buildProfile($name) {
 
     $config = CRM_Core_Config::singleton();
     if ($config->logging && ! $isDialog) {
-      $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+      $contactID = CRM_Utils_Request::retrieve('id', 'Positive');
       CRM_Core_Region::instance('profile-form-hrcareer_tab')->add(array(
         'template' => 'CRM/common/logButton.tpl',
         'instance_id' => CRM_Report_Utils_Report::getInstanceIDForValue('logging/contact/summary'),

--- a/hrident/hrident.php
+++ b/hrident/hrident.php
@@ -140,8 +140,8 @@ function hrident_civicrm_buildProfile($name) {
     $smarty->assign('urlIsPublic', FALSE);
 
     $config = CRM_Core_Config::singleton();
-    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject)) {
-      $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String')) {
+      $contactID = CRM_Utils_Request::retrieve('id', 'Positive');
       CRM_Core_Region::instance('profile-form-hrident_tab')->add(array(
         'template' => 'CRM/common/logButton.tpl',
         'instance_id' => CRM_Report_Utils_Report::getInstanceIDForValue('logging/contact/summary'),

--- a/hrmed/hrmed.php
+++ b/hrmed/hrmed.php
@@ -141,8 +141,8 @@ function hrmed_civicrm_buildProfile($name) {
     $smarty->assign('urlIsPublic', FALSE);
 
     $config = CRM_Core_Config::singleton();
-    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject)) {
-      $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String')) {
+      $contactID = CRM_Utils_Request::retrieve('id', 'Positive');
       CRM_Core_Region::instance('profile-form-hrmed_tab')->add(array(
         'template' => 'CRM/common/logButton.tpl',
         'instance_id' => CRM_Report_Utils_Report::getInstanceIDForValue('logging/contact/summary'),

--- a/hrqual/hrqual.php
+++ b/hrqual/hrqual.php
@@ -36,7 +36,7 @@ function hrqual_civicrm_buildProfile($name) {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('urlIsPublic', FALSE);
 
-    $action = CRM_Utils_Request::retrieve('multiRecord', 'String', $this);
+    $action = CRM_Utils_Request::retrieve('multiRecord', 'String');
     // display the select box only in add and update mode
     if (in_array($action, array("add", "update"))) {
       $regionParams = array(
@@ -46,8 +46,8 @@ function hrqual_civicrm_buildProfile($name) {
     }
 
     $config = CRM_Core_Config::singleton();
-    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject)) {
-      $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String')) {
+      $contactID = CRM_Utils_Request::retrieve('id', 'Positive');
       CRM_Core_Region::instance('profile-form-hrqual_tab')->add(array(
         'template' => 'CRM/common/logButton.tpl',
         'instance_id' => CRM_Report_Utils_Report::getInstanceIDForValue('logging/contact/summary'),

--- a/hrstaffdir/hrstaffdir.php
+++ b/hrstaffdir/hrstaffdir.php
@@ -50,7 +50,7 @@ function hrstaffdir_civicrm_searchColumns($objectName, &$headers, &$values, &$se
   if ($objectName == 'profile') {
     $profileId = hrstaffdir_getUFGroupID();
     $session = CRM_Core_Session::singleton();
-    $gid = CRM_Utils_Request::retrieve('gid', 'Positive', CRM_Core_DAO::$_nullObject);
+    $gid = CRM_Utils_Request::retrieve('gid', 'Positive');
     // Note: This protocol is not safe when concurrently browsing multiple profile-listings, but
     // that doesn't work anyway, so we can't implement/test a better protocol.
     if ($gid) {

--- a/hrui/hrui.php
+++ b/hrui/hrui.php
@@ -72,7 +72,7 @@ function hrui_civicrm_buildForm($formName, &$form) {
   }
 
   if ($formName == 'CRM_Admin_Form_Extensions') {
-    $extensionKey= CRM_Utils_Request::retrieve('key', 'String', $this);
+    $extensionKey= CRM_Utils_Request::retrieve('key', 'String');
     if ($extensionKey == 'uk.co.compucorp.civicrm.hrsampledata') {
       $title = ts("Be Careful");
       $message = ts("Installing/Uninstalling this extension will remove all existing data, so make sure to create a backup first !");

--- a/hrvisa/hrvisa.php
+++ b/hrvisa/hrvisa.php
@@ -36,10 +36,10 @@ function hrvisa_civicrm_buildProfile($name) {
     $smarty = CRM_Core_Smarty::singleton();
     $smarty->assign('urlIsPublic', FALSE);
 
-    $contactID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $contactID = CRM_Utils_Request::retrieve('id', 'Positive');
 
     $config = CRM_Core_Config::singleton();
-    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String', CRM_Core_DAO::$_nullObject)) {
+    if ($config->logging && 'multiProfileDialog' !== CRM_Utils_Request::retrieve('context', 'String')) {
       CRM_Core_Region::instance('profile-form-hrvisa_tab')->add(array(
         'template' => 'CRM/common/logButton.tpl',
         'instance_id' => CRM_Report_Utils_Report::getInstanceIDForValue('logging/contact/summary'),


### PR DESCRIPTION
## Overview

The main reason for this is that `$this` was being passed as the store param in places that we didn't have a context object (i.e. outside of an instance method). Up to PHP 7.0, this would work without a problem, but starting from PHP 7.1, this now results in an error: https://3v4l.org/QXYLB

In a few places, instead of $this, `CRM_Core_DAO::$_nullObject` was being used. This is a risky approach, as it's possible for $_nullObject to not be null (it is just a public static property of the DAO class). This has been removed as well.

## Comments

This is not really related or necessary for the work I'm doing for the CiviHR installation profile. I'm doing the tests for PCHR-3681 in an environment with PHP 7.1 installed and ended up stumbling upon this issue, so I thought it would be nice to fix it.