### PR TITLE
PCHR-4217: Schema Fixes for Absence Type Log Table

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1035.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1035.php
@@ -17,6 +17,10 @@ trait CRM_HRLeaveAndAbsences_Upgrader_Step_1035 {
     $absenceTypeTable = AbsenceType::getTableName();
     if (SchemaHandler::checkIfFieldExists($absenceTypeTable, 'is_default')) {
       CRM_Core_DAO::executeQuery("ALTER TABLE {$absenceTypeTable} DROP COLUMN is_default");
+      // This helps to fix issues with trigger when logging is enabled
+      // as a result of log table structure not being updated with column modifications
+      $logging = new CRM_Logging_Schema();
+      $logging->fixSchemaDifferencesFor($absenceTypeTable, [], TRUE);
     }
 
     return TRUE;


### PR DESCRIPTION
## Overview
This PR fixes issue with absence type sql operations on existing sites whenever logging is enabled.

## Before
Carrying out SQL operations generates error as a result of log table not being synchronized appropriately with changes on `civicrm_hrleaveandabsences_absence_type` table.

## After
SQL operations now occur without error

## Technical Details
Log table is re-checked for newly added columns and triggers re-generated based on changes.
```
$logging->fixSchemaDifferencesFor($absenceTypeTable, [], TRUE)
```

## Comments
An existing upgrader was updated because the epic is still on and not ready for testing.
