### PR TITLE
PCHR-4065: CHange Staff Directory Page Title

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Upgrader.php
@@ -43,6 +43,8 @@ class CRM_HRCore_Upgrader extends CRM_HRCore_Upgrader_Base {
   use CRM_HRCore_Upgrader_Steps_1033;
   use CRM_HRCore_Upgrader_Steps_1034;
   use CRM_HRCore_Upgrader_Steps_1035;
+  use CRM_HRCore_Upgrader_Steps_1036;
+  use CRM_HRCore_Upgrader_Steps_1037;
 
   /**
    * @var array

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -357,6 +357,7 @@ function hrcore_civicrm_navigationMenu(&$params) {
 function hrcore_civicrm_alterMenu(&$items) {
   $items['civicrm/api']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
   $items['civicrm/styleguide']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
+  $items['civicrm/contact/search/advanced']['title'] = 'Staff Directory';
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR changes the staff directory page title to "Staff Directory". It also adjusts the Upgraders call in Upgrader.php, that was forgotten when solving merge conflict.

## Before
![screenshot_20180914_110549](https://user-images.githubusercontent.com/1692858/45542697-e96da800-b812-11e8-915e-b13dafde3989.png)
The Page title was "Advanced Search"

## After
![screenshot_20180914_113928](https://user-images.githubusercontent.com/1692858/45542705-ee325c00-b812-11e8-9d41-7dd81c6bd9e8.png)
The Page Title is now "Staff Directory"

## Technical Details
for this, the hook_civicrm_alterMenu was used. For changes on this hook to take effect is required to clear the cache.