### PR TITLE
PCHR-4311: Create Staff Directory Search Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.mgd.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.mgd.php
@@ -11,7 +11,7 @@ return [
     'params' =>
     [
       'version' => 3,
-      'label' => 'StaffDirectory',
+      'label' => 'Staff Directory',
       'description' => 'Staff Directory Search',
       'class_name' => 'CRM_HRCore_Form_Search_StaffDirectory',
     ],

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.mgd.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.mgd.php
@@ -1,0 +1,19 @@
+<?php
+// This file declares a managed database record of type "CustomSearch".
+// The record will be automatically inserted, updated, or deleted from the
+// database as appropriate. For more details, see "hook_civicrm_managed" at:
+// http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
+return [
+  0 =>
+  [
+    'name' => 'CRM_HRCore_Form_Search_StaffDirectory',
+    'entity' => 'CustomSearch',
+    'params' =>
+    [
+      'version' => 3,
+      'label' => 'StaffDirectory',
+      'description' => 'Staff Directory Search',
+      'class_name' => 'CRM_HRCore_Form_Search_StaffDirectory',
+    ],
+  ],
+];

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -226,7 +226,7 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
     $form->add('datepicker', 'contract_end_date', ts('Job Contract End Date'),
       '', FALSE, ['time' => false]);
 
-//    $form->assign('elements', ['select_staff', 'contact_type', 'group', 'tag']);
+    CRM_Utils_System::setTitle(ts('Staff Directory'));
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -122,6 +122,8 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
           $this->where[] = CRM_Contact_BAO_Query::buildClause($alias, $op, $value);
       }
     }
