### PR TITLE
PCHR-3797: Improve Apply Core Fork Patch Script to Avoid API Rate Limit Errors

### DIFF
--- a/bin/apply-core-fork-patch.sh
+++ b/bin/apply-core-fork-patch.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-BASE_URL="https://github.com/compucorp/civicrm-core"
+API_URL_BASE="https://api.github.com/repos/compucorp/civicrm-core"
+REPO_BASE_URL="https://github.com/compucorp/civicrm-core"
 LAST_COMMIT_PATCHED_FILE="core-fork-last-commit-patched.txt"
 PATCH_FILE="fork-patch.diff"
 
@@ -27,7 +28,7 @@ applyPatch () {
 # Creates a diff patch file by sending a request to the given GitHub API url
 #
 # Globals:
-#   $BASE_URL
+#   $REPO_BASE_URL
 #   $civiRoot
 #   $PATCH_FILE
 # Arguments:
@@ -37,7 +38,7 @@ applyPatch () {
 #   None
 #######################################
 createPatch () {
-  curl "$BASE_URL/compare/$1...$2.diff" -s -H "Accept: application/vnd.github.v3.diff" > "$civiRoot/$PATCH_FILE"
+  curl "$REPO_BASE_URL/compare/$1...$2.diff" -s > "$civiRoot/$PATCH_FILE"
 }
 
 #######################################
@@ -97,7 +98,7 @@ setCivicrmRootPath () {
 #######################################
 updateLastCommitPatched () {
   # It uses the same file as temporary recipient of the full commit data
-  curl "$BASE_URL/commits/$1" -s > "$LAST_COMMIT_PATCHED_FILE"
+  curl "$API_URL_BASE/commits/$1" -s > "$LAST_COMMIT_PATCHED_FILE"
   sha=$(JSONValue "$LAST_COMMIT_PATCHED_FILE" "sha")
 
   echo "$sha" > "$LAST_COMMIT_PATCHED_FILE"

--- a/bin/apply-core-fork-patch.sh
+++ b/bin/apply-core-fork-patch.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-API_URL_BASE="https://api.github.com/repos/compucorp/civicrm-core"
+BASE_URL="https://github.com/compucorp/civicrm-core"
 LAST_COMMIT_PATCHED_FILE="core-fork-last-commit-patched.txt"
 PATCH_FILE="fork-patch.diff"
 
@@ -27,7 +27,7 @@ applyPatch () {
 # Creates a diff patch file by sending a request to the given GitHub API url
 #
 # Globals:
-#   $API_URL_BASE
+#   $BASE_URL
 #   $civiRoot
 #   $PATCH_FILE
 # Arguments:
@@ -37,7 +37,7 @@ applyPatch () {
 #   None
 #######################################
 createPatch () {
-  curl "$API_URL_BASE/compare/$1...$2" -s -H "Accept: application/vnd.github.v3.diff" > "$civiRoot/$PATCH_FILE"
+  curl "$BASE_URL/compare/$1...$2.diff" -s -H "Accept: application/vnd.github.v3.diff" > "$civiRoot/$PATCH_FILE"
 }
 
 #######################################
@@ -97,7 +97,7 @@ setCivicrmRootPath () {
 #######################################
 updateLastCommitPatched () {
   # It uses the same file as temporary recipient of the full commit data
-  curl "$API_URL_BASE/commits/$1" -s > "$LAST_COMMIT_PATCHED_FILE"
+  curl "$BASE_URL/commits/$1" -s > "$LAST_COMMIT_PATCHED_FILE"
   sha=$(JSONValue "$LAST_COMMIT_PATCHED_FILE" "sha")
 
   echo "$sha" > "$LAST_COMMIT_PATCHED_FILE"


### PR DESCRIPTION
## Overview
This PR changes the implementation of Apply Core Fork Patch Script from using the api to using `diff` url when creating patch. This helps to reduce tendency for API rate limit errors.

## Before
API rate limit applies to core fork request for git diff in commits when creating patch.

## After
No API rate limit is applicable to git diff request when applying core fork patch to create patch. 

## Technical Details
The api base url was changed to non api url in order to avoid rate limiting in requests.
```
REPO_BASE_URL="https://github.com/compucorp/civicrm-core"
```