### PR TITLE
PCHR-4328: Create Option Groups for Organization Contact in Job Role

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -79,6 +79,25 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
   }
 
   /**
+   * Creates an option group for organisation provider
+   * used for job role funder
+   *
+   * @return bool
+   */
+  public function upgrade_1007() {
+    $result = civicrm_api3('OptionGroup', 'get', [
+      'name' => 'hrjc_funder',
+    ]);
+
+    if ($result['count'] === 0) {
+      $file = 'xml/option_groups/organisation_provider_install.xml';
+      $this->executeCustomDataFile($file);
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Deletes cost centre option value with name "other"
    */
   private function deleteCostCentreOther() {

--- a/com.civicrm.hrjobroles/xml/option_groups/organisation_provider_install.xml
+++ b/com.civicrm.hrjobroles/xml/option_groups/organisation_provider_install.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="iso-8859-1" ?>
+
+<CustomData>
+
+  <OptionGroups>
+    <OptionGroup>
+      <name>hrjc_funder</name>
+      <title>Job Role Funder</title>
+      <is_reserved>1</is_reserved>
+      <is_active>1</is_active>
+    </OptionGroup>
+  </OptionGroups>
+
+</CustomData>


### PR DESCRIPTION
## Overview
For setting up job role funder, organisation contact records were created for such. This PR creates an option group for the purpose of managing funders list.

## Before
There were no option group for managing job role funders.

## After
An option group is created for managing list of funders.

## Technical Details
An XML file was created for setting up funders option groups. This was then installed by an upgrader, creating the required option group in the process.

```
if ($result['count'] === 0) {
  $file = 'xml/option_groups/organisation_contact_install.xml';
  $this->executeCustomDataFile($file);
}
```
