### PR TITLE
PCHR-4061: Allow Passing Contact Subtype as a Parameter

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/DataSourceFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/DataSourceFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_DataSourceFilter {
+
+  /**
+   * Handle the form. if the form is of type DataSource, it should be Handled
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $this->setContactType($form);
+  }
+
+  /**
+   * Sets the default selected contact type in the form, using the paramter
+   * value
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function setContactType(&$form) {
+    $force = CRM_Utils_Request::retrieve('force', 'Boolean');
+    $contactType = CRM_Utils_Request::retrieve('contactType', 'String');
+
+    if (!$force) {
+      return;
+    }
+
+    foreach ($form->_elements as $index => &$element) {
+      if (isset($element->_name) && $element->_name === 'contactType') {
+        foreach ($element->_elements as $radioInput) {
+          if ($radioInput->_text === $contactType) {
+            $radioInput->setChecked(TRUE);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Checks if the hook should be handled.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    return $formName === CRM_Contact_Import_Form_DataSource::class;
+  }
+
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -119,6 +119,7 @@ function hrcore_civicrm_buildForm($formName, &$form) {
     new CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
     new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
+    new CRM_HRCore_Hook_BuildForm_DataSourceFilter(),
   ];
 
   foreach ($listeners as $currentListener) {


### PR DESCRIPTION
## Overview
This PR allows the user to pass contact subtype as a GET parameter when force is set to 1. Then this subtype is used as the default value on the DataSource selection Form

## Before
It was not possible to pass contact subtype as a parameter.

## After
When force is set to 1 and contactType is set to "Individual", the "Individual" checkbox is selected by default. The same happens with all other contact subtypes.
![screenshot_20180821_103049](https://user-images.githubusercontent.com/1692858/44390468-a0854500-a52d-11e8-8725-43d6e1073e31.png)