### PR TITLE
PCHR-4308: Update Import Contact Page Title

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -378,6 +378,7 @@ function hrcore_civicrm_coreResourceList(&$items, $region) {
 function hrcore_civicrm_alterMenu(&$items) {
   $items['civicrm/api']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
   $items['civicrm/styleguide']['access_arguments'] = [['access CiviCRM', 'access CiviCRM developer menu and tools'], "and"];
+  $items['civicrm/import/contact']['title'] = 'Import Staff';
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR updates the page title of the import contact page.

## Before
The page title of the import contact page was unchanged

<img width="603" alt="import contacts _ staging54 2018-10-19 09-46-13" src="https://user-images.githubusercontent.com/6951813/47207997-9f816000-d384-11e8-977f-28b62af6aa10.png">

## After
The page title of the import contact page was updated from 'Import Contacts' to 'Import Staff'

<img width="606" alt="import staff _ staging54 2018-10-19 09-47-35" src="https://user-images.githubusercontent.com/6951813/47208009-a5774100-d384-11e8-9c9e-e709fb9bba90.png">

