### PR TITLE
PCHR-4131: Hide Import Menus From Staff Menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -22,8 +22,8 @@ trait CRM_HRCore_Upgrader_Steps_1032 {
     ]);
     $this->up1032_disableImportMenus([
       'Import Contacts',
-      'Import / Export',
-      'Import Custom Fields',
+      'import_export_job_contracts',
+      'import_custom_fields',
     ]);
 
     return TRUE;


### PR DESCRIPTION
## Overview
This Upgrader changes the options to use names instead of Label on navigation API calls. There was a problem in items where the names are different from Labels. This PR is an amendment to [PCHR-4059: Improve Staff Menu](https://github.com/compucorp/civihr/pull/2836)

## Before
Some Import items were not disabled on Staff menu

## After
All Import items will be disabled on Staff Menu