### PR TITLE
PCHR-4302: Remove Search Menu and Sub Items

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
@@ -3,14 +3,6 @@
 return [
   'Home' => 'civicrm/tasksassignments/dashboard#/tasks',
 
-  'Search' => [
-    'icon' => 'crm-i fa-search',
-    'children' => [
-      'Find Contacts' => 'civicrm/contact/search?reset=1',
-      'Advanced Search' => 'civicrm/contact/search/advanced?reset=1',
-    ],
-  ],
-
   'Staff' => [
     'icon' => 'crm-i fa-users',
     'children' => [


### PR DESCRIPTION
## Overview
As part of the Staff Menu improvements Epic, this PR removes the Search menu and its sub menu items.

## Before
The  Search menu and its sub menu items were present.
<img width="639" alt="dashboard _ staging54 2018-10-16 14-25-23" src="https://user-images.githubusercontent.com/6951813/47020114-8d1ee080-d150-11e8-908a-746094c6f672.png">


## After
The  Search menu and its sub menu items are no longer present.

<img width="640" alt="dashboard _ staging54 2018-10-16 14-28-49" src="https://user-images.githubusercontent.com/6951813/47020133-9445ee80-d150-11e8-8f01-5cb4947a83c1.png">
