### PR TITLE
PCHR-4310: Modify Bulk Actions After Search for Staff Directory Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -522,13 +522,12 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
    * {@inheritdoc}
    */
   public function buildTaskList(CRM_Core_Form_Search $form) {
-    return  $form->getVar('_taskList');
     $newTaskList = [];
     $taskListLabelMapping = [
       'Create User Accounts(s)' => 'Create User Accounts(s)',
       'Delete contacts' => 'Delete Staff',
       'Delete permanently' => 'Delete Staff Permanently',
-      'Export contacts' => 'Export Staff ',
+      'Export contacts' => 'Export Staff',
       'Print/merge document' => 'Print/merge document'
     ];
     $oldTaskLists = $form->getVar('_taskList');

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -496,7 +496,24 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
    * {@inheritdoc}
    */
   public function buildTaskList(CRM_Core_Form_Search $form) {
-    return $form->getVar('_taskList');
+    $newTaskList = [];
+    $taskListLabelMapping = [
+      'Create User Accounts(s)' => 'Create User Accounts(s)',
+      'Delete contacts' => 'Delete Staff',
+      'Delete permanently' => 'Delete Staff Permanently',
+      'Export contacts' => 'Export Staff ',
+      'Print/merge document' => 'Print/merge document'
+    ];
+    $oldTaskLists = $form->getVar('_taskList');
+
+    foreach($taskListLabelMapping as $oldLabel => $newLabel) {
+      $key = array_search($oldLabel, $oldTaskLists);
+      if ($key !== FALSE) {
+        $newTaskList[$key] = $newLabel;
+      }
+    }
+
+    return $newTaskList;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -421,6 +421,32 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($expectedResults, $results);
   }
 
+  public function testExpectedTaskListIsReturned() {
+    $formValues = [];
+    $searchDirectory =  new SearchDirectory($formValues);
+
+    $expectedTaskList = [
+      'Create User Accounts(s)',
+      'Delete Staff',
+      'Delete Staff Permanently',
+      'Export Staff',
+      'Print/merge document'
+    ];
+
+    $form = new CRM_Core_Form_Search();
+    $form->setVar('_taskList', [
+      'Create User Accounts(s)',
+      'Delete contacts',
+      'Delete permanently',
+      'Export contacts',
+      'Print/merge document',
+      'Sample Task',
+      'Add Tags'
+    ]);
+
+    $this->assertEquals($expectedTaskList, array_values($searchDirectory->buildTaskList($form)));
+  }
+
   private function extractContactIds($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
     $contactId = [];

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -379,6 +379,48 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($expectedResults, $results);
   }
 
+  public function testRightContactsAreReturnedWhenIncludeContactIsTrue() {
+    $contact1 = ContactFabricator::fabricate(['first_name' => 'Contact1']);
+    $contact2 = ContactFabricator::fabricate(['first_name' => 'Contact2']);
+    $contact3 = ContactFabricator::fabricate(['first_name' => 'Contact3']);
+
+    $formValues = [];
+    //We need to simulate the values here when a contact is selected via the
+    //checkbox via the UI.
+    $formValues['mark_x_'. $contact1['id']] = '';
+    $formValues['mark_x_'. $contact3['id']] = '';
+
+    $searchDirectory =  new SearchDirectory($formValues);
+    $includeContactId = TRUE;
+    $results = $this->extractColumnValues($searchDirectory->all(0, 0, NULL, $includeContactId));
+
+    //Only contact1 and contact3 are expected
+    $expectedResults = [
+      [
+        'contact_id' => $contact1['id'],
+        'display_name' => $contact1['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ],
+      [
+        'contact_id' => $contact3['id'],
+        'display_name' => $contact3['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ]
+    ];
+
+    $this->assertEquals($expectedResults, $results);
+  }
+
   private function extractContactIds($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
     $contactId = [];


### PR DESCRIPTION
## Overview
This PR modifies the bulk actions available on the search results page for the Staff directory page.

## Before
All bulk actions provided by Civi are available for the Search directory page.
<img width="481" alt="staff directory _ staging54 2018-10-26 12-50-01" src="https://user-images.githubusercontent.com/6951813/47564691-be03d000-d91d-11e8-9d9d-0a49fddd3bc3.png">

## After
After searching only the following bulk actions are available:
* Create User Accounts
* Delete Staff (Delete Contacts)
* Delete Staff permanently (Delete Contacts permanently
* Export Staff (Export Contact)
* Print merge documents

<img width="448" alt="staff directory _ staging54 2018-10-26 12-48-45" src="https://user-images.githubusercontent.com/6951813/47564680-b6442b80-d91d-11e8-8ef1-195e0f396b62.png">

## Technical Details
The `buildTaskList` method of the `CRM_HRCore_Form_Search_StaffDirectory` class was modified to return the required bulk actions.
There was an issue with Export Staff bulk action yielding an empty CSV which is as a result of the function processing the export functionality [here](https://github.com/compucorp/civihr/blob/49b363e09bfb5d9fd647ba14f7672be70c686c7e/hrjobcontract/CRM/Export/BAO/Export.php#L1123) , 0 is passed for both `offset` and `rowCount` parameters, this was fixed by making provision for that in the `all` function of `CRM_HRCore_Form_Search_StaffDirectory` class.
```php
    if ($offset || $rowCount) {
      $sql .= " LIMIT $offset, $rowCount";
    }
```
Also after this issue was fixed, all the contacts were exported in the generated CSV irrespective of whether the contacts was checked or not, the issue was fixed by putting the `$includeContactIDs` parameter passed to the `all` function in consideration.

The function to retrieve contact_ids from the form values sent via the checkbox was copied(also refactored) from [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L3631-L3646)
```php
  public function includeContactIDs() {
    $contactIds = [];
    foreach ($this->formValues as $id => $value) {
      if (substr($id, 0, CRM_Core_Form::CB_PREFIX_LEN) == CRM_Core_Form::CB_PREFIX) {
        $contactIds[] = substr($id, CRM_Core_Form::CB_PREFIX_LEN);
      }
    }

    CRM_Utils_Type::validateAll($contactIds, 'Positive');
    if (!empty($contactIds)) {
      $this->where[] = " ( contact_a.id IN (" . implode(',', $contactIds) . " ) ) ";
      $this->whereClause =  ' WHERE ' . implode(' AND ', $this->where);
    }
  }
```
