### PR TITLE
PCHR-4305: Filter Unwanted Fields From Import Contact Screen.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactImportFieldsFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ContactImportFieldsFilter.php
@@ -1,0 +1,74 @@
+<?php
+
+class CRM_HRCore_Hook_BuildForm_ContactImportFieldsFilter {
+
+  /**
+   * @var array
+   *  A an array of restricted fields as keys and
+   *  the default values they are to be set to
+   *  as values.
+   */
+  private $restrictedFields = [
+    'dataSource' => CRM_Import_DataSource_CSV::class,
+    'contactType' => CRM_Import_Parser::CONTACT_INDIVIDUAL,
+    'dedupe' => NULL,
+    'fieldSeparator' => ',',
+  ];
+
+  /**
+   * Checks if the form is the contact import form and
+   * performs some logic.
+   *
+   * @param string $formName
+   * @param CRM_Core_Form $form
+   */
+  public function handle($formName, &$form) {
+    if (!$this->shouldHandle($formName)) {
+      return;
+    }
+
+    $this->filterImportFields($form);
+  }
+
+  /**
+   * Freezes the restricted fields and hides them from view and
+   * also sets the default expected values for these fields to
+   * avoid validation issues.
+   *
+   * @param CRM_Core_Form $form
+   */
+  private function filterImportFields($form) {
+    $hiddenOptionsStyle = '#choose-data-source';
+    $defaults = $form->_defaultValues;
+
+    foreach ($this->restrictedFields as $field => $defaultValue) {
+      if ($form->elementExists($field)) {
+        $hiddenOptionsStyle .= ",  .crm-import-datasource-form-block-$field";
+        $form->freeze($field);
+        if ($defaultValue) {
+          $defaults[$field] = $defaultValue;
+        }
+      }
+    }
+
+    $hiddenOptionsStyle .= ' { display: none; }';
+    CRM_Core_Resources::singleton()->addStyle(
+      $hiddenOptionsStyle,
+      CRM_Core_Resources::DEFAULT_WEIGHT,
+      'page-header'
+    );
+    $form->setDefaults($defaults);
+  }
+
+  /**
+   * Returns true if current form is for contact import.
+   * This indicates if the class should modify the form.
+   *
+   * @param string $formName
+   *
+   * @return bool
+   */
+  private function shouldHandle($formName) {
+    return $formName === CRM_Contact_Import_Form_DataSource::class;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -119,7 +119,8 @@ function hrcore_civicrm_buildForm($formName, &$form) {
     new CRM_HRCore_Hook_BuildForm_ContactAdvancedSearch(),
     new CRM_HRCore_Hook_BuildForm_LocalisationPageFilter(),
     new CRM_HRCore_Hook_BuildForm_OptionEditPathFilter(),
-    new CRM_HRCore_Hook_BuildForm_ContactFormCustomGroupFilter()
+    new CRM_HRCore_Hook_BuildForm_ContactFormCustomGroupFilter(),
+    new CRM_HRCore_Hook_BuildForm_ContactImportFieldsFilter()
   ];
 
   foreach ($listeners as $currentListener) {


### PR DESCRIPTION
## Overview
As part of the changes introduced by the Staff menu improvements epic, this PR removes hides some unwanted fields and their labels from the Import Contacts page.

## Before
The contact import screen was un-modified.

<img width="603" alt="import contacts _ staging54 2018-10-17 13-46-06" src="https://user-images.githubusercontent.com/6951813/47090409-c6bc1e00-d21a-11e8-9e7d-a4693e8fc974.png">


## After
The following fields were hidden from the import contacts page. In order to avoid validation issues and also prevent unexpected results, the default expected values of these fields were also set.

1. Choose Data Source data source field 
2. Contact type 
3. Dedupe options
4. Import Field Separator

<img width="620" alt="import contacts _ staging54 2018-10-17 14-37-00" src="https://user-images.githubusercontent.com/6951813/47090394-bdcb4c80-d21a-11e8-9e90-ab282148487d.png">


## Technical Details
Hook `hrcore_civicrm_buildForm` was used to hide freeze these fields and also hide them by injecting appropriate CSS into the form page.

## Manual Testing
A sample CSV was uploaded to create contacts and the contacts were created as expected with no errors to make sure that the functionality still works as expected.