### PR TITLE
PCHR-4207: Add leave type category label

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -213,6 +213,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   }
 
   /**
+   * Returns a list of all possible categories for absence type
+   *
+   * @return array|bool
+   */
+  public static function getCategories() {
+    return self::buildOptions('category');
+  }
+
+  /**
    * Unset the is_default flag for every AbsenceType that has it
    */
   private static function unsetDefaultTypes() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php
@@ -1,10 +1,12 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_Service_AbsenceType as AbsenceTypeService;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 
 class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
 
-  private $links = array();
+  private $links = [];
+  private $categories = [];
 
   /**
    * @var \CRM_HRLeaveAndAbsences_Service_AbsenceType
@@ -32,6 +34,7 @@ class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
           $this->calculateLinksMask($object),
           ['id' => $object->id]
       );
+      $rows[$object->id]['category'] = $this->getCategoryLabel($rows[$object->id]['category']);
     }
 
     $returnURL = CRM_Utils_System::url('civicrm/admin/leaveandabsences/types', 'reset=1');
@@ -182,5 +185,22 @@ class CRM_HRLeaveAndAbsences_Page_AbsenceType extends CRM_Core_Page_Basic {
   private function canNotDelete($absenceType) {
     return $this->absenceTypeService->absenceTypeHasEverBeenUsed($absenceType->id)
            || $absenceType->is_reserved;
+  }
+
+  /**
+   * Retrieves the category label from option value
+   *
+   * @param int $categoryId
+   *
+   * @return mixed
+   */
+  private function getCategoryLabel($categoryId) {
+    if (empty($this->categories)) {
+      $this->categories = AbsenceType::getCategories();
+    }
+
+    if (array_key_exists($categoryId, $this->categories)) {
+      return $this->categories[$categoryId];
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
@@ -17,6 +17,7 @@
               <th>{ts}Title{/ts}</th>
               <th>{ts}Allow Accruals?{/ts}</th>
               <th>{ts}Is default?{/ts}</th>
+              <th>{ts}Category{/ts}</th>
               <th>{ts}Order{/ts}</th>
               <th>{ts}Enabled/Disabled{/ts}</th>
               <th>{ts}Actions{/ts}</th>
@@ -26,6 +27,7 @@
                 <td data-field="title">{$row.title|escape}</td>
                 <td>{if $row.allow_accruals_request eq 1} {ts}Yes{/ts} {else} {ts}No{/ts} {/if}</td>
                 <td>{if $row.is_default eq 1}<i class="fa fa-check"></i>{/if}</td>
+                <td>{$row.category}</td>
                 <td>{$row.weight}</td>
                 <td>{if $row.is_active eq 1} {ts}Enabled{/ts} {else} {ts}Disabled{/ts} {/if}</td>
                 <td>{$row.action|replace:'xx':$row.id}</td>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -865,4 +865,16 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
     $this->assertFalse($absenceType->isCalculationUnitInHours());
   }
+
+  public function testGetCategories() {
+    $categoryOptions = [
+      '1' => 'Leave',
+      '2' => 'Sickness',
+      '3' => 'TOIL',
+      '4' => 'Custom'
+    ];
+    $categories = AbsenceType::getCategories();
+
+    $this->assertEquals($categories, $categoryOptions);
+  }
 }


### PR DESCRIPTION
## Overview
A new field called category was introduced in a previous PR. This PR adds the the category field to leave/absence type listing page.

## Before
<img width="677" alt="before_category" src="https://user-images.githubusercontent.com/1507645/46605349-1d29ae00-caf1-11e8-8341-68781ce024ce.png">


## After
<img width="678" alt="after_category" src="https://user-images.githubusercontent.com/1507645/46605367-27e44300-caf1-11e8-8328-a35b37364c4e.png">


## Technical Details
The categories were fetched using BAO for AbsenceType and mapped to each of the category id in absence type table.
```
private function getCategoryLabel($categoryId) {
  if (empty($this->categories)) {
    $this->categories = AbsenceType::getCategories();
  }

  $categoryLabel = array_search($categoryId, $this->categories);
  if ($categoryLabel !== NULL) {
    return $categoryLabel;
  }
}
```