### PR TITLE
PCHR-4304: Move Import related Items to the Configure menu.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/CustomFields.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/CustomFields.php
@@ -4,7 +4,7 @@
 class CRM_HRCore_Menu_Config_CustomFields {
 
   /**
-   *  Returns menu Items for Custom fields Menu.
+   *  Returns menu Items for Custom fields Imports.
    *
    * @return array
    */
@@ -12,7 +12,8 @@ class CRM_HRCore_Menu_Config_CustomFields {
     $multipleCustomData = CRM_Core_BAO_CustomGroup::getMultipleFieldGroup();
     $menuItems = [];
     foreach ($multipleCustomData as $key => $value) {
-      $menuItems[$value] = [
+      $label = 'Import' . ' ' . $value;
+      $menuItems[$label] = [
         'url' => 'civicrm/import/custom?reset=1&id='.$key,
         'permission' => 'access CiviCRM',
       ];

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/Import.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/Import.php
@@ -1,0 +1,20 @@
+<?php
+
+use CRM_HRCore_Menu_Config_CustomFields as CustomFields;
+use CRM_HRCore_ExtensionUtil as ExtensionUtil;
+
+class CRM_HRCore_Menu_Config_Import {
+
+  /**
+   * Returns the Import related menu Items
+   *
+   * @return array
+   */
+  public static function getItems() {
+    $importFile = CRM_Core_Resources::singleton()->getPath(ExtensionUtil::LONG_NAME, 'config/menu/import.php');
+    $staticImportItems = include $importFile;
+    $customFieldImports = CustomFields::getItems();
+
+    return array_merge($staticImportItems, $customFieldImports);
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/config/menu/configure.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/configure.php
@@ -182,6 +182,10 @@ return [
     ],
   ],
 
+  'Import' => [
+    'children' => CRM_HRCore_Menu_Config_Import::getItems(),
+  ],
+
   'Custom Fields' => [
     'url' => 'civicrm/admin/custom/group?reset=1',
     'permission' => 'administer CiviCRM',

--- a/uk.co.compucorp.civicrm.hrcore/config/menu/import.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/import.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+  'Import Staff' => [
+    'url' => 'civicrm/import/contact?reset=1',
+    'permission' => 'import contacts',
+  ],
+
+  'Import Job Contracts' => [
+    'url' => 'civicrm/job/import',
+    'permission' => 'access HRJobs',
+  ],
+
+  'Import Job Roles' => [
+    'url' => 'civicrm/jobroles/import',
+    'permission' => 'access HRJobs'
+  ],
+];


### PR DESCRIPTION
## Overview
As part of the changes introduced by the Staff menu improvements epic, this PR adds the import related menu items under the Configure menu. The import menu items themselves are under the menu heading 'Import'. The import menu items comprises of static menu import items and dynamic import items which are basically for custom fields and these menu items may change depending on the custom fields present on a site.

## Before
The Import related menu Items were not under 'Configure' Menu.

<img width="341" alt="dashboard _ staging54 2018-10-17 11-48-12" src="https://user-images.githubusercontent.com/6951813/47081867-bea4b400-d203-11e8-9cfa-508d77a271ba.png">

## After
The Import related menu Items are now  under the 'Configure' Menu.

<img width="341" alt="dashboard _ staging54 2018-10-17 11-46-32" src="https://user-images.githubusercontent.com/6951813/47081870-c49a9500-d203-11e8-95fe-4e6812147f2d.png">

## Technical Details
A new class `CRM_HRCore_Menu_Config_Import` was created to merge the static import menu items with the dynamic custom fields import menu items and return the resulting import menus.

``` php
 public static function getItems() {
    $importFile = CRM_Core_Resources::singleton()->getPath(ExtensionUtil::LONG_NAME, 'config/menu/import.php');
    $staticImportItems = include $importFile;
    $customFieldImports = CustomFields::getItems();

    return array_merge($staticImportItems, $customFieldImports);
  }
```