### PR TITLE
WIP: PCHR-4182: Menu Improvements

### DIFF
--- a/hrui/CRM/Core/BAO/Navigation.php
+++ b/hrui/CRM/Core/BAO/Navigation.php
@@ -306,25 +306,26 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
    * @return string
    */
   public static function buildNavigation() {
-    $navigations = self::buildNavigationTree();
+//    $navigations = self::buildNavigationTree();
     $navigationString = '';
 
-    // run the Navigation  through a hook so users can modify it
-    CRM_Utils_Hook::navigationMenu($navigations);
-    self::fixNavigationMenu($navigations);
-
-    // Hooks have added menu items in an arbitrary order. We need to order by
-    // weight again. I would put this function directly after
-    // CRM_Utils_Hook::navigationMenu but for some reason, fixNavigationMenu is
-    // moving items added by hooks on the end of the menu. Hence I do it
-    // afterwards
-    self::orderByWeight($navigations);
+//    // run the Navigation  through a hook so users can modify it
+//    CRM_Utils_Hook::navigationMenu($navigations);
+//    self::fixNavigationMenu($navigations);
+//
+//    // Hooks have added menu items in an arbitrary order. We need to order by
+//    // weight again. I would put this function directly after
+//    // CRM_Utils_Hook::navigationMenu but for some reason, fixNavigationMenu is
+//    // moving items added by hooks on the end of the menu. Hence I do it
+//    // afterwards
+//    self::orderByWeight($navigations);
+    $navigations = CRM_HRCore_Menu_Main::getItems();
 
     //skip children menu item if user don't have access to parent menu item
     $skipMenuItems = array();
     foreach ($navigations as $key => $value) {
       // Home is a special case
-      if ($value['attributes']['name'] != 'Home') {
+      if ($value['attributes']['label'] != 'Home') {
         $name = self::getMenuName($value, $skipMenuItems);
         if ($name) {
           //separator before
@@ -486,7 +487,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
     $menuName = CRM_Utils_Array::value('name', $value['attributes']);
     $target = CRM_Utils_Array::value('target', $value['attributes']);
 
-    if (in_array($parentID, $skipMenuItems) || !$active) {
+    if (in_array($parentID, $skipMenuItems) && $navID !== NULL) {
       $skipMenuItems[] = $navID;
       return FALSE;
     }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/CustomFields.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/CustomFields.php
@@ -1,0 +1,27 @@
+<?php
+
+class CRM_HRCore_Menu_CustomFields {
+
+  /**
+   * Returns menu Items for custom fields.
+   *
+   * @return array
+   */
+  public static function getItems() {
+    $multipleCustomData = CRM_Core_BAO_CustomGroup::getMultipleFieldGroup();
+
+    $menuItems = [];
+    foreach ($multipleCustomData as $key => $value) {
+      $menuItems[] = [
+        'attributes' => [
+          'label' => $value,
+          'url' => 'civicrm/import/custom?reset=1&id='.$key,
+          'permission' => 'access CiviCRM',
+          'operator' => null,
+        ]
+      ];
+    }
+
+    return $menuItems;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Main.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Main.php
@@ -1,0 +1,1349 @@
+<?php
+
+class CRM_HRCore_Menu_Main {
+
+  /**
+   * Return the main menu Items.
+   *
+   * @return array
+   */
+  public static function getItems() {
+    $menuItems = [
+      [
+        'attributes' =>
+          [
+            'label' => 'Search',
+            'icon' => 'crm-i fa-search',
+            'operator' => '',
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Contacts',
+                  'url' => 'civicrm/contact/search?reset=1',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Advanced Search',
+                  'url' => 'civicrm/contact/search/advanced?reset=1',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Contributions',
+                  'url' => 'civicrm/contribute/search?reset=1',
+                  'permission' => 'access CiviContribute',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Mailings',
+                  'url' => 'civicrm/mailing?reset=1',
+                  'permission' => 'access CiviMail',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Memberships',
+                  'url' => 'civicrm/member/search?reset=1',
+                  'permission' => 'access CiviMember',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Participants',
+                  'url' => 'civicrm/event/search?reset=1',
+                  'permission' => 'access CiviEvent',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find Pledges',
+                  'url' => 'civicrm/pledge/search?reset=1',
+                  'permission' => 'access CiviPledge',
+                  'operator' => '',
+                ],
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Staff',
+            'icon' => 'crm-i fa-users',
+            'operator' => '',
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'New Individual',
+                  'url' => 'civicrm/contact/add?reset=1&ct=Individual',
+                  'permission' => 'add contacts',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'New Household',
+                  'url' => 'civicrm/contact/add?reset=1&ct=Household',
+                  'permission' => 'add contacts',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'New Organization',
+                  'url' => 'civicrm/contact/add?reset=1&ct=Organization',
+                  'permission' => 'add contacts',
+                  'operator' => '',
+                  'separator' => '1',
+                ],
+              'child' =>
+                [
+                  [
+                  'attributes' =>
+                    [
+                      'label' => 'New Health Insurance Provider',
+                      'url' => 'civicrm/contact/add?ct=Organization&cst=Health_Insurance_Provider&reset=1',
+                      'permission' => 'add contacts',
+                      'operator' => NULL,
+                    ],
+                  ],
+                  [
+                  'attributes' =>
+                    [
+                      'label' => 'New Life Insurance Provider',
+                      'url' => 'civicrm/contact/add?ct=Organization&cst=Life_Insurance_Provider&reset=1',
+                      'permission' => 'add contacts',
+                      'operator' => NULL,
+                    ],
+                  ],
+                  [
+                  'attributes' =>
+                    [
+                      'label' => 'New Pension Provider',
+                      'url' => 'civicrm/contact/add?ct=Organization&cst=Pension_Provider&reset=1',
+                      'permission' => 'add contacts',
+                      'operator' => NULL,
+                    ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'New Email',
+                  'url' => 'civicrm/activity/email/add?atype=3&action=add&reset=1&context=standalone',
+                  'operator' => '',
+                  'separator' => '1',
+                ],
+              ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Import Contacts',
+                  'url' => 'civicrm/import/contact?reset=1',
+                  'permission' => 'import contacts',
+                  'operator' => '',
+                ],
+              ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Import / Export',
+                  'permission' => 'access HRJobs',
+                  'operator' => NULL,
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Import Job Contracts',
+                        'url' => 'civicrm/job/import',
+                        'permission' => 'access HRJobs',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Import Job Roles',
+                        'url' => 'civicrm/jobroles/import',
+                        'operator' => NULL,
+                        'separator' => true,
+                      ],
+                  ],
+                ],
+              ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Import Custom Fields',
+                  'url' => 'civicrm/import/custom?reset=1',
+                  'permission' => 'access CiviCRM',
+                  'operator' => NULL,
+                ],
+              'child' => CRM_HRCore_Menu_CustomFields::getItems(),
+              ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'New Group',
+                  'url' => 'civicrm/group/add?reset=1',
+                  'permission' => 'edit groups',
+                  'operator' => '',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Manage Groups',
+                  'url' => 'civicrm/group?reset=1',
+                  'permission' => 'access CiviCRM',
+                  'operator' => '',
+                  'separator' => '1',
+                ],
+              ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Find and Merge Duplicate Contacts',
+                  'url' => 'civicrm/contact/deduperules?reset=1',
+                  'permission' => 'administer dedupe rules,merge duplicate contacts',
+                  'operator' => 'OR',
+                ],
+              ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Tasks',
+            'url' => '',
+            'icon' => 'crm-i fa-list-ul',
+            'permission' => 'access Tasks and Assignments',
+            'operator' => NULL,
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'Tasks',
+                  'url' => 'civicrm/tasksassignments/dashboard#/tasks',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Documents',
+                  'url' => 'civicrm/tasksassignments/dashboard#/documents',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Calendar',
+                  'url' => 'civicrm/tasksassignments/dashboard#/calendar',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Key Dates',
+                  'url' => 'civicrm/tasksassignments/dashboard#/key-dates',
+                  'operator' => NULL,
+                ],
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Leave',
+            'icon' => 'crm-i fa-briefcase',
+            'permission' => 'access leave and absences',
+            'operator' => NULL,
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'Leave Requests',
+                  'url' => 'civicrm/leaveandabsences/dashboard#/requests',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Leave Calendar',
+                  'url' => 'civicrm/leaveandabsences/dashboard#/calendar',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Leave Balances',
+                  'url' => 'civicrm/leaveandabsences/dashboard#/leave-balances',
+                  'operator' => NULL,
+                ],
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Reports',
+            'url' => 'civicrm/reports',
+            'icon' => 'fa fa-table',
+            'permission' => 'access hrreports',
+            'operator' => NULL,
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Configure',
+            'icon' => 'crm-i fa-cog',
+            'permission' => 'administer CiviCRM',
+            'operator' => '',
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'Localise CiviCRM',
+                  'url' => 'civicrm/admin/setting/localization?reset=1',
+                  'permission' => 'access CiviCRM',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Job Contract',
+                  'permission' => 'access CiviCRM',
+                  'operator' => NULL,
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Contract Types',
+                        'url' => 'civicrm/admin/options/hrjc_contract_type?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Normal Places of Work',
+                        'url' => 'civicrm/admin/options/hrjc_location?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Contract End Reasons',
+                        'url' => 'civicrm/admin/options/hrjc_contract_end_reason?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Contract Revision Reasons',
+                        'url' => 'civicrm/admin/options/hrjc_revision_change_reason?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Standard Full Time Hours',
+                        'url' => 'civicrm/standard_full_time_hours',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Pay Scales',
+                        'url' => 'civicrm/pay_scale',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Benefits',
+                        'url' => 'civicrm/admin/options/hrjc_benefit_name?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Deductions',
+                        'url' => 'civicrm/admin/options/hrjc_deduction_name?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Insurance Plan Types',
+                        'url' => 'civicrm/admin/options/hrjc_insurance_plantype?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Other Staff Details',
+                  'permission' => 'access CiviCRM',
+                  'operator' => NULL,
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Prefixes',
+                        'url' => 'civicrm/admin/options/individual_prefix?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Genders',
+                        'url' => 'civicrm/admin/options/gender?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Emergency Contact Relationships',
+                        'url' => 'civicrm/admin/options/relationship_with_employee_20150304120408?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Manager Types',
+                        'url' => 'civicrm/admin/reltype?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Career History',
+                        'url' => 'civicrm/admin/options/occupation_type_20130617111138?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Disability Types',
+                        'url' => 'civicrm/admin/options/type_20130502151940?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Qualifications – Skill Categories',
+                        'url' => 'civicrm/admin/options/category_of_skill_20130510015438?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Qualifications – Skill Levels',
+                        'url' => 'civicrm/admin/options/level_of_skill_20130510015934?reset=1',
+                        'permission' => 'access CiviCRM',
+                        'operator' => NULL,
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Tasks',
+                  'permission' => 'administer CiviCase',
+                  'operator' => NULL,
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Tasks Settings',
+                        'url' => 'civicrm/tasksassignments/settings',
+                        'permission' => 'administer CiviCase',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Task and Document Types',
+                        'url' => 'civicrm/admin/options/activity_type?reset=1',
+                        'permission' => 'administer CiviCase',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Workflow Types',
+                        'url' => 'civicrm/a/#/caseType',
+                        'permission' => 'administer CiviCase',
+                        'operator' => NULL,
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Leave',
+                  'permission' => 'administer leave and absences',
+                  'operator' => NULL,
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Leave Types',
+                        'url' => 'civicrm/admin/leaveandabsences/types?action=browse&reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Leave Periods',
+                        'url' => 'civicrm/admin/leaveandabsences/periods?action=browse&reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Public Holidays',
+                        'url' => 'civicrm/admin/leaveandabsences/public_holidays?action=browse&reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Work Patterns',
+                        'url' => 'civicrm/admin/leaveandabsences/work_patterns?action=browse&reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Leave Settings',
+                        'url' => 'civicrm/admin/leaveandabsences/general_settings',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                        'separator' => '1',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Sickness Reasons',
+                        'url' => 'civicrm/admin/options/hrleaveandabsences_sickness_reason?reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'TOIL to be Accrued',
+                        'url' => 'civicrm/admin/options/hrleaveandabsences_toil_amounts?reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Work Pattern Change Reasons',
+                        'url' => 'civicrm/admin/options/hrleaveandabsences_work_pattern_change_reason?reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Work Pattern Day Equivalents',
+                        'url' => 'civicrm/admin/options/hrleaveandabsences_leave_days_amounts?reset=1',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                        'separator' => '1',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Import Leave Requests',
+                        'url' => 'civicrm/admin/leaveandabsences/import',
+                        'permission' => 'administer leave and absences',
+                        'operator' => NULL,
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Calendar Feeds',
+                        'url' => 'civicrm/admin/leaveandabsences/calendar-feeds',
+                        'permission' => 'can administer calendar feeds',
+                        'operator' => NULL,
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Custom Fields',
+                  'url' => 'civicrm/admin/custom/group?reset=1',
+                  'permission' => 'administer CiviCRM',
+                  'operator' => NULL,
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Administration Console',
+                  'url' => 'civicrm/admin?reset=1',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'System Status',
+                        'url' => 'civicrm/a/#/status',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Configuration Checklist',
+                        'url' => 'civicrm/admin/configtask?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Customize Data and Screens',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Custom Fields',
+                        'url' => 'civicrm/admin/custom/group?reset=1',
+                        'permission' => 'administer CiviCRM',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Profiles',
+                        'url' => 'civicrm/admin/uf/group?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Tags (Categories)',
+                        'url' => 'civicrm/tag?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Activity Types',
+                        'url' => 'civicrm/admin/options/activity_type?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Relationship Types',
+                        'url' => 'civicrm/admin/reltype?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Contact Types',
+                        'url' => 'civicrm/admin/options/subtype?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Dropdown Options',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                    'child' =>
+                      [
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Gender Options',
+                              'url' => 'civicrm/admin/options/gender?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Individual Prefixes (Ms, Mr...)',
+                              'url' => 'civicrm/admin/options/individual_prefix?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Individual Suffixes (Jr, Sr...)',
+                              'url' => 'civicrm/admin/options/individual_suffix?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Instant Messenger Services',
+                              'url' => 'civicrm/admin/options/instant_messenger_service?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Location Types (Home, Work...)',
+                              'url' => 'civicrm/admin/locationType?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Mobile Phone Providers',
+                              'url' => 'civicrm/admin/options/mobile_provider?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Phone Types',
+                              'url' => 'civicrm/admin/options/phone_type?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Website Types',
+                              'url' => 'civicrm/admin/options/website_type?reset=1',
+                              'permission' => 'access root menu items and configurations',
+                              'operator' => '',
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Hours Types',
+                              'url' => 'civicrm/hour/editoption',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Job Contract Pay Scale',
+                              'url' => 'civicrm/pay_scale',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Job Contract Hours/Location',
+                              'url' => 'civicrm/hours_location',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Contract Type',
+                              'url' => 'civicrm/admin/options/hrjc_contract_type?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Normal place of work',
+                              'url' => 'civicrm/admin/options/hrjc_location?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Pay cycle',
+                              'url' => 'civicrm/admin/options/hrjc_pay_cycle?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Benefits',
+                              'url' => 'civicrm/admin/options/hrjc_benefit_name?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Benefit type',
+                              'url' => 'civicrm/admin/options/hrjc_benefit_type?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Deductions',
+                              'url' => 'civicrm/admin/options/hrjc_deduction_name?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Deduction type',
+                              'url' => 'civicrm/admin/options/hrjc_deduction_type?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Reason for change',
+                              'url' => 'civicrm/admin/options/hrjc_revision_change_reason?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                        [
+                          'attributes' =>
+                            [
+                              'label' => 'Reason for Job Contract end',
+                              'url' => 'civicrm/admin/options/hrjc_contract_end_reason?reset=1',
+                              'permission' => 'administer CiviCRM',
+                              'operator' => NULL,
+                            ],
+                        ],
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Display Preferences',
+                        'url' => 'civicrm/admin/setting/preferences/display?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Search Preferences',
+                        'url' => 'civicrm/admin/setting/search?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Date Preferences',
+                        'url' => 'civicrm/admin/setting/preferences/date?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Navigation Menu',
+                        'url' => 'civicrm/admin/menu?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Word Replacements',
+                        'url' => 'civicrm/admin/options/wordreplacements?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Manage Custom Searches',
+                        'url' => 'civicrm/admin/options/custom_search?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Communications',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Organization Address and Contact Info',
+                        'url' => 'civicrm/admin/domain?action=update&reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'FROM Email Addresses',
+                        'url' => 'civicrm/admin/options/from_email_address?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Message Templates',
+                        'url' => 'civicrm/admin/messageTemplates?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Schedule Reminders',
+                        'url' => 'civicrm/admin/scheduleReminders?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Preferred Communication Methods',
+                        'url' => 'civicrm/admin/options/preferred_communication_method?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Label Formats',
+                        'url' => 'civicrm/admin/labelFormats?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Print Page (PDF) Formats',
+                        'url' => 'civicrm/admin/pdfFormats?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Communication Style Options',
+                        'url' => 'civicrm/admin/options/communication_style?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Email Greeting Formats',
+                        'url' => 'civicrm/admin/options/email_greeting?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Postal Greeting Formats',
+                        'url' => 'civicrm/admin/options/postal_greeting?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Addressee Formats',
+                        'url' => 'civicrm/admin/options/addressee?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Localization',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Languages, Currency, Locations',
+                        'url' => 'civicrm/admin/setting/localization?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Address Settings',
+                        'url' => 'civicrm/admin/setting/preferences/address?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Date Formats',
+                        'url' => 'civicrm/admin/setting/date?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Preferred Language Options',
+                        'url' => 'civicrm/admin/options/languages?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Users and Permissions',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Permissions (Access Control)',
+                        'url' => 'civicrm/admin/access?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Synchronize Users to Contacts',
+                        'url' => 'civicrm/admin/synchUser?reset=1',
+                        'permission' => 'access root menu items and configurations',
+                        'operator' => '',
+                      ],
+                  ],
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'System Settings',
+                  'permission' => 'access root menu items and configurations',
+                  'operator' => '',
+                ],
+              'child' => CRM_HRCore_Menu_SystemSettings::getItems(),
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Help',
+            'permission' => 'access CiviCRM',
+            'icon' => 'crm-i fa-question-circle',
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'User Guide',
+                  'url' => 'http://civihr-documentation.readthedocs.io/en/latest/',
+                  'target' => '_blank',
+                  'permission' => 'access CiviCRM',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'CiviHR website',
+                  'url' => 'https://www.civihr.org/',
+                  'target' => '_blank',
+                  'permission' => 'access root menu items and configurations',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Get support',
+                  'url' => 'https://www.civihr.org/support',
+                  'target' => '_blank',
+                  'permission' => 'access CiviCRM',
+                ],
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Developer',
+            'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+            'operator' => 'AND',
+            'icon' => 'crm-i fa-code',
+          ],
+        'child' =>
+          [
+            [
+              'attributes' =>
+                [
+                  'label' => 'API Explorer',
+                  'url' => 'civicrm/api',
+                  'target' => '_blank',
+                  'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                  'operator' => 'AND',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Developer Docs',
+                  'target' => '_blank',
+                  'url' => 'https://civihr.atlassian.net/wiki/spaces/CIV/pages',
+                  'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                  'operator' => 'AND',
+                ],
+            ],
+            [
+              'attributes' =>
+                [
+                  'label' => 'Style Guide',
+                  'target' => '_blank',
+                  'url' => 'https://www.civihr.org/support',
+                  'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                  'operator' => 'AND',
+                ],
+              'child' =>
+                [
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'crm-*',
+                        'url' => 'civicrm/styleguide/crm-star',
+                        'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                        'operator' => 'AND',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Bootstrap',
+                        'url' => 'civicrm/styleguide/bootstrap',
+                        'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                        'operator' => 'AND',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Bootstrap-CiviHR',
+                        'url' => 'civicrm/styleguide/bootstrap-civicrm',
+                        'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                        'operator' => 'AND',
+                      ],
+                  ],
+                  [
+                    'attributes' =>
+                      [
+                        'label' => 'Bootstrap-CiviHR',
+                        'url' => 'civicrm/styleguide/bootstrap-civihr',
+                        'permission' => 'access CiviCRM,access CiviCRM developer menu and tools',
+                        'operator' => 'AND',
+                      ],
+                  ],
+                ],
+            ],
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Self Service Portal',
+            'url' => 'dashboard',
+          ],
+      ],
+    ];
+
+    return $menuItems;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/SystemSettings.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/SystemSettings.php
@@ -1,0 +1,179 @@
+<?php
+
+class CRM_HRCore_Menu_SystemSettings {
+
+  /**
+   * Returns the children menu Items for System settings.
+   *
+   * @return array
+   */
+  public static function getItems() {
+    $menuItems = [
+      [
+        'attributes' =>
+          [
+            'label' => 'Components',
+            'url' => 'civicrm/admin/setting/component?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Connections',
+            'url' => 'civicrm/a/#/cxn',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Extensions',
+            'url' => 'civicrm/admin/extensions?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+            'separator' => '1',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Cleanup Caches and Update Paths',
+            'url' => 'civicrm/admin/setting/updateConfigBackend?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'CMS Database Integration',
+            'url' => 'civicrm/admin/setting/uf?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Debugging and Error Handling',
+            'url' => 'civicrm/admin/setting/debug?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Directories',
+            'url' => 'civicrm/admin/setting/path?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Import/Export Mappings',
+            'url' => 'civicrm/admin/mapping?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Mapping and Geocoding',
+            'url' => 'civicrm/admin/setting/mapping?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Misc (Undelete, PDFs, Limits, Logging, Captcha, etc.)',
+            'url' => 'civicrm/admin/setting/misc?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Multi Site Settings',
+            'url' => 'civicrm/admin/setting/preferences/multisite?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Option Groups',
+            'url' => 'civicrm/admin/options?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Outbound Email (SMTP/Sendmail)',
+            'url' => 'civicrm/admin/setting/smtp?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Payment Processors',
+            'url' => 'civicrm/admin/paymentProcessor?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Resource URLs',
+            'url' => 'civicrm/admin/setting/url?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Safe File Extensions',
+            'url' => 'civicrm/admin/options/safe_file_extension?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'Scheduled Jobs',
+            'url' => 'civicrm/admin/job?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+      [
+        'attributes' =>
+          [
+            'label' => 'SMS Providers',
+            'url' => 'civicrm/admin/sms/provider?reset=1',
+            'permission' => 'access root menu items and configurations',
+            'operator' => '',
+          ],
+      ],
+    ];
+
+    return $menuItems;
+  }
+}


### PR DESCRIPTION
## Overview
Currently the process of adding/modifying a menu item is a bit complex and takes more time than necessary. This task hopes to simplify the process by making it easier to add or modify a menu item.

## Approach
The approach taken is to swap the underlying data source that returns the menu tree array and feed this to Civi so that it can build the Navigation menu for display as usual. 
So rather than fetching the data from the `civicrm_navigation` table, the data would be supplied via a Menu configuration file that returns the menu Items in an array format.

There is also the case of dynamic menu Items whereby the menu items are generated based on some conditions. In a bid to keep things as simple as possible.

A `CRM_HRCore_Menu_Main` class was created. It has a `getItems` function that returns the menu items, the `getItems` function uses the 
(1) `CRM_HRCore_Menu_CustomFields` class, an example of how dynamic menu items can be returned.
(2) `CRM_HRCore_Menu_SystemSettings` class, an example of how the long Menu.php file can be splitted into several files by moving out menu items with particularly large item sets.

## Injecting the Menu Items
The next hurdle was to feed the returned menu items array to Civi so that the Navvigation menu is displayed as usual. In generating the Menu items array, the same structure gotten from the `Navigation.get` API is used but unnecessary fields such as ParentID(since the array have nested items now), NavID, active e.t.c were removed from the array structure. 

The `buildNavigation` method of the `CRM_Core_BAO_Navigation` class (already overriden file in the HRUI extension) was modified to swap in the data source from getting the navigation menu tree  from the db to getting it from `CRM_HRCore_Menu_Main::getItems()`  function. with a few changes to other places in the file due to the unnecessary menu properties that were discarded.

## Alternative approach to Injecting the Menu Items.
In a bit to reduce changes/overrided to core to the barest minimun, an alternative I considered and tried out is to comment out all implementations of the `hook_civicrm_navigationMenu` for all the extensions and implement this hook only in HRCore

```php
function hrcore_civicrm_navigationMenu(&$params) {
  $params = CRM_HRCore_Menu_Main::getItems();
}
```
This approach had its downside because, it means the menu Items will still be fetched from civicrm_navigation table but only overriden in this hook and it would still involve changes to the `buildNavigation` method of the `CRM_Core_BAO_Navigation` because the items came out in a different order on the UI(Because the weight parameter was missing from the array supplied) because it was re-ordered by Civi.


