### PR TITLE
PCHR-4370: Fix Issue with Staff Directory Page Not Listing Current Staff By Default

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -91,11 +91,11 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
       'location' => 'hrjobroles.location',
     ];
 
-    $allParameters = array_merge($formValues, $this->getAdditionalParameters());
-    $this->params = CRM_Contact_BAO_Query::convertFormValues($allParameters);
+    $this->addAdditionalParameters($formValues);
+    $this->params = CRM_Contact_BAO_Query::convertFormValues($formValues);
     //relative dates are converted to real dates by convertFormValues hence reason for
     //setting the form values after the function has ran.
-    $this->formValues = $allParameters;
+    $this->formValues = $formValues;
     $this->generateQueryClause();
   }
 
@@ -490,24 +490,22 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
   }
 
   /**
-   * Returns additional parameters set via the URL when force = 1
-   * Only form fields that are included in the filters are returned
+   * Adds the additional parameters set via the URL when force = 1
+   * to the form values array.
+   * Only form fields that are included in the filters are added
    * from the URL parameters.
    *
    * @return array
    */
-  private function getAdditionalParameters() {
-    $additionalParameters = [];
-    if (!empty($this->formValues['force']) && $this->formValues['force'] == 1) {
-      foreach($this->filters as $filter) {
-        $additionalParameters['filter'] = filter_input(
+  private function addAdditionalParameters(&$formValues) {
+    if (!empty($_GET['force']) && $_GET['force'] == 1) {
+      foreach($this->filters as $filter => $alias) {
+        $formValues[$filter] = filter_input(
           INPUT_GET,
           $filter,
           FILTER_SANITIZE_STRING);
       }
     }
-
-    return $additionalParameters;
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR fixes an issue with the Staff directory page not opening the results page with current staff selected by default. 

## Before
- All staff is selected rather than current staff when the Staff directory page is opened and all staff are listed in the results page.

![staffdirectorybugbefore](https://user-images.githubusercontent.com/6951813/47916065-3978fa80-dea5-11e8-98d2-996575e9af2e.gif)


## After
The URL for the staff directory page looks like this: `civicrm/contact/search/custom?csid=16&force=1&reset=1&select_staff=current` and its supposed to add the URL parameters to the form parameters however this does not work as expected. This PR refactors the function responsible for adding the URL parameters to the form parameters.

Only current staff are selected and listed in the results page.
![staffdirectorybugafter](https://user-images.githubusercontent.com/6951813/47916085-439af900-dea5-11e8-9186-f2d1b6c5f0ff.gif)
