### PR TITLE
PCHR-3488: Permission to Edit Message Templates

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -40,6 +40,7 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1030;
   use CRM_HRCore_Upgrader_Steps_1031;
   use CRM_HRCore_Upgrader_Steps_1032;
+  use CRM_HRCore_Upgrader_Steps_1033;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1033.php
@@ -1,0 +1,55 @@
+<?php
+
+trait CRM_HRCore_Upgrader_Steps_1033 {
+
+  /**
+   * Updates menu permissions
+   *
+   * @return bool
+   */
+  public function upgrade_1033() {
+    $permissions = [
+      'access root menu items and configurations',
+      'edit system workflow message templates',
+      'edit user-driven message templates'
+    ];
+
+    $this->up1033_updateMessageTemplatePermissions($permissions);
+    $this->up1033_updateCommunicationsPermissions($permissions);
+
+    return TRUE;
+  }
+
+  /**
+   * Updates message template permissions
+   *
+   * @param array $permissions
+   */
+  private function up1033_updateMessageTemplatePermissions($permissions) {
+    civicrm_api3('Navigation', 'get', [
+      'parent_id' => 'Communications',
+      'name' => 'Message Templates',
+      'api.Navigation.create' => [
+        'id' => '$value.id',
+        'permission' => implode(',', $permissions),
+        'permission_operator' => 'OR'
+      ],
+    ]);
+  }
+
+  /**
+   * Updates communications permissions
+   *
+   * @param array $permissions
+   */
+  private function up1033_updateCommunicationsPermissions($permissions) {
+    civicrm_api3('Navigation', 'get', [
+      'name' => 'Communications',
+      'api.Navigation.create' => [
+        'id' => '$value.id',
+        'permission' => implode(',', $permissions),
+        'permission_operator' => 'OR'
+      ],
+    ]);
+  }
+}


### PR DESCRIPTION
After granting [permission](https://github.com/compucorp/civihr-employee-portal/pull/460) to HR Admin to access `user-driven message templates`, access to the menu was also implemented in the following PR:

* PCHR-4150: Grant HR Admin access to message template menu - [#2848](https://github.com/compucorp/civihr/pull/2848)