### PR TITLE
PCHR-4353: Fix autocompletion for Backup Leave Approver field

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/js/src/leave-absences/leave-type-wizard/components/fields-templates/leave-type-wizard-field-notification_receivers_ids.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/js/src/leave-absences/leave-type-wizard/components/fields-templates/leave-type-wizard-field-notification_receivers_ids.html
@@ -7,7 +7,7 @@
       <ui-select-match placeholder="Search Staff Member" allow-clear>
         {{$item.display_name}}
       </ui-select-match>
-      <ui-select-choices repeat="contact.contact_id as contact in form.contacts">
+      <ui-select-choices repeat="contact.contact_id as contact in (form.contacts | filter: $select.search)">
         {{contact.display_name}}
       </ui-select-choices>
     </ui-select>


### PR DESCRIPTION
## Overview

This PR fixes autocompletion for Backup Leave Approver field. The autocompletion was accidentally removed in https://github.com/compucorp/civihr/pull/2908. 

## Technical Details

```html
<ui-select
  ...
  <ui-select-choices repeat="contact.contact_id as contact in (form.contacts | filter: $select.search)">
    {{contact.display_name}}
```

Basically `(form.contacts | filter: $select.search)` instead of just `form`.

----

✅Manual Tests - passed
⏹Jasmine Tests - not neededmended & passed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed