### PR TITLE
PCHR-4398: Fix Issue With Contract Dates Filter Not Working For Certain Date Options

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -535,20 +535,24 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
    */
   private function getWhenSelectStaffIsChooseDate() {
     $conditions = [];
-    if (!empty($this->formValues['contract_start_date_low']) && !empty($this->formValues['contract_start_date_high'])) {
+    if (!empty($this->formValues['contract_start_date_low'])) {
       $fromDate = new DateTime($this->formValues['contract_start_date_low']);
-      $toDate = new DateTime($this->formValues['contract_start_date_high']);
-
-      $conditions[] = "contract_details.period_start_date >= '" . $fromDate->format('Y-m-d') .
-        "' AND contract_details.period_start_date <= '" . $toDate->format('Y-m-d') . "'";
+      $conditions[] = "contract_details.period_start_date >= '" . $fromDate->format('Y-m-d') . "'";
     }
 
-    if (!empty($this->formValues['contract_end_date_low']) && !empty($this->formValues['contract_end_date_high'])) {
-      $fromDate = new DateTime($this->formValues['contract_end_date_low']);
-      $toDate = new DateTime($this->formValues['contract_end_date_high']);
+    if (!empty($this->formValues['contract_start_date_high'])) {
+      $toDate = new DateTime($this->formValues['contract_start_date_high']);
+      $conditions[] = "contract_details.period_start_date <= '" . $toDate->format('Y-m-d') . "'";
+    }
 
-      $conditions[] = "contract_details.period_end_date >= '" . $fromDate->format('Y-m-d') .  "'
-        AND contract_details.period_end_date <= '" . $toDate->format('Y-m-d') . "'";
+    if (!empty($this->formValues['contract_end_date_low'])) {
+      $fromDate = new DateTime($this->formValues['contract_end_date_low']);
+      $conditions[] = "contract_details.period_end_date >= '" . $fromDate->format('Y-m-d') .  "'";
+    }
+
+    if (!empty($this->formValues['contract_end_date_high'])) {
+      $toDate = new DateTime($this->formValues['contract_end_date_high']);
+      $conditions[] = "contract_details.period_end_date <= '" . $toDate->format('Y-m-d') . "'";
     }
 
     return implode(' AND ', $conditions);

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Form/Search/StaffDirectory.php
@@ -501,6 +501,9 @@ class CRM_HRCore_Form_Search_StaffDirectory implements CRM_Contact_Form_Search_I
   private function addAdditionalParameters(&$formValues) {
     if (!empty($_GET['force']) && $_GET['force'] == 1) {
       foreach($this->filters as $filter => $alias) {
+        if (empty($_GET[$filter])) {
+          continue;
+        }
         $formValues[$filter] = filter_input(
           INPUT_GET,
           $filter,

--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Form/Search/StaffDirectoryTest.php
@@ -874,6 +874,159 @@ class CRM_HRCore_Form_Search_StaffDirectoryTest extends CRM_HRCore_Test_BaseHead
     $this->assertEquals($expectedResults, $results);
   }
 
+  public function testSelectStaffCanFilterCorrectlyForRelativeDateWhereEndDateRangeIsNotPopulatedForJobContractStartDate() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => date('Y-m-d', strtotime('this year January 1st'))]
+    );
+
+    //When the greater_previous.year option is selected and Civi converts the date to actual dates
+    //only the contract_start_date_low field is populated. i.e the SQL condition will be where
+    //contract start date >= From End of previous calendar year.
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_start_date_relative' => 'greater_previous.year',// From End of previous calendar year option
+      'contract_start_date_low' => '',
+      'contract_start_date_high' => '',
+    ];
+
+    $searchDirectory = new SearchDirectory($formValues);
+
+    //only Contact2 has contract start dates >= from end of previous year
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact2['id']]);
+  }
+
+  public function testSelectStaffCanFilterCorrectlyForRelativeDateWhereStartDateRangeIsNotPopulatedForJobContractStartDate() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2025-01-01',
+        'period_end_date' => '2025-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      ['period_start_date' => date('Y-m-d', strtotime('last year December 31st'))]
+    );
+
+    //When the earlier.year option is selected and Civi converts the date to actual dates
+    //only the contract_start_date_high field is populated. i.e the SQL condition will be where
+    //contract start date <= To End of previous calendar year.
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_start_date_relative' => 'earlier.year',// To End of previous calendar year option
+      'contract_start_date_low' => '',
+      'contract_start_date_high' => '',
+    ];
+
+    $searchDirectory = new SearchDirectory($formValues);
+
+    //only Contact2 has contract start dates <= to end of previous year
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact2['id']]);
+  }
+
+  public function testSelectStaffCanFilterCorrectlyForRelativeDateWhereStartDateRangeIsNotPopulatedForJobContractEndDate() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2025-01-01',
+        'period_end_date' => '2025-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => date('Y-m-d', strtotime('last year December 31st'))
+      ]
+    );
+
+    //When the earlier.year option is selected and Civi converts the date to actual dates
+    //only the contract_start_date_high field is populated. i.e the SQL condition will be where
+    //contract end date <= To End of previous calendar year.
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_end_date_relative' => 'earlier.year',// To End of previous calendar year option
+      'contract_end_date_low' => '',
+      'contract_end_date_high' => '',
+    ];
+
+    $searchDirectory = new SearchDirectory($formValues);
+
+    //only Contact2 has contract end date <= to end of previous year
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact2['id']]);
+  }
+
+  public function testSelectStaffCanFilterCorrectlyForRelativeDatesWhereEndDateRangeIsNotPopulatedForJobContractEndDate() {
+    $contact1 = ContactFabricator::fabricate();
+    $contact2 = ContactFabricator::fabricate();
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact1['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => '2016-12-31'
+      ]
+    );
+
+    HRJobContractFabricator::fabricate(
+      ['contact_id' => $contact2['id']],
+      [
+        'period_start_date' => '2016-01-01',
+        'period_end_date' => date('Y-m-d', strtotime('this year January 1st'))
+      ]
+    );
+
+    //When the greater_previous.year option is selected and Civi converts the date to actual dates
+    //only the contract_start_date_low field is populated. i.e the SQL condition will be where
+    //contract end date >= From End of previous calendar year.
+    $formValues = [
+      'select_staff' => 'choose_date',
+      'contract_end_date_relative' => 'greater_previous.year',// From End of previous calendar year option
+      'contract_end_date_low' => '',
+      'contract_end_date_high' => '',
+    ];
+    $searchDirectory = new SearchDirectory($formValues);
+
+    //only Contact2 has contract end dates >= from end of previous year
+    $this->assertEquals(1, $searchDirectory->count());
+
+    //verify contact ids
+    $contactIds = $this->extractContactIds($searchDirectory->contactIDs()) ;
+    $this->assertEquals($contactIds, [$contact2['id']]);
+  }
+
   private function extractContactIds($sql) {
     $result = CRM_Core_DAO::executeQuery($sql);
     $contactId = [];


### PR DESCRIPTION
## Overview
When a relative date options are selected for the Contract Start date or Contract end dates filters, It leads to unpredictable results. Also a bug related to sorting columns on the staff directory which will reset the entire results set was fixed.

## Before
- When a relative date such as `To End Of Previous Calendar Year` is selected for any of the contract date fields, rather than return the results that satisfy the criteria, the whole result set is returned.

- When a column is sorted on the Staff directory, it resets/ignores the current filter values  and returns the whole result set.


## After
- When a relative date such as `Current Year` is selected,  Internally Civi will translate this relative date to two date values, more like a lower date and higher date range. Current year will evaluate to
Start Date Range: 2018-01-01
End Date Range: 2018-12-31
This SQL query used to filter contract dates was based off this assumption. However there are certain relative date options that only has one of the date ranges populated. E.g `From End of previous calendar year` option will only populate the Start Date range field while the End Date Range field is left as NULL. This PR takes care of these scenarios and refactors the SQL query that is generated when a staff is filtered by contract dates.

- When a column is sorted on the Staff directory, the results set is not preserved and not reset.

## Technical Details
- When a column is sorted on the Staff directory, the `force=1` parameter is sent to the `CRM_HRCore_Form_Search_StaffDirectory` class where the addAdditionalParameters function replaces filter values with a NULL value even if the filter is not present in the $_GET request thereby introducing a bug. This was fixed by refactoring the function.

```php
  private function addAdditionalParameters(&$formValues) {
    if (!empty($_GET['force']) && $_GET['force'] == 1) {
      foreach($this->filters as $filter => $alias) {
        if (empty($_GET[$filter])) {
          continue;
        }
        $formValues[$filter] = filter_input(
          INPUT_GET,
          $filter,
          FILTER_SANITIZE_STRING);
      }
    }
  }
```
