### PR TITLE
PCHR-4063: Changing Import Contacts to Import Staff

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -358,6 +358,7 @@ function hrcore_civicrm_navigationMenu(&$params) {
 function hrcore_civicrm_alterMenu(&$items) {
   $items['civicrm/api']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
   $items['civicrm/styleguide']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
+  $items['civicrm/import/contact']['title'] = 'Import Staff';
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR changes the heading of the import page from "Import Contacts" to "Import Staff"

## Before
The page heading was "Import Contacts"

## After
The Page heading will be "Import Staff"

## Technical Details
It is required to clear the cache for this change to take effect.