+
+    $this->where[] = "contact_a.contact_type = 'Individual' AND contact_a.is_deleted = 0";
   }
 
   /**
@@ -253,7 +255,7 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
   ) {
 
     $orderBy = '';
-    if ($sort) {
+    if ($sort instanceof CRM_Utils_Sort) {
       $orderBy = " ORDER BY " . trim($sort->orderBy());
     }
 

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -255,8 +255,16 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
   ) {
 
     $orderBy = '';
-    if ($sort instanceof CRM_Utils_Sort) {
-      $orderBy = " ORDER BY " . trim($sort->orderBy());
+
+    if ($sort) {
+      if ($sort instanceof CRM_Utils_Sort) {
+        $sort = trim($sort->orderBy());
+      }
+      else{
+        $sort = trim($sort);
+      }
+
+      $orderBy = " ORDER BY " . trim($sort);
     }
 
     $sql = $this->selectClause .  $this->fromClause . $this->whereClause . $this->getGroupBy() . $orderBy ;

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Custom_Base implements CRM_Contact_Form_Search_Interface {
+class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_Interface {
 
   /**
    * @var array
@@ -43,14 +43,24 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
   protected $params = [];
 
   /**
+   * @var array
+   */
+  protected $formValues = [];
+
+  /**
+   * @var array
+   */
+  protected $columns = [];
+
+  /**
    * Class constructor.
    *
    * @param array $formValues
    */
   public function __construct(&$formValues) {
-    parent::__construct($formValues);
+    $this->formValues = $formValues;
 
-    $this->_columns = [
+    $this->columns = [
       ts('Display Name') => 'display_name',
       ts('Work Phone') => 'work_phone',
       ts('Work Email') => 'work_email',
@@ -64,7 +74,7 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
       'select_staff' => '',
     ];
 
-    $allParameters = array_merge($this->_formValues, $this->getAdditionalParameters());
+    $allParameters = array_merge($this->formValues, $this->getAdditionalParameters());
     $this->params = CRM_Contact_BAO_Query::convertFormValues($allParameters);
     $this->generateQueryClause();
   }
@@ -100,8 +110,8 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
             $jobDetailsCondition = $this->getJobDetailsConditionForSpecificStaff($value);
           }
           elseif ($value == 'choose_date') {
-            $fromDate = $this->_formValues['contract_start_date'] ? new DateTime($this->_formValues['contract_start_date']) : '';
-            $toDate = $this->_formValues['contract_end_date'] ? new DateTime($this->_formValues['contract_end_date']) : '';
+            $fromDate = $this->formValues['contract_start_date'] ? new DateTime($this->formValues['contract_start_date']) : '';
+            $toDate = $this->formValues['contract_end_date'] ? new DateTime($this->formValues['contract_end_date']) : '';
             $jobDetailsCondition = $this->getJobDetailsConditionForSpecificDates($fromDate, $toDate);
           }
           else {
@@ -364,7 +374,7 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
    */
   private function getAdditionalParameters() {
     $additionalParameters = [];
-    if (!empty($this->_formValues['force']) && $this->_formValues['force'] == 1) {
+    if (!empty($this->formValues['force']) && $this->formValues['force'] == 1) {
       $additionalParameters = array_intersect($_GET, $this->filters);
     }
 
@@ -387,4 +397,40 @@ class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Cust
   public function templateFile() {
     return 'CRM/HRCore/Form/Search/StaffDirectory.tpl';
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function &columns() {
+    return $this->columns;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildTaskList(CRM_Core_Form_Search $form) {
+    return $form->getVar('_taskList');
+  }
+
+  /**
+   * Validate form input.
+   *
+   * @param array $fields
+   * @param array $files
+   * @param CRM_Core_Form $self
+   *
+   * @return array
+   *   Input errors from the form.
+   */
+  public function formRule($fields, $files, $self) {
+    return [];
+  }
+
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -1,0 +1,390 @@
+<?php
+
+
+class CRM_HRCore_Form_Search_StaffDirectory extends CRM_Contact_Form_Search_Custom_Base implements CRM_Contact_Form_Search_Interface {
+
+  /**
+   * @var array
+   *  An array of form field as key and its table
+   *  alias as the value.
+   */
+  protected $filters = [];
+
+  /**
+   * @var array
+   */
+  protected $where = [];
+
+  /**
+   * @var array
+   */
+  protected $from =[];
+
+  /**
+   * @var string
+   */
+  protected $selectClause = NULL;
+
+  /**
+   * @var string
+   */
+  protected $whereClause = NULL;
+
+  /**
+   * @var string
+   */
+  protected $fromClause = NULL;
+
+  /**
+   * @var array
+   *   Stores the form values in query compatible
+   *   format.
+   */
+  protected $params = [];
+
+  /**
+   * Class constructor.
+   *
+   * @param array $formValues
+   */
+  public function __construct(&$formValues) {
+    parent::__construct($formValues);
+
+    $this->_columns = [
+      ts('Display Name') => 'display_name',
+      ts('Work Phone') => 'work_phone',
+      ts('Work Email') => 'work_email',
+      ts('Manager') => 'manager',
+      ts('Location') => 'location',
+      ts('Department') => 'department',
+      ts('Job Title') => 'job_title',
+    ];
+
+    $this->filters = [
+      'select_staff' => '',
+    ];
+
+    $allParameters = array_merge($this->_formValues, $this->getAdditionalParameters());
+    $this->params = CRM_Contact_BAO_Query::convertFormValues($allParameters);
+    $this->generateQueryClause();
+  }
+
+  /**
+   * Builds the select part of the query.
+   */
+  private function buildSelect() {
+    $this->selectClause = "SELECT contact_a.id as contact_id,
+      contact_a.display_name as display_name,
+      GROUP_CONCAT(DISTINCT CASE WHEN phone_location.name = 'Work' THEN CONCAT(c_phone.phone, IF (c_phone.phone_ext, CONCAT(' + ', c_phone.phone_ext), '')) END) AS work_phone,
+      GROUP_CONCAT(DISTINCT CASE WHEN email_location.name = 'Work' THEN c_email.email END) AS work_email,
+      GROUP_CONCAT(DISTINCT CASE WHEN civicrm_relationship_type.is_active = '1' THEN manager_contact.display_name END) AS manager,
+      GROUP_CONCAT(DISTINCT ov_location.name) AS location,
+      GROUP_CONCAT(DISTINCT ov_department.name) AS department,
+      contract_details.title AS job_title ";
+  }
+
+  /**
+   * Builds the where part of the overrall sql query.
+   */
+  private function buildWhere() {
+    foreach ($this->params as $param) {
+      list($name, $op, $value, $grouping, $wildcard) = $param;
+      if (!in_array($name, array_keys($this->filters))) {
+        continue;
+      }
+
+      $alias =  $this->filters[$name];
+      switch ($name) {
+        case 'select_staff':
+          if (in_array($value, ['all', 'current', 'past', 'future'])) {
+            $jobDetailsCondition = $this->getJobDetailsConditionForSpecificStaff($value);
+          }
+          elseif ($value == 'choose_date') {
+            $fromDate = $this->_formValues['contract_start_date'] ? new DateTime($this->_formValues['contract_start_date']) : '';
+            $toDate = $this->_formValues['contract_end_date'] ? new DateTime($this->_formValues['contract_end_date']) : '';
+            $jobDetailsCondition = $this->getJobDetailsConditionForSpecificDates($fromDate, $toDate);
+          }
+          else {
+            list($term, $unit) = explode('.', $value, 2);
+            $dateRange = CRM_Utils_Date::relativeToAbsolute($term, $unit);
+            $from = substr($dateRange['from'], 0, 8);
+            $to = substr($dateRange['to'], 0, 8);
+            $jobDetailsCondition = $this->getJobDetailsConditionForSpecificDates(new DateTime($from), new DateTime($to));
+          }
+
+          $this->from['contract_join'] = $this->getJobContractJoin($jobDetailsCondition);
+          if ($jobDetailsCondition) {
+            $this->where[] = $jobDetailsCondition;
+          }
+          break;
+        default:
+          $this->where[] = CRM_Contact_BAO_Query::buildClause($alias, $op, $value);
+      }
+    }
+  }
+
+  /**
+   * Builds the FROM part of the overrall sql query.
+   *
+   * @return string
+   */
+  private function buildFrom() {
+    $this->from['before_contract'] = "civicrm_contact contact_a
+    LEFT JOIN civicrm_phone c_phone ON c_phone.contact_id = contact_a.id
+    LEFT JOIN civicrm_location_type phone_location ON  c_phone.location_type_id = phone_location.id
+    LEFT JOIN civicrm_email c_email ON c_email.contact_id = contact_a.id
+    LEFT JOIN civicrm_location_type email_location ON c_email.location_type_id = email_location.id";
+
+    $this->from['contract_join'] = $this->getJobContractJoin($this->getJobDetailsConditionForSpecificStaff());
+
+    $this->from['after_contract'] = "LEFT JOIN civicrm_hrjobroles hrjobroles ON contract_details.id = hrjobroles.job_contract_id
+    LEFT JOIN civicrm_option_group og_department ON og_department.name = 'hrjc_department'
+    LEFT JOIN civicrm_option_value ov_department ON og_department.id = ov_department.option_group_id AND ov_department.value = hrjobroles.department
+    LEFT JOIN civicrm_option_group og_location ON og_location.name = 'hrjc_location'
+    LEFT JOIN civicrm_option_value ov_location ON og_location.id = ov_location.option_group_id AND ov_location.value = hrjobroles.location
+    LEFT JOIN civicrm_relationship 
+      ON (contact_a.id = civicrm_relationship.contact_id_a AND civicrm_relationship.is_active = '1' 
+      AND ((civicrm_relationship.start_date IS NULL OR civicrm_relationship.start_date <= CURDATE()) 
+      AND (civicrm_relationship.end_date IS NULL OR civicrm_relationship.end_date >= CURDATE())))
+    LEFT JOIN civicrm_relationship_type ON civicrm_relationship.relationship_type_id = civicrm_relationship_type.id
+    LEFT JOIN civicrm_contact manager_contact ON  civicrm_relationship.contact_id_b = manager_contact.id";
+  }
+
+  /**
+   * Sets the Select, From and Where clause of the overall sql query.
+   */
+  private function generateQueryClause() {
+    $this->buildSelect();
+    $this->buildFrom();
+    $this->buildWhere();
+
+    if (!empty($this->where)) {
+      $this->whereClause =  ' WHERE ' . implode(' AND ', $this->where);
+    }
+
+    $this->fromClause = ' FROM ' . implode(' ', $this->from);
+  }
+
+  /**
+   * Returns the GROUP BY part of the sql.
+   *
+   * @return string
+   */
+  private function getGroupBy() {
+    return ' GROUP BY contact_a.id';
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function contactIDs($offset = 0, $rowcount = 0, $sort = NULL, $returnSQL = FALSE) {
+    $sql = "SELECT contact_a.id as contact_id " .
+      $this->fromClause . $this->whereClause . $this->getGroupBy();
+
+    if ($rowcount > 0 && $offset >= 0) {
+      $offset = CRM_Utils_Type::escape($offset, 'Int');
+      $rowcount = CRM_Utils_Type::escape($rowcount, 'Int');
+
+      $sql .= " LIMIT $offset, $rowcount";
+    }
+
+    return CRM_Core_DAO::composeQuery($sql, CRM_Core_DAO::$_nullArray);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(&$form) {
+    $additional = [
+      'all' => 'All Staff',
+      'current' => 'Current Staff',
+      'future' => 'Future Staff',
+      'past' => 'Past Staff',
+      'choose_date' => 'Select Dates'
+    ];
+
+    $selector = CRM_Core_Form_Date::returnDateRangeSelector(
+      $form,
+      'select_staff',
+      1,
+      '_low',
+      '_high',
+      ts('From:')
+
+    );
+    //remove unwanted options from the relative dates list.
+    unset($selector[0], $selector['']);
+    $options = $additional + $selector;
+
+    $form->add('select', 'select_staff', ts('Select Staff'), $options, FALSE,
+      ['class' => 'crm-select2', 'multiple' => FALSE]
+    );
+
+    $form->add('datepicker', 'contract_start_date', ts('Job Contract Start Date'),
+      '', FALSE, ['time' => false]);
+    $form->add('datepicker', 'contract_end_date', ts('Job Contract End Date'),
+      '', FALSE, ['time' => false]);
+
+//    $form->assign('elements', ['select_staff', 'contact_type', 'group', 'tag']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count() {
+    $sql = "SELECT COUNT(DISTINCT(contact_a.id)) as total_count " . $this->fromClause . $this->whereClause;
+    $count = 0;
+    $result = CRM_Core_DAO::executeQuery($sql);
+    if ($result->fetch()) {
+      $count = $result->total_count;
+    }
+
+    return $count;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function all(
+    $offset = 0,
+    $rowCount = 0,
+    $sort = NULL,
+    $includeContactIDs = FALSE,
+    $justIDs = FALSE
+  ) {
+
+    $orderBy = trim($sort->orderBy());
+    $sql = $this->selectClause .  $this->fromClause . $this->whereClause . $this->getGroupBy()  . " ORDER BY " . $orderBy ;
+
+    return $sql ." LIMIT $offset, $rowCount ";
+  }
+
+
+  /**
+   * The part of the query that returns the JOIN to the job contracts table.
+   * We need to create a derived job contract details table so as to ensure
+   * that the job contract record with the latest start date for the contact
+   * is the record fetched as regards the contract period dates condition.
+   *
+   * @param string $jobDetailsCondition
+   *
+   * @return string
+   */
+  private function getJobContractJoin($jobDetailsCondition) {
+    $jobDetailsQuery =  "SELECT * FROM civicrm_hrjobcontract_details contract_details ";
+    if ($jobDetailsCondition) {
+      $jobDetailsQuery .= "WHERE {$jobDetailsCondition}";
+    }
+
+    $jobDetailsQuery .= " ORDER BY period_start_date DESC";
+
+    $sql = "LEFT JOIN (SELECT civicrm_hrjobcontract_details.title, civicrm_hrjobcontract.id, civicrm_hrjobcontract.contact_id,
+      civicrm_hrjobcontract_details.period_start_date, civicrm_hrjobcontract_details.period_end_date
+      FROM civicrm_hrjobcontract 
+      INNER JOIN civicrm_hrjobcontract_revision rev 
+      ON rev.id = (SELECT id
+                   FROM civicrm_hrjobcontract_revision jcr2
+                   WHERE jcr2.jobcontract_id = civicrm_hrjobcontract.id
+                   ORDER BY jcr2.effective_date DESC LIMIT 1)
+      INNER JOIN ({$jobDetailsQuery}) civicrm_hrjobcontract_details
+        ON rev.details_revision_id = civicrm_hrjobcontract_details.jobcontract_revision_id 
+      WHERE civicrm_hrjobcontract.deleted = 0 
+      GROUP BY civicrm_hrjobcontract.contact_id) contract_details
+      ON contract_details.contact_id = contact_a.id";
+
+    return $sql;
+  }
+
+  /**
+   * Returns the SQL query condition for the period start and end dates
+   * depending on the staff type.
+   *
+   * @param string $staffType
+   *
+   * @return string
+   */
+  private function getJobDetailsConditionForSpecificStaff($staffType = 'all') {
+    $today = date('Y-m-d');
+    $sql = '';
+
+    if ($staffType == 'current') {
+      $sql .= "contract_details.period_start_date <= '{$today}'
+               AND (contract_details.period_end_date >= '{$today}' OR contract_details.period_end_date IS NULL)";
+    }
+
+    if ($staffType == 'past') {
+      $sql .= "contract_details.period_end_date < '{$today}'";
+    }
+
+    if ($staffType == 'future') {
+      $sql .= "contract_details.period_start_date > '{$today}'";
+    }
+
+    return $sql;
+  }
+
+  /**
+   * Returns the SQL query condition for the period start and end dates
+   * depending on the given period start and end dates.
+   *
+   * @param \DateTime|NULL $periodStartDate
+   * @param \DateTime|NULL $periodEndDate
+   *
+   * @return string
+   */
+  private function getJobDetailsConditionForSpecificDates(
+    DateTime $periodStartDate = NULL,
+    DateTime $periodEndDate = NULL)
+  {
+
+    $sql = '';
+    if (!$periodStartDate && !$periodEndDate) {
+      return $this->getJobDetailsConditionForSpecificStaff();
+    }
+
+    if ($periodStartDate) {
+      $sql .= "(contract_details.period_end_date >= '" .
+        $periodStartDate->format('Y-m-d') . "' OR contract_details.period_end_date IS NULL) AND ";
+    }
+
+    if ($periodEndDate) {
+      $sql .= "contract_details.period_start_date <= '". $periodEndDate->format('Y-m-d') . "' AND ";
+    }
+
+    return rtrim($sql, 'AND ');
+  }
+
+  /**
+   * Returns additional parameters set via the URL when force = 1
+   * Only form fields that are included in the filters are returned
+   * from the URL parameters.
+   *
+   * @return array
+   */
+  private function getAdditionalParameters() {
+    $additionalParameters = [];
+    if (!empty($this->_formValues['force']) && $this->_formValues['force'] == 1) {
+      $additionalParameters = array_intersect($_GET, $this->filters);
+    }
+
+    return $additionalParameters;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function where($includeContactIDs = FALSE) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function from() {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function templateFile() {
+    return 'CRM/HRCore/Form/Search/StaffDirectory.tpl';
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/SearchCriteria.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/SearchCriteria.tpl
@@ -1,0 +1,77 @@
+{if $context EQ 'smog'}
+  {capture assign=editTitle}{ts}Find Contacts within this Group{/ts}{/capture}
+{elseif $context EQ 'amtg' AND !$rows}
+  {capture assign=editTitle}{ts}Find Contacts to Add to this Group{/ts}{/capture}
+{else}
+  {capture assign=editTitle}{ts}Edit Search Criteria{/ts}{/capture}
+{/if}
+
+{strip}
+  <div class="crm-block crm-form-block crm-basic-criteria-form-block">
+    <div class="crm-accordion-wrapper crm-case_search-accordion {if $rows}collapsed{/if}">
+      <div class="crm-accordion-header crm-master-accordion-header">
+        {$editTitle}
+      </div>
+      <div class="crm-accordion-body">
+
+        <div class="crm-section" id="select-staff">
+          <div class="label">
+            {$form.select_staff.label}
+          </div>
+          <div class="content">
+            {$form.select_staff.html}
+          </div>
+          <div class="clear"></div>
+        </div>
+
+        <div class="contract-dates">
+          <div class="crm-section">
+            <div class="label">
+              {$form.contract_start_date.label}
+            </div>
+            <div class="content">
+              {$form.contract_start_date.html}
+            </div>
+          </div>
+
+          <div class="crm-section">
+            <div class="label">
+              {$form.contract_end_date.label}
+            </div>
+            <div class="content">
+              {$form.contract_end_date.html}
+            </div>
+          </div>
+        </div>
+
+        <script type="text/javascript">
+          {literal}
+          CRM.$(function($) {
+            $(document).ready(function() {
+              toogleContractDates();
+              initSelectStaffControls();
+            });
+
+            function initSelectStaffControls() {
+              $('#select-staff select').on('change', function(e) {
+                toogleContractDates();
+              });
+            }
+
+            function toogleContractDates() {
+              var select_staff_value = $('#select-staff select option:selected').val();
+              if (select_staff_value === 'choose_date') {
+                $('.contract-dates').show()
+              } else {
+                $('.contract-dates').hide();
+              }
+            }
+          });
+          {/literal}
+        </script>
+
+        <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl"}</div>
+      </div>
+    </div>
+  </div>
+{/strip}

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/Selector.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/Selector.tpl
@@ -1,0 +1,68 @@
+{include file="CRM/common/pager.tpl" location="top"}
+<a href="#" class="crm-selection-reset crm-hover-button"><i class="crm-i fa-times-circle-o"></i> {ts}Reset all selections{/ts}</a>
+
+<table summary="{ts}Search results listings.{/ts}" class="selector row-highlight">
+  <thead class="sticky">
+  <tr>
+    <th scope="col" title="Select All Rows">{$form.toggleSelect.html}</th>
+    {if $context eq 'smog'}
+      <th scope="col">
+        {ts}Status{/ts}
+      </th>
+    {/if}
+    {foreach from=$columnHeaders item=header}
+      <th scope="col">
+        {if $header.sort}
+          {assign var='key' value=$header.sort}
+          {$sort->_response.$key.link}
+        {else}
+          {$header.name}
+        {/if}
+      </th>
+    {/foreach}
+    <th scope="col">
+      {ts}Actions{/ts}
+    </th>
+  </tr>
+  </thead>
+
+  {counter start=0 skip=1 print=false}
+
+  {foreach from=$rows item=row}
+    <tr id="rowid{$row.contact_id}" class="{cycle values='odd-row,even-row'}">
+      {assign var=cbName value=$row.checkbox}
+      <td>{$form.$cbName.html}</td>
+      {if $context eq 'smog'}
+        {if $row.status eq 'Pending'}<td class="status-pending"}>
+        {elseif $row.status eq 'Removed'}<td class="status-removed">
+        {else}<td>{/if}
+        {$row.status}</td>
+      {/if}
+      {foreach from=$columnHeaders item=value key=column}
+        {assign var='columnName' value=$value.sort}
+        {if $columnName neq 'action'}
+          <td class="crm-{$columnName} crm-{$columnName}_{$row.columnName}">{$row.$columnName} </td>
+        {/if}
+
+      {/foreach}
+
+      <td style='width:125px;'>{$row.action|replace:'xx':$row.contact_id}</td>
+    </tr>
+  {/foreach}
+
+</table>
+
+<script type="text/javascript">
+  {literal}
+  CRM.$(function($) {
+    // Clear any old selection that may be lingering in quickform
+    $("input.select-row, input.select-rows", 'form.crm-search-form').prop('checked', false).closest('tr').removeClass('crm-row-selected');
+    // Retrieve stored checkboxes
+    var cids = {/literal}{$selectedContactIds|@json_encode}{literal};
+    if (cids.length > 0) {
+      $('#mark_x_' + cids.join(',#mark_x_') + ',input[name=radio_ts][value=ts_sel]').prop('checked', true);
+    }
+  });
+  {/literal}
+</script>
+{include file="CRM/common/pager.tpl" location="bottom"}

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
@@ -1,0 +1,41 @@
+{* Main template for basic search (Find Contacts) *}
+{include file="CRM/Contact/Form/Search/Intro.tpl"}
+<div class="crm-form-block crm-search-form-block">
+{* This section handles form elements for search criteria *}
+  <div id="searchForm">
+    {include file="CRM/HRCore/Form/Search/SearchCriteria.tpl"}
+  </div>
+</div>
+<div class="crm-content-block">
+{if $rowsEmpty}
+  <div class="crm-results-block crm-results-block-empty">
+    {include file="CRM/Contact/Form/Search/EmptyResults.tpl"}
+  </div>
+{elseif $rows}
+  <div class="crm-results-block">
+    {* Search request has returned 1 or more matching rows. *}
+    {* This section handles form elements for action task select and submit *}
+    <div class="crm-search-tasks">
+      {if $taskFile}
+        {if $taskContext}
+          {include file=$taskFile context=$taskContext}
+        {else}
+          {include file=$taskFile}
+        {/if}
+      {else}
+        {include file="CRM/Contact/Form/Search/ResultTasks.tpl"}
+      {/if}
+    </div>
+
+    {* This section displays the rows along and includes the paging controls *}
+    <div class="crm-search-results">
+      {include file="CRM/HRCore/Form/Search/Selector.tpl"}
+    </div>
+
+  {* END Actions/Results section *}
+  </div>
+{else}
+  <div class="spacer">&nbsp;</div>
+{/if}
+</div>
+{*include file="CRM/common/searchJs.tpl"*}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+use CRM_HRCore_Form_Search_StaffDirectory as SearchDirectory;
+use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+
+/**
+ * @group headless
+ */
+class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
+
+  public function setUp() {
+    CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
+    $tableName = CRM_Contact_BAO_Contact::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+  }
+
+  public function testCountReturnsTheTotalNumberOfStaff() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    $formValues = [];
+    $searchDirectory =  new SearchDirectory($formValues);
+    $this->assertEquals(2, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs());
+    $this->assertEquals($contactIds, [$contact1['id'], $contact2['id']]);
+  }
+
+  public function testCountReturnsTheTotalNumberOfStaffWithCurrentContracts() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact3['id']],
+      [
+        'period_start_date' => '2018-01-01',
+        'period_end_date' => date('Y-m-d', strtotime('+1 year'))
+      ]
+    );
+
+    $formValues = ['select_staff' => 'current'];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //Contact2 and contact3 have current contracts
+    $this->assertEquals(2, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs());
+    $this->assertEquals($contactIds, [$contact2['id'], $contact3['id']]);
+  }
+
+  public function testCountReturnsTheTotalNumberOfStaffWithPastContracts() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    $formValues = ['select_staff' => 'past'];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //Contact1 has past contract
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact1['id']]);
+  }
+
+  public function testCountReturnsTheTotalNumberOfStaffWithFutureContracts() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      ['period_start_date' => date('Y-m-d', strtotime('+1 day'))]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => date('Y-m-d')]
+    );
+
+    $formValues = ['select_staff' => 'future'];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //Contact1 has future contract
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact1['id']]);
+  }
+
+  public function testCountReturnsTheCorrectNumberOfStaffWithSpecificJobContractDates() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_start_date' => '2016-04-01',
+      'contract_end_date' => '2016-05-01'
+    ];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //only Contact1 has contract dates overlapping selected dates
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact1['id']]);
+  }
+
+  public function testCountReturnsZeroWhenNoStaffWithContractsOverlappingSpecificJobContractDates() {
+    $contact1 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-05-02',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_start_date' => '2016-04-01',
+      'contract_end_date' => '2016-05-01'
+    ];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //No staff with contract dates overlapping the contract dates selected
+    $this->assertEquals(0, $searchDirectory->count());
+  }
+
+  public function testCountReturnsTheCorrectNumberOfStaffWithRelativeJobContractDate() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    $formValues = ['select_staff' => 'this.day'];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    //only Contact2 has contract dates overlapping today
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact2['id']]);
+  }
+
+  private function extractContactIds($sql) {
+    $result = CRM_Core_DAO::executeQuery($sql);
+    $contactId = [];
+    while ($result->fetch()) {
+      $contactId[] = $result->contact_id;
+    }
+
+    sort($contactId);
+
+    return $contactId;
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -3,16 +3,23 @@
 use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 use CRM_HRCore_Form_Search_StaffDirectory as SearchDirectory;
 use CRM_Hrjobcontract_Test_Fabricator_HRJobContract as HRJobContractFabricator;
+use CRM_Hrjobroles_Test_Fabricator_HrJobRoles as HRJobRolesFabricator;
+use CRM_HRCore_Test_Fabricator_OptionValue as OptionValueFabricator;
+use CRM_HRCore_Test_Fabricator_RelationshipType as RelationshipTypeFabricator;
+use CRM_HRCore_Test_Fabricator_Relationship as RelationshipFabricator;
 
 /**
  * @group headless
  */
 class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHeadlessTest {
 
+  private $relationshipType;
+
   public function setUp() {
     CRM_Core_DAO::executeQuery('SET foreign_key_checks = 0;');
     $tableName = CRM_Contact_BAO_Contact::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $this->relationshipType = RelationshipTypeFabricator::fabricate(['is_active' => 1]);
   }
 
   public function testCountReturnsTheTotalNumberOfStaff() {
@@ -28,7 +35,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id'], $contact2['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithCurrentContracts() {
+  public function testCountReturnsTheTotalNumberOfStaffWithCurrentContractsForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
     $contact3 = ContactFabricator::fabricate();
@@ -65,7 +72,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact2['id'], $contact3['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithPastContracts() {
+  public function testCountReturnsTheTotalNumberOfStaffWithPastContractsForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -93,7 +100,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithFutureContracts() {
+  public function testCountReturnsTheTotalNumberOfStaffWithFutureContractsForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -118,7 +125,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsTheCorrectNumberOfStaffWithSpecificJobContractDates() {
+  public function testCountReturnsTheCorrectNumberOfStaffWithSpecificJobContractDatesForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -150,7 +157,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsZeroWhenNoStaffWithContractsOverlappingSpecificJobContractDates() {
+  public function testCountReturnsZeroWhenNoStaffWithContractsOverlappingSpecificJobContractDatesForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
 
     HRJobContractFabricator::fabricate(
@@ -172,7 +179,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals(0, $searchDirectory->count());
   }
 
-  public function testCountReturnsTheCorrectNumberOfStaffWithRelativeJobContractDate() {
+  public function testCountReturnsTheCorrectNumberOfStaffWithRelativeJobContractDateForSelectStaffFilter() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -200,6 +207,172 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact2['id']]);
   }
 
+  public function testOnlyJobRoleRelatedValuesLinkedToMostRecentJobContractForContactAreReturned() {
+    $contactWorkEmail = 'contactemail@test.com';
+    $contactWorkPhone = '209889940';
+    $contactWorkPhoneExtension = 01;
+    $contractTitle = 'Most Recent Contract';
+    $contact1 = $this->fabricateContactWithWorkContactDetails(
+      [],
+      $contactWorkEmail,
+      $contactWorkPhone,
+      $contactWorkPhoneExtension
+    );
+
+    $manager = ContactFabricator::fabricate();
+
+    //Most recent contract for contact 1
+    $contract1 = HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2017-01-01',
+        'period_end_date' => '2017-12-31',
+        'title' => $contractTitle
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31',
+        'title' => 'Past Contract'
+      ]
+    );
+
+    $location1 = $this->createLocation('location1');
+    $location2 = $this->createLocation('location2');
+    $department1 = $this->createDepartment('department1');
+    $department2 = $this->createDepartment('department2');
+
+    //Assign the contact to a job role with access to location1
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'location' => $location1['value'],
+      'department' => $department1['value']
+    ]);
+
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'location' => $location2['value'],
+      'department' => $department2['value']
+    ]);
+
+    $this->createRelationShip($contact1, $manager);
+    $formValues = [];
+    $searchDirectory =  new SearchDirectory($formValues);
+    $results = $this->extractColumnValues($searchDirectory->all(0, 10));
+
+    $expectedResults = [
+      [
+        'display_name' => $contact1['display_name'],
+        'work_phone' => "{$contactWorkPhone} + {$contactWorkPhoneExtension}",
+        'work_email' => $contactWorkEmail,
+        'manager' => $manager['display_name'],
+        'location' => "{$location1['name']},{$location2['name']}",
+        'department' => "{$department1['name']},{$department2['name']}",
+        'job_title' => $contractTitle,
+      ],
+      [
+        'display_name' => $manager['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ]
+    ];
+
+    $this->assertEquals($expectedResults, $results);
+  }
+
+  public function testOnlyActiveContactManagersAreReturnedForTheManagerColumn() {
+    $contactWorkEmail = 'contactemail@test.com';
+    $contactWorkPhone = '209889940';
+    $contactWorkPhoneExtension = 01;
+    $contractTitle = 'Most Recent Contract';
+    $contact1 = $this->fabricateContactWithWorkContactDetails(
+      [],
+      $contactWorkEmail,
+      $contactWorkPhone,
+      $contactWorkPhoneExtension
+    );
+
+    $manager1 = ContactFabricator::fabricate(['first_name' => 'Manager2']);
+    $manager2 = ContactFabricator::fabricate(['first_name' => 'Manager2']);
+    $manager3 = ContactFabricator::fabricate(['first_name' => 'Manager3']);
+
+    $contract1 = HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2017-01-01',
+        'period_end_date' => '2017-12-31',
+        'title' => $contractTitle
+      ]
+    );
+
+    $location1= $this->createLocation('location1');
+    $department1 = $this->createDepartment('department1');
+
+    HRJobRolesFabricator::fabricate([
+      'job_contract_id' => $contract1['id'],
+      'location' => $location1['value'],
+      'department' => $department1['value']
+    ]);
+
+    //active manger relationship
+    $this->createRelationShip($contact1, $manager1);
+    $this->createRelationShip($contact1, $manager3, '2016-01-01');
+    //inactive relationship
+    $this->createRelationShip($contact1, $manager2, '2016-01-01', '2016-12-31');
+
+    $formValues = [];
+    $searchDirectory =  new SearchDirectory($formValues);
+    $results = $this->extractColumnValues($searchDirectory->all(0, 10));
+
+    $expectedResults = [
+      [
+        'display_name' => $contact1['display_name'],
+        'work_phone' => "{$contactWorkPhone} + {$contactWorkPhoneExtension}",
+        'work_email' => $contactWorkEmail,
+        'manager' => "{$manager1['display_name']},{$manager3['display_name']}",
+        'location' => $location1['name'],
+        'department' => $department1['name'],
+        'job_title' => $contractTitle,
+      ],
+      [
+        'display_name' => $manager1['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ],
+      [
+        'display_name' => $manager2['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ],
+      [
+        'display_name' => $manager3['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ]
+    ];
+
+    $this->assertEquals($expectedResults, $results);
+  }
+
   private function extractContactIds($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
     $contactId = [];
@@ -210,5 +383,83 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     sort($contactId);
 
     return $contactId;
+  }
+
+  private function extractColumnValues($sql) {
+    $result = CRM_Core_DAO::executeQuery($sql);
+    $results = [];
+
+    while ($result->fetch()) {
+      $results[] = [
+        'display_name' => $result->display_name,
+        'work_phone' => $result->work_phone,
+        'work_email' => $result->work_email,
+        'manager' => $result->manager,
+        'location' => $result->location,
+        'department' => $result->department,
+        'job_title' => $result->job_title
+      ];
+    }
+
+    return $results;
+  }
+
+  private function createDepartment($departmentName) {
+    $department = OptionValueFabricator::fabricate([
+      'option_group_id' => 'hrjc_department',
+      'name' => $departmentName,
+      'value' => $departmentName,
+      'label' => $departmentName,
+    ]);
+
+    return $department;
+  }
+
+  private function createLocation($locationName) {
+    $location = OptionValueFabricator::fabricate([
+      'option_group_id' => 'hrjc_location',
+      'name' => $locationName,
+      'value' => $locationName,
+      'label' => $locationName,
+    ]);
+
+    return $location;
+  }
+
+  private function createRelationShip($contactA, $contactB, $startDate = NULL, $endDate = NULL, $isActive = 1) {
+    RelationshipFabricator::fabricate([
+      'contact_id_a' => $contactA['id'],
+      'contact_id_b' => $contactB['id'],
+      'relationship_type_id' => $this->relationshipType['id'],
+      'start_date' => $startDate,
+      'end_date' => $endDate,
+      'is_active' => $isActive
+    ]);
+  }
+
+  public static function fabricateContactWithWorkContactDetails($params = [], $email, $phone, $phone_ext = '') {
+    $contact = ContactFabricator::fabricate($params);
+    $workLocationId = CRM_Core_DAO::getFieldValue(
+      'CRM_Core_DAO_LocationType',
+      'Work',
+      'id',
+      'name'
+    );
+
+    civicrm_api3('Email', 'create', [
+      'email' => $email,
+      'contact_id' => $contact['id'],
+      'is_primary' => 1,
+      'location_type_id' => $workLocationId
+    ]);
+
+    civicrm_api3('Phone', 'create', [
+      'contact_id' => $contact['id'],
+      'phone' => $phone,
+      'location_type_id' => $workLocationId,
+      'phone_ext' => $phone_ext
+    ]);
+
+    return $contact;
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -35,7 +35,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id'], $contact2['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithCurrentContractsForSelectStaffFilter() {
+  public function testSelectStaffFilterCanFilterOnlyCurrentStaff() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
     $contact3 = ContactFabricator::fabricate();
@@ -72,7 +72,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact2['id'], $contact3['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithPastContractsForSelectStaffFilter() {
+  public function testSelectStaffFilterCanFilterOnlyPastStaff() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -100,7 +100,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsTheTotalNumberOfStaffWithFutureContractsForSelectStaffFilter() {
+  public function testSelectStaffFilterCanFilterOnlyFutureStaff() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -125,7 +125,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsTheCorrectNumberOfStaffWithSpecificJobContractDatesForSelectStaffFilter() {
+  public function testSelectStaffFilterCanFilterStaffWithSpecificJobContractDates() {
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
@@ -157,7 +157,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($contactIds, [$contact1['id']]);
   }
 
-  public function testCountReturnsZeroWhenNoStaffWithContractsOverlappingSpecificJobContractDatesForSelectStaffFilter() {
+  public function testSelectStaffDoesNotReturnResultsWhenNoStaffWithContractsOverlappingSpecificJobContractDates() {
     $contact1 = ContactFabricator::fabricate();
 
     HRJobContractFabricator::fabricate(
@@ -258,13 +258,14 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
       'department' => $department2['value']
     ]);
 
-    $this->createRelationShip($contact1, $manager);
+    $this->createRelationship($contact1, $manager);
     $formValues = [];
     $searchDirectory =  new SearchDirectory($formValues);
     $results = $this->extractColumnValues($searchDirectory->all(0, 10));
 
     $expectedResults = [
       [
+        'contact_id' => $contact1['id'],
         'display_name' => $contact1['display_name'],
         'work_phone' => "{$contactWorkPhone} + {$contactWorkPhoneExtension}",
         'work_email' => $contactWorkEmail,
@@ -274,6 +275,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
         'job_title' => $contractTitle,
       ],
       [
+        'contact_id' => $manager['id'],
         'display_name' => $manager['display_name'],
         'work_phone' => NULL,
         'work_email' => NULL,
@@ -299,7 +301,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
       $contactWorkPhoneExtension
     );
 
-    $manager1 = ContactFabricator::fabricate(['first_name' => 'Manager2']);
+    $manager1 = ContactFabricator::fabricate(['first_name' => 'Manager1']);
     $manager2 = ContactFabricator::fabricate(['first_name' => 'Manager2']);
     $manager3 = ContactFabricator::fabricate(['first_name' => 'Manager3']);
 
@@ -312,7 +314,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
       ]
     );
 
-    $location1= $this->createLocation('location1');
+    $location1 = $this->createLocation('location1');
     $department1 = $this->createDepartment('department1');
 
     HRJobRolesFabricator::fabricate([
@@ -321,11 +323,11 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
       'department' => $department1['value']
     ]);
 
-    //active manger relationship
-    $this->createRelationShip($contact1, $manager1);
-    $this->createRelationShip($contact1, $manager3, '2016-01-01');
+    //active manager relationship
+    $this->createRelationship($contact1, $manager1);
+    $this->createRelationship($contact1, $manager3, '2016-01-01');
     //inactive relationship
-    $this->createRelationShip($contact1, $manager2, '2016-01-01', '2016-12-31');
+    $this->createRelationship($contact1, $manager2, '2016-01-01', '2016-12-31');
 
     $formValues = [];
     $searchDirectory =  new SearchDirectory($formValues);
@@ -333,6 +335,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
 
     $expectedResults = [
       [
+        'contact_id' => $contact1['id'],
         'display_name' => $contact1['display_name'],
         'work_phone' => "{$contactWorkPhone} + {$contactWorkPhoneExtension}",
         'work_email' => $contactWorkEmail,
@@ -342,6 +345,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
         'job_title' => $contractTitle,
       ],
       [
+        'contact_id' => $manager1['id'],
         'display_name' => $manager1['display_name'],
         'work_phone' => NULL,
         'work_email' => NULL,
@@ -351,6 +355,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
         'job_title' => NULL,
       ],
       [
+        'contact_id' => $manager2['id'],
         'display_name' => $manager2['display_name'],
         'work_phone' => NULL,
         'work_email' => NULL,
@@ -360,6 +365,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
         'job_title' => NULL,
       ],
       [
+        'contact_id' => $manager3['id'],
         'display_name' => $manager3['display_name'],
         'work_phone' => NULL,
         'work_email' => NULL,
@@ -387,21 +393,8 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
 
   private function extractColumnValues($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
-    $results = [];
 
-    while ($result->fetch()) {
-      $results[] = [
-        'display_name' => $result->display_name,
-        'work_phone' => $result->work_phone,
-        'work_email' => $result->work_email,
-        'manager' => $result->manager,
-        'location' => $result->location,
-        'department' => $result->department,
-        'job_title' => $result->job_title
-      ];
-    }
-
-    return $results;
+    return $result->fetchAll();
   }
 
   private function createDepartment($departmentName) {
@@ -426,7 +419,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     return $location;
   }
 
-  private function createRelationShip($contactA, $contactB, $startDate = NULL, $endDate = NULL, $isActive = 1) {
+  private function createRelationship($contactA, $contactB, $startDate = NULL, $endDate = NULL, $isActive = 1) {
     RelationshipFabricator::fabricate([
       'contact_id_a' => $contactA['id'],
       'contact_id_b' => $contactB['id'],
@@ -437,7 +430,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     ]);
   }
 
-  public static function fabricateContactWithWorkContactDetails($params = [], $email, $phone, $phone_ext = '') {
+  public static function fabricateContactWithWorkContactDetails($params = [], $email, $phone, $phoneExt = '') {
     $contact = ContactFabricator::fabricate($params);
     $workLocationId = CRM_Core_DAO::getFieldValue(
       'CRM_Core_DAO_LocationType',
@@ -457,7 +450,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
       'contact_id' => $contact['id'],
       'phone' => $phone,
       'location_type_id' => $workLocationId,
-      'phone_ext' => $phone_ext
+      'phone_ext' => $phoneExt
     ]);
 
     return $contact;


### PR DESCRIPTION
## Overview
As part of the changes introduced by the Staff Menu Improvement Epic, this PR adds the Staff Directory Page that allows the Admin view a list of users and use a form filters to refine the search results. 

## Before
- The Staff Directory Page does not exist.

## After
The Staff Directory page was created and ships with only the `Select Staff` filter field for now. This filter field allows the admin to filter staff based on Job contract dates.
The `Select Staff` filter is a select dropdown that has the following options:

- **Current Staff**: i.e. 
  Job Contract Start Date <= Todays date
  Job Contract End Date >= Todays date (or is null)

- **Past Staff** i.e
Job Contract End Date < Todays date

- **Staff Joining in Future** i.e
Job Contract Start Date > Todays date

- **All Staff**

- **Relative Dates** i.e
CiviCRM relative dates (i.e. last month, last year etc).

- **Select Dates** i.e
Allow user to enter an exact: Job Contract Start Date and Job Contract End Date using date pickers 

The following columns are displayed in the Staff Directory results page:

- Display Name
- Work Email
- Work Phone (Work Phone + Extension)
- Job Title (Job Contract Title)
- Manager (concatenated if more then 1 )
- Location (concatenated if more then 1 job role)
- Department (concatenated if more then 1 job role)

![staffdirectory](https://user-images.githubusercontent.com/6951813/47437728-0e095800-d7a1-11e8-9ef6-fed71cc73b3f.gif)


## Technical Details
The `CRM_HRCore_Form_Search_StaffDirectory` class was created as a custom search class that implements the `CRM_Contact_Form_Search_Interface` and was created following the instructions [HERE](https://docs.civicrm.org/dev/en/latest/extensions/civix/#generate-search), using the command
```php
civix generate:search --copy CRM_Contact_Form_Search_Custom_Basic StaffDirectory
```
This generated the `StaffDirectory.php`, `StaffDirectory.mgd` and `StaffDirectory.tpl` files. The `Selector.tpl` and `SearchCriteria.tpl` files were based off the `CRM/Contact/Form/Selector.tpl` and `CRM/Contact/Form/Search/BasicCriteria.tpl` files in core and included in `StaffDirectory.tpl` so that we can fully customize the search results and search form.

**Regarding the Select Staff Field**
The Select Staff field was created in a different way that from the Job contract dates field in advanced search [ Here ](https://github.com/compucorp/civihr/blob/e2ea5d1a0ddc70fbaeb066b05629c9eebf0eb84f/hrjobcontract/CRM/Hrjobcontract/BAO/Query.php#L426) because if we add additional options like ['All Staff', 'Current Staff'], in the options array, Civi will throw an error when evaluating these values after submission because it will not consider them to be relative dates and these options are not part of civi recognized relative dates processed internally by the `CRM_Utils_Date::relativeToAbsolute` function.
The Select Staff field is created in a different way by by fetching the relative dates options and merging them with our own custom options and then parsing only the relative dates with Civi. This route made the Choose Date Range option that ships with this field not to work as expected because the field was created differently. 

## Comments
There will be a separate task to style this page as this task is only focused on functionality.