### PR TITLE
PCHR-4345: Improve Absence Type Title Validation

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -276,9 +276,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    */
   private static function validateAbsenceTypeTitle($params) {
-    $title = CRM_Utils_Array::value('title', $params);
-    if (!$title) {
-      return;
+    $title = trim(CRM_Utils_Array::value('title', $params));
+    if (empty($title) && $title !== '0') {
+      throw new InvalidAbsenceTypeException(
+        'The title is not provided'
+      );
     }
 
     $absenceType = new self();

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -277,6 +277,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function validateAbsenceTypeTitle($params) {
     $title = trim(CRM_Utils_Array::value('title', $params));
+
     if (empty($title) && $title !== '0') {
       throw new InvalidAbsenceTypeException(
         'The title is not provided'

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/AbsenceType.php
@@ -13,10 +13,10 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType extends
     'calculation_unit' => 1
   ];
 
-  public static function fabricate($params = []) {
+  public static function fabricate($params = [], $strictTitle = TRUE) {
     $params = array_merge(static::$defaultParams, $params);
 
-    if(empty($params['title'])) {
+    if(empty($params['title']) && $strictTitle) {
       $params['title'] = static::nextSequentialTitle();
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -39,6 +39,37 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     AbsenceTypeFabricator::fabricate(['title' => 'Type 1']);
   }
 
+  public function testTypeTitleUniquenessValidationRespectsTrailingSpaces() {
+    AbsenceTypeFabricator::fabricate(['title' => 'Type 1']);
+
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException',
+      'Absence Type with same title already exists!'
+    );
+    AbsenceTypeFabricator::fabricate(['title' => ' Type 1 ']);
+  }
+
+  public function testTypeTitleShouldNotBeEmpty() {
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException',
+      'The title is not provided'
+    );
+    AbsenceTypeFabricator::fabricate(['title' => ''], FALSE);
+  }
+
+  public function testTypeTitleShouldNotContainSpacesOnly() {
+    $this->setExpectedException(
+      'CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException',
+      'The title is not provided'
+    );
+    AbsenceTypeFabricator::fabricate(['title' => '   '], FALSE);
+  }
+
+  public function testTypeTitleCanBeZero() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['title' => '0'], FALSE);
+    $this->assertEquals('0', $absenceType->title);
+  }
+
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it
@@ -644,6 +675,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     //disable TOIL
     AbsenceType::create([
       'id' => $absenceType->id,
+      'title' => $absenceType->title,
       'allow_accruals_request' => false,
       'color' => '#000000'
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -3059,6 +3059,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $maxLeaveAccrual = 1;
     AbsenceType::create([
       'id' => $absenceType->id,
+      'title' => $absenceType->title,
       'max_leave_accrual' => $maxLeaveAccrual,
       'allow_accruals_request' => true,
       'color' => '#000000'

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/AbsenceTypeTest.php
@@ -73,6 +73,7 @@ class CRM_HRLeaveAndAbsences_Service_AbsenceTypeTest extends BaseHeadlessTest {
     //disable TOIL
     $updatedAbsenceType = AbsenceType::create([
       'id' => $absenceType->id,
+      'title' => $absenceType->title,
       'allow_accruals_request' => false,
       'color' => '#000000'
     ]);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/api/v3/LeaveRequestTest.php
@@ -3071,6 +3071,7 @@ class api_v3_LeaveRequestTest extends BaseHeadlessTest {
     // decrease the max leave accrual
     AbsenceType::create([
       'id' => $absenceType->id,
+      'title' => $absenceType->title,
       'max_leave_accrual' => 1,
       'allow_accruals_request' => true,
       'color' => '#000000'


### PR DESCRIPTION
## Overview
Absence type title is a required field and null is not allowed. If no value is specified for title and other required fields are provided, the record still get inserted into the db. This PR fixes the issue

## Before
Creating absence type with empty title works.

## After
Creating absence type with empty title now throws an exception.

## Technical Details
The title was checked for emptiness(after trimming), and error is thrown if title is not present or evaluates to false. 
```
private static function validateAbsenceTypeTitle($params) {
  $title = trim(CRM_Utils_Array::value('title', $params));

  if (empty($title) && $title !== '0') {
    throw new InvalidAbsenceTypeException(
      'The title is not provided'
    );
  }
  ....
}
```
This is with the exception of `0` as discussed in slack conversation.
cc @igorpavlov.
