### PR TITLE
PCHR-3369: Fix return value for upgrader

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1034.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1034.php
@@ -39,6 +39,8 @@ trait CRM_HRCore_Upgrader_Steps_1034 {
         'is_active' => TRUE,
       ]);
     }
+
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
## Overview
This PR fixes an upgrader introduced in https://github.com/compucorp/civihr/pull/2776 The upgrader was missing a return TRUE which was forgotten when fixing git conflicts.

## Technical details

The missing `return TRUE` was added to https://github.com/compucorp/civihr/blob/64435a95e1b1d5b4caf90c43a5a968659109012f/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader/Steps/1034.php :

```php
<?php

trait CRM_HRCore_Upgrader_Steps_1034 {

  public function upgrade_1034() {
    // ...

    return TRUE;
  }

}
``` 

