### PR TITLE
PCHR-3410: Change default assignee option labels

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -39,6 +39,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1029;
   use CRM_HRCore_Upgrader_Steps_1030;
   use CRM_HRCore_Upgrader_Steps_1031;
+  use CRM_HRCore_Upgrader_Steps_1032;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -17,7 +17,6 @@ trait CRM_HRCore_Upgrader_Steps_1032 {
     $optionValuesNames = array_keys($optionValuesNewLabels);
     $optionValues = civicrm_api3('OptionValue', 'get', [
       'name' => ['IN' => $optionValuesNames],
-      'option' => ['limit' => 0],
     ]);
 
     foreach ($optionValues['values'] as $optionValue) {

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -1,0 +1,35 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1032 {
+
+  /**
+   * This upgrader changes the labels for the default assignee options used in
+   * case type management.
+   *
+   * @return bool
+   */
+  public function upgrade_1032() {
+    $optionValuesNewLabels = [
+      'BY_RELATIONSHIP' => 'By relationship to target staff member',
+      'USER_CREATING_THE_CASE' => 'User who starts the workflow',
+    ];
+
+    $optionValuesNames = array_keys($optionValuesNewLabels);
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'name' => ['IN' => $optionValuesNames],
+      'option' => ['limit' => 0],
+    ]);
+
+    foreach ($optionValues['values'] as $optionValue) {
+      $newLabel = $optionValuesNewLabels[$optionValue['name']];
+
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $optionValue['id'],
+        'label' => $newLabel,
+      ]);
+    }
+
+    return TRUE;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR changes the labels for some of the default assignee options:

<table>
  <tr>
    <th>From</th>
    <th>To</th>
  </tr>
  <tr>
    <td>By relationship to workflow client</td>
    <td>By relationship to target staff member</td>
  </tr>
  <tr>
    <td>User creating the case</td>
    <td>User who starts the workflow</td>
  </tr>
</table>

## Before
![pr-before](https://user-images.githubusercontent.com/1642119/44344602-1a023200-a45f-11e8-83d6-06810079ba24.png)

## After
![pr-after](https://user-images.githubusercontent.com/1642119/44344613-1e2e4f80-a45f-11e8-9633-7ff197d706f1.png)


## Technical Details
Since these options are created by CiviCRM core, a new upgrader was added to HRCore:

```php
<?php

trait CRM_HRCore_Upgrader_Steps_1032 {

  public function upgrade_1032() {
    $optionValuesNewLabels = [
      'BY_RELATIONSHIP' => 'By relationship to target staff member',
      'USER_CREATING_THE_CASE' => 'User who starts the workflow',
    ];

    $optionValuesNames = array_keys($optionValuesNewLabels);
    $optionValues = civicrm_api3('OptionValue', 'get', [
      'sequential' => 1,
      'name' => ['IN' => $optionValuesNames],
      'option' => ['limit' => 0],
    ]);

    foreach ($optionValues['values'] as $optionValue) {
      $newLabel = $optionValuesNewLabels[$optionValue['name']];

      civicrm_api3('OptionValue', 'create', [
        'id' => $optionValue['id'],
        'label' => $newLabel,
      ]);
    }

    return TRUE;
  }

}

```
