### PR TITLE
PCHR-4207: Add Leave Type Category Label

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/templates/CRM/HRLeaveAndAbsences/Page/AbsenceType.tpl
@@ -17,7 +17,7 @@
             <thead class="sticky">
               <th>{ts}Title{/ts}</th>
               <th>{ts}Allow Accruals?{/ts}</th>
-              <th>{ts}Category{/ts}</th>
+              <th>{ts}Leave/Absence Type{/ts}</th>
               <th>{ts}Order{/ts}</th>
               <th>{ts}Enabled/Disabled{/ts}</th>
               <th>{ts}Actions{/ts}</th>


### PR DESCRIPTION
## Overview
This PR updates the category column label to `Leave/Absence Type` as stated in the [wiki](https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/626556929/Leave+type+categories).

## Before
<img width="686" alt="before_title_update" src="https://user-images.githubusercontent.com/1507645/47491980-e7e8c400-d843-11e8-9da1-5486c74aadd9.png">


## After
<img width="692" alt="after_title_update" src="https://user-images.githubusercontent.com/1507645/47491801-7d378880-d843-11e8-80db-67f023923dce.png">

## Comments
Replaced the category title to that stated in the wiki mockup

------
[x] Manual testing - passed