### PR TITLE
PCHR-4369: Add View and Edit To Individual Contact Actions on Staff Directory Page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Links/ContactCustomActions.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/Links/ContactCustomActions.php
@@ -42,6 +42,20 @@ class CRM_HRCore_Hook_Links_ContactCustomActions {
   private function setContactCustomLinks(&$links) {
     $links = [
       [
+        'name' => 'View',
+        'url' => 'civicrm/contact/view',
+        'class' => 'no-popup',
+        'qs' => 'reset=1&cid=%%id%%',
+        'title' => 'View Staff Details',
+      ],
+      [
+        'name' => 'Edit',
+        'url' => 'civicrm/contact/add',
+        'class' => 'no-popup',
+        'qs' => 'reset=1&action=update&cid=%%id%%',
+        'title' => 'Edit Staff Details',
+      ],
+      [
         'name' => 'Record Leave',
         'url' => 'civicrm/contact/view',
         'class' => 'no-popup',


### PR DESCRIPTION
## Overview
This PR adds the View and Edit actions to the list of available actions for an individual contact on the Staff directory results page.

## Before
- The View and Edit actions were not in the list of available actions.

<img width="610" alt="staff directory _ staging54 2018-11-02 16-37-55" src="https://user-images.githubusercontent.com/6951813/47925330-350d0b80-debe-11e8-99ae-100cf99cb81b.png">

## After
- The View and Edit actions was added to the list of available actions.

<img width="605" alt="staff directory _ staging54 2018-11-02 16-37-07" src="https://user-images.githubusercontent.com/6951813/47925314-29b9e000-debe-11e8-863c-b625d549a665.png">

