### PR TITLE
PCHR-4134: Change the Add New Member Menu Item

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1032.php
@@ -39,7 +39,6 @@ trait CRM_HRCore_Upgrader_Steps_1032 {
         'id' => '$value.id',
         'label' => 'Add New Staff Member',
         'name' => 'Add New Staff Member',
-        'url' => 'civicrm/import/contact?reset=1&force=1',
       ],
     ]);
   }


### PR DESCRIPTION
## Overview
This PR changes the Upgrader to not updating the URL of Add New Staff Member menu item. An early description of the task said that the URL should be changed, but it was later reverted.

## Before
The Upgrader was changing the Menu URL

## After
The Upgrader will not touch the menu URL