### PR TITLE
PCHR-4209: Move delete leave type button

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsenceType.php
@@ -396,12 +396,6 @@ class CRM_HRLeaveAndAbsences_Form_AbsenceType extends CRM_Core_Form {
       ['type' => 'cancel', 'name' => ts('Cancel')],
     ];
 
-    $defaultValues = $this->setDefaultValues();
-    $is_reserved   = empty($defaultValues['is_reserved']) ? FALSE : TRUE;
-    if (($this->_action & CRM_Core_Action::UPDATE) && !$is_reserved) {
-      $buttons[] = ['type' => 'delete', 'name' => ts('Delete')];
-    }
-
     return $buttons;
   }
 


### PR DESCRIPTION
## Overview
When editing absence type, delete button was shown by default for non reserved types. This PR removes the button, meaning delete button is only available on the listing page and not on both listing and editing page. 

## Before
![before_delete](https://user-images.githubusercontent.com/1507645/46616631-e06eae80-cb12-11e8-91c0-a447748c1d38.gif)


## After
![after_delete](https://user-images.githubusercontent.com/1507645/46616638-e5cbf900-cb12-11e8-99f4-d369e3111087.gif)


## Comment
Implementation for showing the button for un-reserved absence types was removed