### PR TITLE
PCHR-3039: Allow admins to change Absence Type of open Leave Requests

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -14,12 +14,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
   private $leaveManagerService;
 
   /**
-   * @var array|null
-   *   Stores the list of option values for the LeaveRequest status_id field.
-   */
-  private static $leaveStatuses;
-
-  /**
    * CRM_HRLeaveAndAbsences_Service_LeaveRequestRights constructor.
    *
    * @param \CRM_HRLeaveAndAbsences_Service_LeaveManager $leaveManagerService
@@ -57,13 +51,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
       return TRUE;
     }
 
-    $leaveRequestStatuses = self::getLeaveRequestStatuses();
-    $openStatuses = [
-      $leaveRequestStatuses['awaiting_approval'],
-      $leaveRequestStatuses['more_information_required']
-    ];
-
-    $isOpenLeaveRequest = in_array($statusID, $openStatuses);
+    $isOpenLeaveRequest = in_array($statusID, LeaveRequest::getOpenStatuses());
     $currentUserIsLeaveContact = $this->currentUserIsLeaveContact($contactID);
 
     if ($currentUserIsLeaveContact && $isOpenLeaveRequest) {
@@ -88,9 +76,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canChangeAbsenceTypeFor($contactID, $statusID) {
-    $leaveRequestStatuses = self::getLeaveRequestStatuses();
-    return $this->currentUserIsLeaveContact($contactID) &&
-           in_array($statusID, [$leaveRequestStatuses['awaiting_approval'], $leaveRequestStatuses['more_information_required']]);
+    $isOpenLeaveRequest = in_array($statusID, LeaveRequest::getOpenStatuses());
+
+    return $this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest;
   }
 
   /**
@@ -159,19 +147,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    */
   private function currentUserIsLeaveContact($contactID) {
     return CRM_Core_Session::getLoggedInContactID() == $contactID;
-  }
-
-  /**
-   * Returns the array of the option values for the LeaveRequest status_id field.
-   *
-   * @return array
-   */
-  private static function getLeaveRequestStatuses() {
-    if (is_null(self::$leaveStatuses)) {
-      self::$leaveStatuses = array_flip(LeaveRequest::buildOptions('status_id', 'validate'));
-    }
-
-    return self::$leaveStatuses;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -77,8 +77,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    */
   public function canChangeAbsenceTypeFor($contactID, $statusID) {
     $isOpenLeaveRequest = in_array($statusID, LeaveRequest::getOpenStatuses());
+    $isLeaveContactOrAdmin = $this->currentUserIsLeaveContact($contactID) || $this->currentUserIsAdmin();
 
-    return $this->currentUserIsLeaveContact($contactID) && $isOpenLeaveRequest;
+    return $isLeaveContactOrAdmin && $isOpenLeaveRequest;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -228,6 +228,34 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   }
 
   /**
+   * @dataProvider openLeaveRequestStatusesDataProvider
+   */
+  public function testCanChangeAbsenceTypeForReturnsTrueWhenCurrentUserIsAdminAndTheLeaveRequestIsOpen($status) {
+    $contactID = 2;
+
+    $this->assertTrue(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
+        $contactID,
+        $status
+      )
+    );
+  }
+
+  /**
+   * @dataProvider closedLeaveRequestStatusesDataProvider
+   */
+  public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserIsAdminAndTheLeaveRequestIsClosed($status) {
+    $contactID = 2;
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
+        $contactID,
+        $status
+      )
+    );
+  }
+
+  /**
    * @dataProvider leaveRequestStatusesDataProvider
    */
   public function testCanChangeAbsenceTypeForReturnsFalseWhenCurrentUserNotLeaveContactIrrespectiveOfStatusPassed($status) {
@@ -235,13 +263,6 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
 
     $this->assertFalse(
       $this->getLeaveRequestRightsForLeaveManagerAsCurrentUser()->canChangeAbsenceTypeFor(
-        $contactID,
-        $status
-      )
-    );
-
-    $this->assertFalse(
-      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeAbsenceTypeFor(
         $contactID,
         $status
       )


### PR DESCRIPTION
## Overview

According to the specification, admins should be able to change the Absence Type of any open Leave Request, the same way as staff members are allowed to do that to their own Leave Requests. However, the current implementation allowed only staff members to do that.

## Before

Admins could not change the Absence Type of an open Leave Request. When trying to do that, they would get a "You are not allowed to change the type of a request" error.

## After

Admins can change the Absence Type of an open Leave Request

## Comments

Before actually making the changes for this fix, on  https://github.com/compucorp/civihr/pull/2876/commits/b4355593b00f81a3ab7bbd7c49ca0c639c16095a I did a quick refactoring of the `LeaveRequestRights` class by replacing a helper method to get the Leave Request statuses with a call to `LeaveRequest::getOpenStatuses()`

