### PR TITLE
PCHR-4317: Add menu URL for staff directory.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Menu/Config/StaffDirectory.php
@@ -1,0 +1,24 @@
+<?php
+
+class CRM_HRCore_Menu_Config_StaffDirectory {
+
+  /**
+   *  Returns the Staff Directory menu Item.
+   *
+   * @return array
+   */
+  public static function getItems() {
+    $result = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id' => 'custom_search',
+      'name' => 'CRM_HRCore_Form_Search_StaffDirectory',
+    ]);
+
+    $searchDirectoryURL = '';
+    if (!empty($result['value'])) {
+      $searchDirectoryURL =
+        "civicrm/contact/search/custom?csid={$result['value']}&force=1&reset=1&select_staff=current";
+    }
+
+    return ['url' => $searchDirectoryURL, 'separator' => 1];
+  }
+}

--- a/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
@@ -1,17 +1,5 @@
 <?php
 
-$result = civicrm_api3('OptionValue', 'getsingle', [
-  'option_group_id' => 'custom_search',
-  'name' => 'CRM_HRCore_Form_Search_StaffDirectory',
-]);
-
-$searchDirectoryURL = '';
-if (!empty($result['value'])) {
-  $searchDirectoryURL =
-    "civicrm/contact/search/custom?csid={$result['value']}&force=1&reset=1&select_staff=current";
-}
-
-
 return [
   'Home' => 'civicrm/tasksassignments/dashboard#/tasks',
 
@@ -22,10 +10,7 @@ return [
         'url' => 'civicrm/contact/add?reset=1&ct=Individual',
         'permission' => 'add contacts',
       ],
-      'Staff Directory' => [
-        'url' => $searchDirectoryURL,
-        'separator' => 1
-      ],
+      'Staff Directory' => CRM_HRCore_Menu_Config_StaffDirectory::getItems(),
       'Record Communication' => [
         'children' => [
           'New Email' => 'civicrm/activity/email/add?atype=3&action=add&reset=1&context=standalone',

--- a/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/main.php
@@ -1,5 +1,17 @@
 <?php
 
+$result = civicrm_api3('OptionValue', 'getsingle', [
+  'option_group_id' => 'custom_search',
+  'name' => 'CRM_HRCore_Form_Search_StaffDirectory',
+]);
+
+$searchDirectoryURL = '';
+if (!empty($result['value'])) {
+  $searchDirectoryURL =
+    "civicrm/contact/search/custom?csid={$result['value']}&force=1&reset=1&select_staff=current";
+}
+
+
 return [
   'Home' => 'civicrm/tasksassignments/dashboard#/tasks',
 
@@ -11,7 +23,7 @@ return [
         'permission' => 'add contacts',
       ],
       'Staff Directory' => [
-        'url' => '/civicrm/contact/search/advanced?reset=1',
+        'url' => $searchDirectoryURL,
         'separator' => 1
       ],
       'Record Communication' => [


### PR DESCRIPTION
## Overview
This PR adds the URL for the Staff Directory Page. The URL opens the page listing the current staff.
## Before
- A placeholder URL was in place

## After
![staffdirectory](https://user-images.githubusercontent.com/6951813/47571730-3031e000-d931-11e8-9a40-6262e5ab5835.gif)

