### PR TITLE
PCHR-4132: Add the Correct Menu Link to New Meeting

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -143,7 +143,7 @@ trait CRM_HRCore_Upgrader_Steps_1032 {
         'permission' => $menu['permission'],
         'is_active' => 1,
         'weight' => 2,
-        'url' => '/activity?reset=1&action=add&context=standalone',
+        'url' => 'civicrm/activity?reset=1&action=add&context=standalone',
       ]);
       // If we don't flush it will not recognize newly created parent_id
       CRM_Core_PseudoConstant::flush();


### PR DESCRIPTION
## Overview
This PR is an amendment to [PCHR-4059: Improve Staff Menu](https://github.com/compucorp/civihr/pull/2836) where there was an issue with the menu link in New Meeting.

## Before
The menu wrongly pointed to /activity?reset=1&action=add&context=standalone
## After
The menu link is pointing to civicrm/activity?reset=1&action=add&context=standalone