### PR TITLE
PCHR-4062: Hide some sections from Import Screen

### DIFF
--- a/hrui/scss/hrui.scss
+++ b/hrui/scss/hrui.scss
@@ -40,3 +40,14 @@
 .crm-relationship-form-block-is_permission_b_a {
   display: none;
 }
+
+/*This hides some fields on the Import Page*/
+/* stylelint-disable selector-max-id */
+#crm-import-datasource-form-block-dataSource,
+.crm-import-datasource-form-block-contactType,
+.crm-import-datasource-form-block-dedupe,
+.crm-import-datasource-form-block-fieldSeparator,
+.crm-custom-import-uploadfile-from-block-contactType {
+  display: none;
+}
+/* stylelint-enable selector-max-id */


### PR DESCRIPTION
## Overview
This PR hides the following sections from the Import Screen:

**Screen: Import staff/contacts: /civicrm/import/contact?reset=1&force=1**
Contact subtype
Choose Data Source data source field 
Contact type (pre-populated as staff)
Dedupe options
Import Separator

**Screen: Import Job Contracts / Import Job Roles: /civicrm/job/import AND /civicrm/jobroles/import**
Contact subtype
Import Field Separator

**Screen: Import Multi-value Custom Data: /civicrm/import/custom?reset=1**
Contact subtype
Import Field Separator

 This ensures that the default data are still be sent to avoid import errors

## Before
![screenshot_20180913_103906](https://user-images.githubusercontent.com/1692858/45477443-de971280-b741-11e8-951f-bb50e0650586.png)

## After
![screenshot_20180913_103929](https://user-images.githubusercontent.com/1692858/45477488-ea82d480-b741-11e8-8b53-d2749e21f42d.png)

## Technical Details
We are only hidding this fields and not removing it to ensure that the default values are still being sent
```css
#choose-data-source,
.crm-import-datasource-form-block-contactType,
.crm-import-datasource-form-block-dedupe,
.crm-import-datasource-form-block-fieldSeparator,
.crm-custom-import-uploadfile-from-block-contactType {
  display: none;
}```

✅Manual Tests - passed
⏹PHP Unit Tests - not needed