### PR TITLE
PCHR-4306: Filter Unwanted Fields From Job Roles/Job Contract Import Page

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Form/DataSource.php
@@ -61,6 +61,8 @@ class CRM_Hrjobroles_Import_Form_DataSource extends CRM_Import_Form_DataSource {
     $this->addGroup($duplicateOptions, 'onDuplicate',
       ts('On duplicate entries')
     );
+
+    $this->setDefaults(['fieldSeparator' => ',']);
   }
 
   /**

--- a/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
+++ b/com.civicrm.hrjobroles/templates/CRM/Hrjobroles/Import/Form/DataSource.tpl
@@ -51,7 +51,7 @@
                <span class="description">{ts}Check this box if the first row of your file consists of field names (Example: 'Contract ID', 'Role Title', 'Start Date').{/ts}</span>
            </td>
         </tr>
-        <tr class="crm-import-datasource-form-block-fieldSeparator">
+        <tr class="crm-import-datasource-form-block-fieldSeparator hiddenElement">
           <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
           <td>{$form.fieldSeparator.html}</td>
         </tr>

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Form/DataSource.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Form/DataSource.php
@@ -65,21 +65,22 @@ class CRM_Hrjobcontract_Import_Form_DataSource extends CRM_Import_Form_DataSourc
       ts('Import Mode')
     );
 
-    $this->setDefaults(array(
+    $this->setDefaults([
       'importMode' =>
         CRM_Hrjobcontract_Import_Parser::IMPORT_CONTRACTS,
-    ));
+    ]);
 
-    $this->setDefaults(array(
+    $this->setDefaults([
       'onDuplicate' =>
         CRM_Import_Parser::DUPLICATE_SKIP,
-    ));
+    ]);
 
-    $this->setDefaults(array(
+    $this->setDefaults([
         'contactType' =>
           CRM_Import_Parser::CONTACT_INDIVIDUAL,
-      )
-    );
+    ]);
+
+    $this->setDefaults(['fieldSeparator' => ',']);
   }
 
   /**

--- a/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/DataSource.tpl
+++ b/hrjobcontract/templates/CRM/Hrjobcontract/Import/Form/DataSource.tpl
@@ -62,7 +62,7 @@
                 </span>
             </td>
   </tr>
-     <tr class="crm-import-datasource-form-block-fieldSeparator">
+     <tr class="crm-import-datasource-form-block-fieldSeparator hiddenElement">
        <td class="label">{$form.fieldSeparator.label} {help id='id-fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
        <td>{$form.fieldSeparator.html}</td>
      </tr>


### PR DESCRIPTION
## Overview
As part of the changes introduced by the Staff menu improvements epic, this PR removes hides some unwanted fields and their labels from the Job contract and Job roles Import pages.

## Before
Job contract and Job roles Import pages was un-modified.

<img width="604" alt="import job roles _ staging54 2018-10-18 14-34-04" src="https://user-images.githubusercontent.com/6951813/47160774-8c20b700-d2e8-11e8-84a3-352cdb713c52.png">


<img width="602" alt="import job contracts _ staging54 2018-10-18 14-35-27" src="https://user-images.githubusercontent.com/6951813/47160676-58de2800-d2e8-11e8-91dc-8137dffbe218.png">

## After
The Import Field Separator field was hidden from the Job contract and Job roles Import pages. In order to avoid validation issues and also prevent unexpected results, the default expected value for field was also set.

<img width="608" alt="import job roles _ staging54 2018-10-18 15-03-15" src="https://user-images.githubusercontent.com/6951813/47160670-58459180-d2e8-11e8-9394-ebcf8dc3a426.png">
<img width="601" alt="import job contracts _ staging54 2018-10-18 15-02-13 1" src="https://user-images.githubusercontent.com/6951813/47160673-58459180-d2e8-11e8-91cf-b349597f6fc5.png">

## Technical details
The core css class [here](https://github.com/civicrm/civicrm-core/blob/master/css/civicrm.css#L26-L29) was used to hide the Import Field Separator field from the view.