### PR TITLE
PCHR-4380: Allow meeting activity and filter by meeting activity.

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityFilterSelectFieldsModifier.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityFilterSelectFieldsModifier.php
@@ -32,11 +32,11 @@ class CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier {
 
     return FALSE;
   }
-  
+
   /**
    * Overrides the include and exclude select activity Form fields on the
    * activities tab of the contact summary page to display only activities of
-   * type Email, Inbound Email, Reminder Sent, Print PDf Letter.
+   * type Email, Inbound Email, Reminder Sent, Print PDf Letter, Meeting.
    *
    * @param object $form
    */
@@ -67,6 +67,6 @@ class CRM_HRCore_Hook_BuildForm_ActivityFilterSelectFieldsModifier {
    * @return array
    */
   private function getAllowedActivityTypes() {
-    return ['Email',  'Inbound Email', 'Reminder Sent', 'Print PDF Letter'];
+    return ['Email', 'Inbound Email', 'Meeting', 'Print PDF Letter', 'Reminder Sent'];
   }
 }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityLinksFilter.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Hook/BuildForm/ActivityLinksFilter.php
@@ -6,7 +6,7 @@ class CRM_HRCore_Hook_BuildForm_ActivityLinksFilter {
    * Determines what happens if the hook is handled.
    * Basically, it filters the activity type links on
    * the activities tab.
-   * 
+   *
    * @param string $formName
    * @param object $form
    */
@@ -20,9 +20,9 @@ class CRM_HRCore_Hook_BuildForm_ActivityLinksFilter {
 
   /**
    * Checks if the hook should be handled.
-   * 
+   *
    * @param string $formName
-   * 
+   *
    * @return bool
    */
   private function shouldHandle($formName) {
@@ -36,8 +36,8 @@ class CRM_HRCore_Hook_BuildForm_ActivityLinksFilter {
   /**
    * Filters the activity type links on the activities tab on the
    * contact summary page so that only links related to the Email,
-   * Inbound Email, Reminder Sent and Print PDf Letter activity types
-   * are returned.
+   * Inbound Email, Reminder Sent and Print PDf Letter and Meeting
+   * activity types are returned.
    *
    * @param object $form
    */
@@ -46,21 +46,42 @@ class CRM_HRCore_Hook_BuildForm_ActivityLinksFilter {
     $activityTypes = [];
     $activityTypeLinks = $form->get_template_vars('activityTypes');
 
-    foreach($activityTypeLinks as $id => $activityTypeLink) {
-      if(in_array($activityTypeLink['name'], $allowedActivities))  {
+    foreach ($activityTypeLinks as $id => $activityTypeLink) {
+      if (!empty($allowedActivities[$activityTypeLink['name']]))  {
+        $activityTypeLink['label'] = $allowedActivities[$activityTypeLink['name']];
         $activityTypes[$id] = $activityTypeLink;
       }
     }
 
+    $this->sortActivityTypes($activityTypes);
     $form->assign('activityTypes', $activityTypes);
   }
 
   /**
-   * Returns the allowed activity types.
-   * 
+   * Returns the allowed activity types in name/label
+   * array format.
+   *
    * @return array
    */
   private function getAllowedActivityTypes() {
-    return ['Email',  'Inbound Email', 'Reminder Sent', 'Print PDF Letter'];
+    return [
+      'Email' => 'Email',
+      'Inbound Email' => 'Inbound Email',
+      'Reminder Sent' => 'Reminder Sent',
+      'Print PDF Letter' => 'Print PDF Letter',
+      'Meeting' => 'Record Meeting'
+    ];
+  }
+
+  /**
+   * Sorts activity types links in an alphabetical
+   * manner based on the label.
+   *
+   * @param array $activityTypes
+   */
+  function sortActivityTypes(&$activityTypes) {
+    usort($activityTypes, function($a, $b) {
+      return strcasecmp($a['label'], $b['label']);
+    });
   }
 }


### PR DESCRIPTION
## Overview
#2444 , modifies the communications tab to restrict what activities can be added and what activities to filtered by.  
This PR adds the meeting activity back to the list of un-restricted activities, i.e it allows to add a meeting Activity from the communications tab and also to filter meeting activity types.

## Before
- The meeting activity can not be added neither can it be filtered by in the communications tab.

<img width="640" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 15-11-16" src="https://user-images.githubusercontent.com/6951813/48006542-f70a2480-e115-11e8-96dd-550c1f8d8b18.png">
<img width="640" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 15-11-06" src="https://user-images.githubusercontent.com/6951813/48006543-f7a2bb00-e115-11e8-9acb-6090d0b72336.png">
<img width="638" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 15-10-13" src="https://user-images.githubusercontent.com/6951813/48006545-f7a2bb00-e115-11e8-98c2-ee1b0bae1350.png">

## After
- A meeting activity (Record Meeting) can now be added, also the Meeting activity is now among the list of activity filters.

<img width="640" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 16-04-05" src="https://user-images.githubusercontent.com/6951813/48006585-0a1cf480-e116-11e8-875c-2792e3850cc0.png">
<img width="640" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 16-03-38" src="https://user-images.githubusercontent.com/6951813/48006586-0a1cf480-e116-11e8-8ba9-912c6a5a2c89.png">
<img width="638" alt="civihr_staff compucorp co uk _ staging54 2018-11-05 16-03-14" src="https://user-images.githubusercontent.com/6951813/48006588-0ab58b00-e116-11e8-9910-36bb7d0b9db9.png">
