### PR TITLE
PCHR-4148: Fix issue with blank/incorrect display of Contract length of service field

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -335,6 +335,7 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     $this->upgrade_1040();
     $this->upgrade_1041();
     $this->upgrade_1042();
+    $this->upgrade_1043();
   }
 
   function upgrade_1001() {
@@ -1033,6 +1034,20 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
     civicrm_api3('CustomGroup', 'get', [
       'name' => 'Contact_Length_Of_Service',
       'api.CustomGroup.create' => ['id' => '$value.id', 'is_active' => 0],
+    ]);
+
+    return TRUE;
+  }
+
+  /**
+   * Sets the Contact_Length_Of_Service custom group active
+   *
+   * @return bool
+   */
+  public function upgrade_1043() {
+    civicrm_api3('CustomGroup', 'get', [
+      'name' => 'Contact_Length_Of_Service',
+      'api.CustomGroup.create' => ['id' => '$value.id', 'is_active' => 1],
     ]);
 
     return TRUE;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactFormCustomGroupFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactFormCustomGroupFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_ContactFormCustomGroupFilter {
+
+  /**
+   * Removes some custom groups from the accordion
+   * list on the contact add/edit form page.
+   * Presently, only the Contact_Length_Of_Service
+   * custom group is filtered out.
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => 'Contact_Length_Of_Service',
+    ]);
+
+    if (!$customGroup['id']) {
+      return;
+    }
+
+    $customGroupTree = $form->get_template_vars('groupTree');
+    //remove the Contact_Length_Of_Service from the custom group list.
+    unset($customGroupTree[$customGroup['id']]);
+    $form->assign('groupTree', $customGroupTree);
+  }
+
+  /**
+   * Returns true if current form is for the contact add/edit form.
+   * This indicates if the class should modify the form.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    $expectedFormName = 'CRM_Contact_Form_Contact';
+
+    return $formName === $expectedFormName;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/ContactSummaryCustomGroupFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/PageRun/ContactSummaryCustomGroupFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+class CRM_HRCore_Hook_PageRun_ContactSummaryCustomGroupFilter {
+
+  /**
+   * Removes certain custom groups from the contact card
+   * display on the contact summary page on the personal
+   * details tab so that the custom fields for these custom
+   * groups will not be displayed. Presently, only the
+   * Contact_Length_Of_Service custom group is filtered out.
+   *
+   * @param CRM_Core_Page $page
+   */
+  public function handle($page) {
+    if (!$this->shouldHandle($page)) {
+      return;
+    }
+
+    $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+      'name' => 'Contact_Length_Of_Service',
+    ]);
+
+    if (!$customGroup['id']) {
+      return;
+    }
+
+    $customData = $page->get_template_vars('viewCustomData');
+    //remove the Contact_Length_Of_Service from the custom group list.
+    unset($customData[$customGroup['id']]);
+    $page->assign('viewCustomData', $customData);
+  }
+
+
+  /**
+   * Checks if this is the right page
+   *
+   * @param CRM_Core_Page $page
+   *
+   * @return bool
+   */
+  public function shouldHandle($page) {
+    return $page instanceof CRM_Contact_Page_View_Summary;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -119,6 +119,7 @@ function hrcore_civicrm_buildForm($formName, &$form) {
     new CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
     new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
+    new CRM_HRCore_Hook_BuildForm_ContactFormCustomGroupFilter()
   ];
 
   foreach ($listeners as $currentListener) {
@@ -316,6 +317,7 @@ function hrcore_civicrm_pageRun($page) {
   $hooks = [
     new CRM_HRCore_Hook_PageRun_LocationTypeFilter(),
     new CRM_HRCore_Hook_PageRun_RelationshipTypesFilter(),
+    new CRM_HRCore_Hook_PageRun_ContactSummaryCustomGroupFilter()
   ];
 
   foreach ($hooks as $hook) {


### PR DESCRIPTION
## Problem
The Contact_Length_Of_Service custom group was disabled as part of https://compucorp.atlassian.net/browse/PCHR-3608 in https://github.com/compucorp/civihr/blob/ca1854d9030af597f0d29eea9b5fe33f0a8f9c6b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php#L1035. The reason was to hide the Contact Length Of Service  display on the contact summary details page(personal details tab) and the edit contact page. However after disabling this, updates to the `Length_Of_Service`  custom field belonging to the Contact_Length_Of_Service custom group stopped working, this resulted in a blank value for new contacts with newly created contracts and the values stopped updating for old contacts with existing contracts.

<img width="363" alt="civihr_staff compucorp co uk _ staging54 2018-09-28 16-38-40" src="https://user-images.githubusercontent.com/6951813/46218598-f7581880-c33c-11e8-837b-887028494727.png">

## Solution
The approach to fix the issue is by adding another upgrader to make the Contact_Length_Of_Service custom group active and using hooks to hide the Contact Length Of Service  display on the contact summary details page(personal details tab) and the edit contact page.
This ensured that these fields stay hidden from view and also that that updates to the `Length_Of_Service`  custom field now works https://github.com/compucorp/civihr/blob/3773644e1b0f064dc6978681c2698838ac51a814/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContract.php#L303

Contact Length Of Service  display on the contact summary details page(personal details tab) contact card section and the on the accordion list on the add/edit contact page remains hidden.

<img width="640" alt="monosnap 2018-09-28 16-53-38" src="https://user-images.githubusercontent.com/6951813/46219391-296a7a00-c33f-11e8-8702-3bea4804591a.png">
<img width="640" alt="monosnap 2018-09-28 16-53-04" src="https://user-images.githubusercontent.com/6951813/46219393-296a7a00-c33f-11e8-92ce-6ef3ab95da4c.png">


## Technical Details
HRCore's implementation of `hrcore_civicrm_pageRun` and `hrcore_civicrm_buildForm` was used to remove the Contact_Length_Of_Service custom group from the contact summary page and the contact add/edit form respectively.

