### PR TITLE
PCHR-4383: Reorder Staff Directory Columns

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -75,12 +75,12 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
   public function __construct(&$formValues) {
     $this->columns = [
       ts('Name') => 'display_name',
-      ts('Work Phone') => 'work_phone',
       ts('Work Email') => 'work_email',
+      ts('Work Phone') => 'work_phone',
+      ts('Job Title') => 'job_title',
       ts('Manager') => 'manager',
       ts('Location') => 'location',
       ts('Department') => 'department',
-      ts('Job Title') => 'job_title',
     ];
 
     $this->filters = [


### PR DESCRIPTION
## Overview
This PR reorders the staff directory columns to match the wireframe at https://compucorp.atlassian.net/wiki/spaces/PCHR/pages/134906300/Improve+the+Staff+menu+items

## Before
- The  search results columns are not ordered according to the wireframe.

## After
The search results columns are ordered according to the wireframe.

- Name
- Work Email
- Work Phone
- Job Title
- Manager
- Location
- Department
- Actions


<img width="1250" alt="staff directory staging54 2018-11-09 12-56-41" src="https://user-images.githubusercontent.com/6951813/48261989-2fb14300-e421-11e8-9aea-12533c4d5afe.png">
