### PR TITLE
PCHR-4335: Link Option Group to Configure Menu

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/config/menu/configure.php
+++ b/uk.co.compucorp.civicrm.hrcore/config/menu/configure.php
@@ -41,8 +41,20 @@ return [
         'url' => 'civicrm/admin/options/hrjc_deduction_name?reset=1',
         'permission' => 'access CiviCRM',
       ],
+      'Health Insurance Providers' => [
+        'url' => 'civicrm/admin/options/hrjc_health_insurance_provider?reset=1',
+        'permission' => 'access CiviCRM',
+      ],
+      'Life Insurance Providers' => [
+        'url' => 'civicrm/admin/options/hrjc_life_insurance_provider?reset=1',
+        'permission' => 'access CiviCRM',
+      ],
       'Insurance Plan Types' => [
         'url' => 'civicrm/admin/options/hrjc_insurance_plantype?reset=1',
+        'permission' => 'access CiviCRM',
+      ],
+      'Pension Providers' => [
+        'url' => 'civicrm/admin/options/hrjc_pension_provider?reset=1',
         'permission' => 'access CiviCRM',
       ],
     ],
@@ -65,6 +77,10 @@ return [
       ],
       'Levels' => [
         'url' => 'civicrm/admin/options/hrjc_level_type?reset=1',
+        'permission' => 'access CiviCRM',
+      ],
+      'Funders' => [
+        'url' => 'civicrm/admin/options/hrjc_funder?reset=1',
         'permission' => 'access CiviCRM',
       ],
       'Cost Centres' => [


### PR DESCRIPTION
## Overview
New options groups were added in [#2919](https://github.com/compucorp/civihr/pull/2919) and [#2920](https://github.com/compucorp/civihr/pull/2920). This PR creates a link to each option group page in the configure menu . The option groups are Health Insurance Provider, Life Insurance Provider, Pension Provider and Funder (for job roles).

## Before
<img width="291" alt="job_contract_before" src="https://user-images.githubusercontent.com/1507645/48073536-42d4d080-e1df-11e8-8c24-3b7a44f1b455.png">

<img width="276" alt="job_role_before" src="https://user-images.githubusercontent.com/1507645/48073553-48cab180-e1df-11e8-9255-d89a81a3f98a.png">

## After
<img width="292" alt="job_contract_after" src="https://user-images.githubusercontent.com/1507645/48076780-3d2eb900-e1e6-11e8-90fa-8aaf0a2ce1cd.png">

<img width="300" alt="job_roles_after" src="https://user-images.githubusercontent.com/1507645/48075370-6ef25080-e1e3-11e8-82e1-863acb85a821.png">


## Technical Details
The configure file was updated with link to each of the added option groups
```
...
'Health Insurance Providers' => [
  ...
],
'Life Insurance Providers' => [
  ...
],
'Pension Providers' => [
  ...
],
...
'Funders' => [
  ...
],
```
