### PR TITLE
PCHR-4374: Recreate missing "Open Case" activity type

### DIFF
--- a/hrcase/CRM/HRCase/Upgrader.php
+++ b/hrcase/CRM/HRCase/Upgrader.php
@@ -170,6 +170,40 @@ class CRM_HRCase_Upgrader extends CRM_HRCase_Upgrader_Base {
   }
 
   /**
+   * CiviCRM has the Open Case activity type hardcoded in some places of the
+   * code dealing with creating new Case Types, meaning that it must always be
+   * present.
+   *
+   * During the CiviHR 1.7.11 release, we uninstalled the hrrecruitment extension
+   * and together with that the Application case type. This triggered the deletion
+   * of the "Open Case" activity type (which was used by Application) making it
+   * impossible to create new Case Types on the sites where this happened.
+   *
+   * We still don't know exactly why this deletion happened, but this upgrader
+   * makes sure the missing activity type will exist.
+   *
+   * @return bool
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function upgrade_1433() {
+    $optionValue = [
+      'option_group_id' => 'activity_type',
+      'name' => 'Open Case',
+      'label' => 'Created New Assignment',
+      'component_id' => 'CiviTask',
+    ];
+    $result = civicrm_api3('OptionValue', 'get', $optionValue);
+
+    if (!$result['count']) {
+      $optionValue['is_reserved'] = 1;
+      $optionValue['icon'] = 'fa-folder-open-o';
+      civicrm_api3('OptionValue', 'create', $optionValue);
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Replaces (Case) keyword and (Open Case) keyword with (Assignment) keyword
    * and (Created New Assignment) keyword respectively and vise versa for
    * civicrm default activity types labels when installing/uninstalling the extension.


### PR DESCRIPTION
## Overview

Some clients reported they were not able to create new Workflow types. After some investigation, we discovered that this was happening because the "Open Case" activity type was missing in these sites.

## Before

The "Open Case" activity type is missing is some sites. This prevents users from creating new Workflow types.

## After

The "Open Case" activity type is recreated in the sites where it was missing and users can create new Workflow types.

## Technical Details

Workflow types are nothing more than Case Types. When creating a new Case Type, civi uses a harcoded template for the Case Type definition and [this template includes the "Open Case"](https://github.com/civicrm/civicrm-core/blob/ffee3b9dc3d728ae951bff8fbc106acf7ed3cbb5/ang/crmCaseType.js#L13) by default. This is the reason users cannot create new Workflow types when it is missing.

The label is set as "Created New Assignment", because this is how it is supposed to be labeled on sites where the activity type is present. We have this method in hrcase which is called while the extension is being installed: https://github.com/compucorp/civihr/blob/master/hrcase/CRM/HRCase/Upgrader.php#L181-L202

## Comments

The "Open Case" activity type is supposed to be created automatically when enabling the CiviCase component and creating some Case Types that use it. For some uncertain reason, when the HRRecruitment extension uninstalled during the CiviHR 1.7.11 release the activity type ended up being deleted.