### PR TITLE
PCHR-4173: Local Admin Role is not available

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/CreateUserRecordTaskForm.php
@@ -180,7 +180,7 @@ class CRM_HRCore_Form_CreateUserRecordTaskForm extends AbstractDrupalInteraction
    * @return array
    */
   private function getAssignableRoles() {
-    $roles = ['HR Admin', 'Manager', 'Staff'];
+    $roles = ['HR Admin', 'Manager', 'Staff', 'Regional HR Admin'];
     $assignable = [];
 
     foreach ($roles as $role) {


### PR DESCRIPTION
## Overview
When creating a user account by `HR Admin`, option for assigning `Regional HR Admin` role to user account was not available. This PR fixes the issue.

## Before
<img width="665" alt="before_fixes" src="https://user-images.githubusercontent.com/1507645/46344787-4bfbdc00-c63a-11e8-962d-f3aa377c9ca9.png">


## After
<img width="653" alt="after_fixes" src="https://user-images.githubusercontent.com/1507645/46344802-51592680-c63a-11e8-9ff2-dc9db666352c.png">


## Technical Details
Regional HR Admin was added to the list of roles that can be assigned
```
$roles = ['HR Admin', 'Manager', 'Staff', 'Regional HR Admin'];
```

---

- [x] Manual Testing Pass
