### PR TITLE
PCHR-4138: The link is wrong

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -507,7 +507,7 @@ function _hrcore_createHelpMenu(&$menu) {
 
   _hrcore_civix_insert_navigation_menu($menu, 'Help', [
     'name' => ts('User Guide'),
-    'url' => 'http://userguide.civihr.org/en/latest/',
+    'url' => 'http://userguide.civihr.org/',
     'target' => '_blank',
     'permission' => 'access CiviCRM'
   ]);


### PR DESCRIPTION
## Overview
The link was [previously](https://github.com/compucorp/civihr/pull/2822) updated but incorrect URI was used. This PR changes the URI as appropriate.

## Before
User guide help menu points to `http://userguide.civihr.org/en/latest/`

## After
User guide help menu points to `http://userguide.civihr.org/`

## Technical Details
The URI contains `en/latest/` which was not meant to be part of it. The civicrm navigation [url](https://github.com/compucorp/civihr/blob/staging/uk.co.compucorp.civicrm.hrcore/hrcore.php#L510] for user guide help menu was therefore updated.