### PR TITLE
PCHR-4139: Remove HRRecruitment For New Sites

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -425,12 +425,6 @@ def listCivihrExtensions() {
       hasJSTests: true,
       hasPHPTests: true
     ],
-    hrrecruitment: [
-      name: 'Recruitment',
-      folder: 'hrrecruitment',
-      hasJSTests: false,
-      hasPHPTests: true
-    ],
     hrreport: [
       name: 'Reports',
       folder: 'hrreport',

--- a/bin/civihr-crm-api-tests.sh
+++ b/bin/civihr-crm-api-tests.sh
@@ -66,7 +66,6 @@ runTest hrreport org.civicrm.hrabsence,org.civicrm.hrjob,org.civicrm.hrreport CR
 runTest hrjob org.civicrm.hrjob api_v3_AllTests
 runTest hrjob org.civicrm.hrjob CRM_AllTests
 runTest hrabsence org.civicrm.hrabsence api_v3_AllTests
-runTest hrrecruitment org.civicrm.hrrecruitment CRM_AllTests
 
 if [ -f "${SQLDUMP}" ] ; then
   rm "${SQLDUMP}"

--- a/bin/civihr-webtests.sh
+++ b/bin/civihr-webtests.sh
@@ -9,7 +9,6 @@ hrjob \
 hrmed \
 hrqual \
 hrstaffdir \
-hrrecruitment \
 )
 
 CONF=`dirname $0`/setup.conf

--- a/bin/drush-install.sh
+++ b/bin/drush-install.sh
@@ -28,7 +28,6 @@ org.civicrm.hrreport,\
 org.civicrm.hrui,\
 org.civicrm.hrcase,\
 org.civicrm.hrim,\
-org.civicrm.hrrecruitment,\
 org.civicrm.reqangular,\
 org.civicrm.contactsummary,\
 org.civicrm.shoreditch,\

--- a/bin/git-release.sh
+++ b/bin/git-release.sh
@@ -9,7 +9,6 @@ hrim \
 hrmed \
 hrprofile \
 hrqual \
-hrrecruitment \
 hrreport \
 uk.co.compucorp.civicrm.hrsampledata \
 hrstaffdir \

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Service/Stats/StatsGatherer.php
@@ -239,24 +239,6 @@ class CRM_HRCore_Service_Stats_StatsGatherer {
   }
 
   /**
-   * Fetches entity counts for the recruitment entities
-   *
-   * @return array
-   */
-  private function getRecruitmentEntityCounts() {
-    $recruitmentKey = 'org.civicrm.hrrecruitment';
-    $counts = [];
-
-    if (!ExtensionHelper::isExtensionEnabled($recruitmentKey)) {
-      return $counts;
-    }
-
-    $counts['vacancy'] = $this->getEntityCount('HRVacancy');
-
-    return $counts;
-  }
-
-  /**
    * Checks if the underlying CMS system is Drupal
    *
    * @return bool

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Test/BaseHeadlessTest.php
@@ -9,7 +9,6 @@ abstract class CRM_HRCore_Test_BaseHeadlessTest extends PHPUnit_Framework_TestCa
   public function setUpHeadless() {
     $requiredExtensions = [
       'uk.co.compucorp.civicrm.tasksassignments',
-      'org.civicrm.hrrecruitment',
       'uk.co.compucorp.civicrm.hrleaveandabsences',
       'org.civicrm.hrjobcontract', // L&A depends on HRJobContract
       'uk.co.compucorp.civicrm.hrcontactactionsmenu',

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1031.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1031.php
@@ -4,6 +4,7 @@ trait CRM_HRCore_Upgrader_Steps_1031 {
 
   /**
    * Disables and Uninstall the Recruitment Extension
+   *
    * @return bool
    */
   public function upgrade_1031() {
@@ -16,10 +17,13 @@ trait CRM_HRCore_Upgrader_Steps_1031 {
    * disables and then Uninstalls the Recruitment Extensions
    */
   private function up1031_disableAndUninstallRecruitment() {
-    civicrm_api3('Extension', 'disable', [
-      'keys' => 'org.civicrm.hrrecruitment',
-      'api.Extension.uninstall' => ['keys' => 'org.civicrm.hrrecruitment'],
-    ]);
+    if (CRM_HRCore_Helper_ExtensionHelper::isExtensionEnabled('org.civicrm.hrrecruitment')) {
+      civicrm_api3('Extension', 'disable', [
+        'keys' => 'org.civicrm.hrrecruitment',
+        'api.Extension.uninstall' => ['keys' => 'org.civicrm.hrrecruitment'],
+      ]);
+    }
+
   }
 
 }

--- a/uk.co.compucorp.civicrm.hrsampledata/tests/phpunit/CRM/HRSampleData/BaseCSVProcessorTest.php
+++ b/uk.co.compucorp.civicrm.hrsampledata/tests/phpunit/CRM/HRSampleData/BaseCSVProcessorTest.php
@@ -18,7 +18,6 @@ class CRM_HRSampleData_BaseCSVProcessorTest extends \PHPUnit_Framework_TestCase 
       ->install('org.civicrm.hrjobcontract')
       ->install('org.civicrm.hrabsence')
       ->install('com.civicrm.hrjobroles')
-      ->install('org.civicrm.hrrecruitment')
       ->install('org.civicrm.hremergency')
       ->install('org.civicrm.hrbank')
       ->install('uk.co.compucorp.civicrm.tasksassignments')


### PR DESCRIPTION
## Overview
This PR prevents hrrecruitment for being installed on new sites. It also removes all occurrencies of hrrecruitment on the code

## Before
Hrrecruitment was being installed on new sites.

## After
Hrrecruitment will not be installed on new sites
