### PR TITLE
PCHR-4398: Fix the date range filters on Staff Directory page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryFiltersSection.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryFiltersSection.tpl
@@ -86,6 +86,7 @@
 
     /**
      * Toggles contract dates depending on the related Date Range selector value
+     * If it gets hidden, it flushes the inputs of the absolute date range fields.
      *
      * @param {jQuery} $dateRangeSelector
      */
@@ -94,24 +95,29 @@
       var $absoluteDateRange = $dateRangeSelector
         .closest(CONTRACT_DATES_BLOCK_CLASS)
         .find('.absolute-date-range');
-      var toggleFunction = absoluteDateRangeOptionSelected
-        ? 'removeClass'
-        : 'addClass';
 
-      $absoluteDateRange[toggleFunction]('hidden');
+      if (absoluteDateRangeOptionSelected) {
+        $absoluteDateRange.removeClass('hidden');
+      } else {
+        $absoluteDateRange.addClass('hidden');
+        $absoluteDateRange.find('input').val('');
+      }
     }
 
     /**
      * Toggles contract dates depending on the Select Staff control value
+     * If it gets hidden, it flushes the date range selector.
      */
     function toggleContractDates() {
       var selectStaffValue = $('#select-staff select').val();
       var $contractDates = $(CONTRACT_DATES_BLOCK_CLASS);
-      var toggleFunction = selectStaffValue === 'choose_date'
-        ? 'removeClass'
-        : 'addClass';
 
-      $contractDates[toggleFunction]('hidden');
+      if (selectStaffValue === 'choose_date') {
+        $contractDates.removeClass('hidden');
+      } else {
+        $contractDates.addClass('hidden');
+        $contractDates.find('.crm-select2').select2('val', '').change();
+      }
     }
   });
   {/literal}


### PR DESCRIPTION
## Overview

This PR fixes an issue with date range filters on the Staff Directory page.

## Before

Selectors do not flush the data inside inputs on toggling:

![1](https://user-images.githubusercontent.com/3973243/48363646-4fa16a80-e69e-11e8-8fe4-4903777c8187.gif)

## After

Selectors **do** flush the data inside inputs on toggling:

![2](https://user-images.githubusercontent.com/3973243/48363657-54feb500-e69e-11e8-9761-774b0eebcb57.gif)

## Technical Details

We amend the function which is triggered when date range selector is changed so it also flushes date range fields:
```js
function toggleAbsoluteDateRangeFields ($dateRangeSelector) {
  // ...

  if (absoluteDateRangeOptionSelected) {
    $absoluteDateRange.removeClass('hidden');
  } else {
    $absoluteDateRange.addClass('hidden');
    $absoluteDateRange.find('input').val(''); // <<< here
  }
```

We also do a similar thing to the contact range selector:

```js
function toggleContractDates() {
  // ...

  if (selectStaffValue === 'choose_date') {
    $contractDates.removeClass('hidden');
  } else {
    $contractDates.addClass('hidden');
    $contractDates.find('.crm-select2').select2('val', '').change(); // <<< here
    // NOTE: this also will trigger toggleAbsoluteDateRangeFields()
``` 

Now if something gets hidden it also flushes the data which was hidden, even in a chain manner.

-----

✅Manual Tests - passed
⏹Jasmine Tests - not needed, only jQuery JS is used
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - suppressed
⏹PHP Unit Tests - not needed