### PR TITLE
PCHR-4384: Fix Job Contract End Date Filter Bug

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -547,9 +547,8 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
       $fromDate = new DateTime($this->formValues['contract_end_date_low']);
       $toDate = new DateTime($this->formValues['contract_end_date_high']);
 
-      $conditions[] = "((contract_details.period_end_date >= '" . $fromDate->format('Y-m-d') .  "'
-        AND contract_details.period_end_date <= '" . $toDate->format('Y-m-d') . "')
-        OR (contract_details.period_end_date IS NULL))";
+      $conditions[] = "contract_details.period_end_date >= '" . $fromDate->format('Y-m-d') .  "'
+        AND contract_details.period_end_date <= '" . $toDate->format('Y-m-d') . "'";
     }
 
     return implode(' AND ', $conditions);

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -790,6 +790,90 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEmpty($results);
   }
 
+  public function testSelectStaffFilterCanFilterStaffCorrectlyWhenOnlyJobContractEndDateIsSelected() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_end_date_relative' => 0,
+      'contract_end_date_low' => '2016-12-31',
+      'contract_end_date_high' => '2016-12-31'
+    ];
+
+    $searchDirectory = new SearchDirectory($formValues);
+    //only Contact1 has contract end date between the given contract end low and high dates
+    $results = $this->extractColumnValues($searchDirectory->all(0, 10));
+    $expectedResults = [
+      [
+        'contact_id' => $contact1['id'],
+        'display_name' => $contact1['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ],
+    ];
+    $this->assertEquals($expectedResults, $results);
+  }
+
+  public function testSelectStaffFilterCanFilterStaffCorrectlyWhenOnlyJobContractStartDateIsSelected() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+    $contact3 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => '2018-01-01']
+    );
+
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_start_date_relative' => 0,
+      'contract_start_date_low' => '2018-01-01',
+      'contract_start_date_high' => '2018-01-01'
+    ];
+
+    $searchDirectory = new SearchDirectory($formValues);
+    //only Contact2 has contract start date between the given contract start low and high dates
+    $results = $this->extractColumnValues($searchDirectory->all(0, 10));
+    $expectedResults = [
+      [
+        'contact_id' => $contact2['id'],
+        'display_name' => $contact2['display_name'],
+        'work_phone' => NULL,
+        'work_email' => NULL,
+        'manager' => NULL,
+        'location' => NULL,
+        'department' => NULL,
+        'job_title' => NULL,
+      ],
+    ];
+    $this->assertEquals($expectedResults, $results);
+  }
+
   private function extractContactIds($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
     $contactId = [];

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -203,7 +203,10 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
 
     HRJobContractFabricator::fabricate(
       ['contact_id' => $contact2['id']],
-      ['period_start_date' => date('Y-m-d')]
+      [
+        'period_start_date' => date('Y-m-d'),
+        'period_end_date' => date('Y-m-d')
+      ]
     );
 
     $formValues = [
@@ -219,7 +222,7 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $searchDirectory = new SearchDirectory($formValues);
 
     //only Contact2 has contract start dates within this year
-    //and also end date within this year(since period end date is NULL)
+    //and also end date within this year
     $this->assertEquals(1, $searchDirectory->count());
 
     //verify contact ids


### PR DESCRIPTION
## Overview
When the Job contract end date filter is selected on the Staff directory page without selecting the Job contract start date, it leads to unpredictable results as contacts that does not match the job contract end date filter criteria are also displayed.

## Before
Currently, the Staff directory SQL allows contacts with contract without an end date to show up in results as long as the condition for their contract start dates are met.

For example: A staff with contract start date Jan 1, 2018 and no contract end date.
If contract start date filter is Jan 1, 2018  and contract end date filter is Today, the staff will show up in the search results.

The SQL part that takes care of this logic adds the `OR (contract_details.period_end_date IS NULL)` . If no contract start date is selected, this led to unpredictable results as contracts without a contract will now come up as part of the search results as well as contracts without a contract end date in addition to valid contracts that meet the criteria.

## After
It was decided to not add any extra logic for contacts having contracts without end dates. i.e 

For example: A staff with contract start date Jan 1, 2018 and no contract end date.
If contract start date filter is Jan 1, 2018  and contract end date filter is Today, the staff will not show up in the search results. The staff will only show up if the contract start date filter is Jan 1, 2018 and the contract end date filter is not selected.
