### PR TITLE
PCHR-4249: Existing Leave Types to be Working after Upgrade

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -33,6 +33,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1033;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1034;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1035;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1036;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1036.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1036.php
@@ -64,6 +64,9 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1036 {
       $absenceType->allow_accruals_request = 0;
       $absenceType->must_take_public_holiday_as_leave = 0;
       $absenceType->allow_carry_forward = 0;
+      $absenceType->max_number_of_days_to_carry_forward = 0;
+      $absenceType->carry_forward_expiration_duration = 0;
+      $absenceType->carry_forward_expiration_unit = 0;
     }
 
     AbsenceType::create($absenceType->toArray());

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1036.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1036.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1036 {
+
+  /**
+   * Updates absence type category for existing records
+   *
+   * @return bool
+   */
+  public function upgrade_1036() {
+    $categoryOptions = array_flip(AbsenceType::buildOptions('category', 'validate'));
+    $absenceTypes = $this->up1036_getAbsenceTypes();
+    foreach ($absenceTypes as $absenceType) {
+      if (empty($absenceType->category)) {
+        $this->up1036_updateAbsenceTypeCategory($absenceType, $categoryOptions);
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Retrieves all absence types
+   *
+   * @return array
+   */
+  private function up1036_getAbsenceTypes() {
+    $absenceTypes = [];
+    $absenceType = new AbsenceType();
+    $absenceType->find();
+    while($absenceType->fetch()) {
+      $absenceTypes[] = clone $absenceType;
+    }
+
+    return $absenceTypes;
+  }
+
+  /**
+   * Updates absence type category and optional fields
+   *
+   * @param CRM_HRLeaveAndAbsences_BAO_AbsenceType $absenceType
+   * @param array $categoryOptions
+   */
+  private function up1036_updateAbsenceTypeCategory($absenceType, $categoryOptions) {
+    if ($absenceType->is_sick) {
+      $absenceType->category = $categoryOptions['sickness'];
+    }
+
+    if ($absenceType->allow_accruals_request) {
+      $absenceType->category = $categoryOptions['toil'];
+    }
+
+    if ($absenceType->is_sick && $absenceType->allow_accruals_request) {
+      $absenceType->category = $categoryOptions['custom'];
+    }
+
+    if (empty($absenceType->category)) {
+      $absenceType->category = $categoryOptions['leave'];
+    }
+    elseif ($absenceType->category === $categoryOptions['sickness']) {
+      $absenceType->add_public_holiday_to_entitlement = 0;
+      $absenceType->allow_accruals_request = 0;
+      $absenceType->must_take_public_holiday_as_leave = 0;
+      $absenceType->allow_carry_forward = 0;
+    }
+
+    AbsenceType::create($absenceType->toArray());
+  }
+}


### PR DESCRIPTION
## Overview
This PR updates existing sites absence type by linking the newly created category column to option group used for listing available values.

## Before
Absence type category were not initialized

## After
Absence type category are now initialized

## Technical Details
When the category column was created in `civicrm_hrleaveandabsences_absence_type` table, it was done with `NOT NULL` property. This implies the value will be empty for existing sites. This was used as criteria for differentiating between new and existing systems. 

All absence types were first fetched
```
private function up1036_getAbsenceTypes() {
  $absenceTypes = [];
  $absenceType = new AbsenceType();
  $absenceType->find();
  while($absenceType->fetch()) {
    $absenceTypes[] = clone $absenceType;
  }

  return $absenceTypes;
}
```
and then updated only if category was empty.
```
...
  foreach ($absenceTypes as $absenceType) {
    if (empty($absenceType->category)) {
      $this->up1036_updateAbsenceTypeCategory($absenceType, $categoryOptions);
    }
  }
...
}
```

All the categories were updated based on these criteria:
1. is_sick: Sickness
2. allow_accruals_request: TOIL
3. is_sick and allow_accruals_request: Custom
4. Others: Leave 

In addition to updating the categories, leave types that have *_is_sick_* have the following additional update:
* By default should public holiday be added to the default entitlement?" Set this to NO.
* Set field "Allow staff to request to accrue additional leave of this type during the period" to NO
* Set "Must staff take public holiday as leave?" to NO
* Set "allow leave of this type to be carried forward from one period to another" to NO
* Set "Maximum amount of leave that can be carried forward " to 0
* Set "Carry forward expiration duration and unit" to 0