### PR TITLE
PCHR-4166: Set Jenkins failure threshold to 0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,10 +96,10 @@ pipeline {
                 thresholds: [
                   [
                     $class: 'FailedThreshold',
-                    failureNewThreshold: '1',
-                    failureThreshold: '1',
-                    unstableNewThreshold: '1',
-                    unstableThreshold: '1'
+                    failureNewThreshold: '0',
+                    failureThreshold: '0',
+                    unstableNewThreshold: '0',
+                    unstableThreshold: '0'
                   ]
                 ],
                 tools: [
@@ -142,10 +142,10 @@ pipeline {
                 thresholds: [
                   [
                     $class: 'FailedThreshold',
-                    failureNewThreshold: '1',
-                    failureThreshold: '1',
-                    unstableNewThreshold: '1',
-                    unstableThreshold: '1'
+                    failureNewThreshold: '0',
+                    failureThreshold: '0',
+                    unstableNewThreshold: '0',
+                    unstableThreshold: '0'
                   ]
                 ],
                 tools: [


### PR DESCRIPTION
### Problem

The failure threshold in Jenkins was set to `1`. This would make Jenkins mark a build as passed when it had exactly 1 failure, as it can be seen [here](https://jenkins.compucorp.co.uk/blue/organizations/jenkins/Tasks%20and%20Assignments/detail/staging/55/pipeline/45) (Open the details of the JS test to see the reported failure).

### Solution

The threshold was set to `0`, which will make Jenkins mark a build as failed if it has 1 or more failures.

### Comments

The threshold has always been `1` since the [Jenkins file was introduced](https://github.com/compucorp/civihr/pull/2195). There's no explanation why I set it like that, but it was clearly a mistake.