### PR TITLE
PCHR-4385: Redirect to Absence Period Listing Page After Saving Entitlements

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
@@ -97,7 +97,7 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
 
         $url =  CRM_Utils_System::url(
           'civicrm/admin/leaveandabsences/periods/manage_entitlements',
-          'reset=1&id=' . $absenceType->id . "&returnUrl=" . urlencode($returnUrl)
+          'reset=1&id=' . $absenceType->id . '&returnUrl=' . urlencode($returnUrl)
         );
       }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/AbsencePeriod.php
@@ -90,9 +90,15 @@ class CRM_HRLeaveAndAbsences_Form_AbsencePeriod extends CRM_Core_Form {
       $url = CRM_Utils_System::url('civicrm/admin/leaveandabsences/periods', 'reset=1&action=browse');
 
       if ($params['confirmEntitlement'] == 'yes' && !empty($absenceType)) {
+        $returnUrl = CRM_Utils_System::url(
+          'civicrm/admin/leaveandabsences/periods',
+          'action=browse&reset=1'
+        );
+
         $url =  CRM_Utils_System::url(
           'civicrm/admin/leaveandabsences/periods/manage_entitlements',
-          'reset=1&id=' . $absenceType->id);
+          'reset=1&id=' . $absenceType->id . "&returnUrl=" . urlencode($returnUrl)
+        );
       }
 
       $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
## Overview
When creating a new absence period and the user is directed to proceed to the calculate entitlements page, after the entitlements calculation is saved, the user should be redirected back to the Absence period listing page.

## Before
- The user is not redirected to absence period listing page after calculating entitlements for a new absence period.

## After
- The user is redirected to absence period listing page after calculating entitlements for a new absence period.

![returnurl](https://user-images.githubusercontent.com/6951813/48266842-ebc63a00-e430-11e8-9b62-a29c0426679a.gif)
