### PR TITLE
PCHR-4150: Grant HR Admin access to message template menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -40,6 +40,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1030;
   use CRM_HRCore_Upgrader_Steps_1031;
   use CRM_HRCore_Upgrader_Steps_1032;
+  use CRM_HRCore_Upgrader_Steps_1033;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
@@ -1,0 +1,55 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1033 {
+
+  /**
+   * Updates menu permissions
+   *
+   * @return bool
+   */
+  public function upgrade_1033() {
+    $permissions = [
+      'access root menu items and configurations',
+      'edit system workflow message templates',
+      'edit user-driven message templates'
+    ];
+
+    $this->up1033_updateMessageTemplatePermissions($permissions);
+    $this->up1033_updateCommunicationsPermissions($permissions);
+
+    return TRUE;
+  }
+
+  /**
+   * Updates message template permissions
+   *
+   * @param array $permissions
+   */
+  private function up1033_updateMessageTemplatePermissions($permissions) {
+    civicrm_api3('Navigation', 'get', [
+      'parent_id' => 'Communications',
+      'url' => 'civicrm/admin/messageTemplates?reset=1',
+      'api.Navigation.create' => [
+        'id' => '$value.id',
+        'permission' => implode(',', $permissions),
+        'permission_operator' => 'OR'
+      ],
+    ]);
+  }
+
+  /**
+   * Updates communications permissions
+   *
+   * @param array $permissions
+   */
+  private function up1033_updateCommunicationsPermissions($permissions) {
+    civicrm_api3('Navigation', 'get', [
+      'name' => 'Communications',
+      'api.Navigation.create' => [
+        'id' => '$value.id',
+        'permission' => implode(',', $permissions),
+        'permission_operator' => 'OR'
+      ],
+    ]);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
@@ -28,7 +28,7 @@ trait CRM_HRCore_Upgrader_Steps_1033 {
   private function up1033_updateMessageTemplatePermissions($permissions) {
     civicrm_api3('Navigation', 'get', [
       'parent_id' => 'Communications',
-      'url' => 'civicrm/admin/messageTemplates?reset=1',
+      'name' => 'Message Templates',
       'api.Navigation.create' => [
         'id' => '$value.id',
         'permission' => implode(',', $permissions),


### PR DESCRIPTION
## Overview
In order to access the `message template menu`, permission to `access root menu items and configurations` is required. This does not give `HR admin` access to the page even though they have access to a granular permission - `edit user-driven message templates`. This PR adds the two new granular permissions to the existing permission.

## Before
<img width="196" alt="before_permission" src="https://user-images.githubusercontent.com/1507645/44862585-e8fdda80-ac72-11e8-8aea-87e34e3ec210.png">


## After
<img width="246" alt="after_permission" src="https://user-images.githubusercontent.com/1507645/44862599-f0bd7f00-ac72-11e8-9ed0-332cf2ec96d5.png">


## Technical Details
The permissions for both `Communications` and `Message Templates` were modified to ensure it grants access to users with any of the following permission - 
* access root menu items and configurations
* edit system workflow message templates
* edit user-driven message templates

```
'api.Navigation.create' => [
  'id' => '$value.id',
  'permission' => implode(',', $permissions),
  'permission_operator' => 'OR'
],
```

## Comments
The permissions were created using this PR [#543](https://github.com/compucorp/civihr-employee-portal/pull/543)
