### PR TITLE
PCHR-4350: Existing Sickness Leave Request Migration

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader.php
@@ -34,6 +34,7 @@ class CRM_HRLeaveAndAbsences_Upgrader extends CRM_HRLeaveAndAbsences_Upgrader_Ba
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1034;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1035;
   use CRM_HRLeaveAndAbsences_Upgrader_Step_1036;
+  use CRM_HRLeaveAndAbsences_Upgrader_Step_1037;
 
   /**
    * A list of directories to be scanned for XML installation files

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1037.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Upgrader/Step/1037.php
@@ -1,0 +1,67 @@
+<?php
+
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
+use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
+
+trait CRM_HRLeaveAndAbsences_Upgrader_Step_1037 {
+  /**
+   * Updates request type and sickness reason for sickness leave requests
+   *
+   * @return bool
+   */
+  public function upgrade_1037() {
+    $sickAbsenceTypeId = $this->up1037_getSicknessAbsenceTypeId();
+    if (count($sickAbsenceTypeId) === 0) {
+      return TRUE;
+    }
+
+    $sicknessReasons = array_flip(LeaveRequest::buildOptions('sickness_reason', 'validate'));
+    $otherSicknessReason = $sicknessReasons['other'];
+    $sicknessLeaveRequests = $this->up1037_getSicknessLeaveRequests($sickAbsenceTypeId);
+
+    foreach ($sicknessLeaveRequests as $sicknessLeaveRequest) {
+      $sicknessLeaveRequest->request_type = LeaveRequest::REQUEST_TYPE_SICKNESS;
+      $sicknessLeaveRequest->sickness_reason = $otherSicknessReason;
+      $sicknessLeaveRequest->save(FALSE);
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Retrieves ids of sickness absence type
+   *
+   * @return array
+   */
+  private function up1037_getSicknessAbsenceTypeId() {
+    $sicknessIds = [];
+    $absenceType = new AbsenceType();
+    $absenceType->is_sick = 1;
+    $absenceType->find();
+    while ($absenceType->fetch()) {
+      $sicknessIds[] = $absenceType->id;
+    }
+
+    return $sicknessIds;
+  }
+
+  /**
+   * Retrieves sickness leave requests
+   *
+   * @param $sicknessIds
+   *
+   * @return array
+   */
+  private function up1037_getSicknessLeaveRequests($sicknessIds) {
+    $leaveRequests = [];
+    $leaveRequest = new LeaveRequest();
+    $leaveRequest->whereAdd('request_type != "' . LeaveRequest::REQUEST_TYPE_SICKNESS . '"');
+    $leaveRequest->whereAdd('type_id in (' . implode(',', $sicknessIds) . ')');
+    $leaveRequest->find();
+    while ($leaveRequest->fetch()) {
+      $leaveRequests[] = clone $leaveRequest;
+    }
+
+    return $leaveRequests;
+  }
+}


### PR DESCRIPTION
## Overview
Due to categorization of absence types on sites, the need arise to ensure those categorized as _is_sick_ also have their leave requests properly categorized. This PR migrates existing sickness leave request for proper alignment.

## Before
Some non sickness leave requests are linked to sickness absence type

## After
Non sickness leave requests are now correctly linked to sickness absence type

## Technical Details
All sickness absence types were fetched
```
private function up1037_getSicknessAbsenceTypeId() {
  $sicknessIds = [];
  $absenceType = new AbsenceType();
  $absenceType->is_sick = 1;
  $absenceType->find();
  while ($absenceType->fetch()) {
    $sicknessIds[] = $absenceType->id;
  }

  return $sicknessIds;
}
```
and their ids used to match sickness leave requests whose request type is not yet `sickness`
```
private function up1037_getSicknessLeaveRequests($sicknessIds) {
  $leaveRequests = [];
  $leaveRequest = new LeaveRequest();
  $leaveRequest->whereAdd('request_type != "' . LeaveRequest::REQUEST_TYPE_SICKNESS . '"');
  $leaveRequest->whereAdd('type_id in (' . implode(',', $sicknessIds) . ')');
  $leaveRequest->find();
  while ($leaveRequest->fetch()) {
    $leaveRequests[] = clone $leaveRequest;
  }

  return $leaveRequests;
}
```
Matched records were updated to sickness reason `other` value
```
....
foreach ($sicknessLeaveRequests as $sicknessLeaveRequest) {
  $sicknessLeaveRequest->request_type = LeaveRequest::REQUEST_TYPE_SICKNESS;
  $sicknessLeaveRequest->sickness_reason = $otherSicknessReason;
  $sicknessLeaveRequest->save(FALSE);
}
...
```
Value for `other` sickness reason was fetched from option values
```
$sicknessReasons = array_flip(LeaveRequest::buildOptions('sickness_reason', 'validate'));
$otherSicknessReason = $sicknessReasons['other'];
```
