### PR TITLE
PCHR-4309: Modify Search Actions for Individual Contacts on Staff Directory Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Links/ContactCustomActions.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Links/ContactCustomActions.php
@@ -1,0 +1,104 @@
+<?php
+
+class CRM_HRCore_Hook_Links_ContactCustomActions {
+
+  /**
+   * Determines what happens if the hook is handled.
+   *
+   * @param string $op
+   * @param string $objectName
+   * @param mixed $objectId
+   * @param array $links
+   * @param string $mask
+   * @param array $values
+   */
+  public function handle($op, $objectName, $objectId, &$links, &$mask, &$values) {
+    if (!$this->shouldHandle($objectName, $op)) {
+      return;
+    }
+
+    $this->setContactCustomLinks($links);
+
+  }
+
+  /**
+   * Checks whether the hook should be handled or not.
+   *
+   * @param string $objectName
+   * @param string $op
+   *
+   * @return bool
+   */
+  private function shouldHandle($objectName, $op) {
+    return $objectName == 'Contact' && $op == 'contact.custom.actions';
+  }
+
+  /**
+   * This overrides the custom contact actions for individual contacts on
+   * custom search pages.
+   *
+   * @param array $links
+   */
+  private function setContactCustomLinks(&$links) {
+    $links = [
+      [
+        'name' => 'Record Leave',
+        'url' => 'civicrm/contact/view',
+        'class' => 'no-popup',
+        'qs' => 'reset=1&cid=%%id%%&selectedChild=absence&openModal=leave',
+        'title' => 'Record Leave',
+      ],
+      [
+        'name' => 'Record Sickness',
+        'url' => 'civicrm/contact/view',
+        'class' => 'no-popup',
+        'qs' => 'reset=1&cid=%%id%%&selectedChild=absence&openModal=sickness',
+        'title' => 'Record Sickness',
+      ],
+      [
+        'name' => 'Record Overtime',
+        'url' => 'civicrm/contact/view',
+        'qs' => 'reset=1&cid=%%id%%&selectedChild=absence&openModal=toil',
+        'title' => 'Record Overtime',
+        'class' => 'no-popup',
+      ],
+      [
+        'name' => 'Add Task',
+        'url' => 'civicrm/tasksassignments/dashboard',
+        'qs' => 'reset=1&cid=%%id%%&openModal=task',
+        'title' => 'Add Task',
+        'class' => 'no-popup',
+      ],
+      [
+        'name' => 'Add Document',
+        'url' => 'civicrm/tasksassignments/dashboard',
+        'qs' => 'reset=1&cid=%%id%%&openModal=document',
+        'title' => 'Add Document',
+        'class' => 'no-popup',
+        'bit' => 7002,
+      ],
+      [
+        'name' => 'Add Workflow',
+        'url' => 'civicrm/tasksassignments/dashboard',
+        'qs' => 'reset=1&cid=%%id%%&openModal=assignment',
+        'title' => 'Add Workflow',
+        'ref' => 'new-activity',
+        'class' => 'no-popup',
+      ],
+      [
+        'name' => 'Delete Staff',
+        'url' => 'civicrm/contact/view/delete',
+        'qs' => 'reset=1&delete=&cid=%%id%%',
+        'title' => 'Delete Staff',
+        'class' => 'no-popup',
+      ],
+      [
+        'name' => 'Delete Staff Permanently',
+        'url' => 'civicrm/contact/view/delete',
+        'qs' => 'reset=1&delete=&cid=%%id%%&skip_undelete=1',
+        'title' => 'Delete Staff Permanently',
+        'class' => 'no-popup',
+      ],
+    ];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/hrcore.php
+++ b/uk.co.compucorp.civicrm.hrcore/hrcore.php
@@ -130,6 +130,26 @@ function hrcore_civicrm_buildForm($formName, &$form) {
 }
 
 /**
+ * Implements hook_civicrm_links().
+ *
+ * @param string $op
+ * @param string $objectName
+ * @param mixed $objectId
+ * @param array $links
+ * @param string $mask
+ * @param array $values
+ */
+function hrcore_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$values) {
+  $listeners = [
+    new CRM_HRCore_Hook_Links_ContactCustomActions(),
+  ];
+
+  foreach ($listeners as $currentListener) {
+    $currentListener->handle($op, $objectName, $objectId, $links, $mask, $values);
+  }
+}
+
+/**
  * Implements hook_civicrm_preProcess().
  *
  * @param string $formName


### PR DESCRIPTION
## Overview
This PR modifies the actions available for individual contact on the Staff directory search results page for Individual contacts.

## Before
<img width="609" alt="staff directory _ staging54 2018-10-26 14-39-40" src="https://user-images.githubusercontent.com/6951813/47570066-20180180-d92d-11e8-8cfc-7f58d7d7c6b6.png">


## After
After searching the following actions are available for each staff member in the list:

* Record Leave
* Record Sickness
* Record Overtime
* Add Task
* Add Document
* Add Workflow
* Delete Staff
* Delete Staff Permanently
<img width="610" alt="staff directory _ staging54 2018-10-26 14-39-02" src="https://user-images.githubusercontent.com/6951813/47570050-17bfc680-d92d-11e8-998e-df1992724775.png">


## Technical Details
The `hrcore_civicrm_links` hook was used to modify the contact links for the staff directory search page. 

