### PR TITLE
PCHR-4328: Renamed Funder Option Group API Title

### DIFF
--- a/com.civicrm.hrjobroles/xml/option_groups/organisation_provider_install.xml
+++ b/com.civicrm.hrjobroles/xml/option_groups/organisation_provider_install.xml
@@ -5,7 +5,7 @@
   <OptionGroups>
     <OptionGroup>
       <name>hrjc_funder</name>
-      <title>Job Role Funder</title>
+      <title>Funder</title>
       <is_reserved>1</is_reserved>
       <is_active>1</is_active>
     </OptionGroup>


### PR DESCRIPTION
## Overview
Option group was created with `Job role funder` in https://github.com/compucorp/civihr/pull/2920. This PR renamed the title to `Funder`.

## Before
Option group title for Job role is "Job Role Funder"

## After
Option group title for Job role is "Funder"

## Comments
The option group title was renamed.
