### PR TITLE
PCHR-4401: Fix selector counter after submit on Staff Directory page

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
@@ -1,3 +1,5 @@
+{* This input is needed to flush the selections after submit *}
+<input type="hidden" name="_qf_Custom_refresh" value="true"/>
 <div id="bootstrap-theme">
   <div class="staff-directory panel panel-default">
     {* Top bar section *}


### PR DESCRIPTION
## Overview

This PR fixes the issue with selectors counter after submitting filters on Staff Directory page

## Before

The counter is not reset:

![1](https://user-images.githubusercontent.com/3973243/48411022-406efb00-e738-11e8-8cf1-8fc7b0c15ca1.gif)

## How it should work

This GIF was taken from the commit before styling started:

![3](https://user-images.githubusercontent.com/3973243/48411059-5aa8d900-e738-11e8-8125-6cb6b5bb48ed.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/48411073-61375080-e738-11e8-8cb0-f80181166bbe.gif)

## Technical Details

The issue was introduced here: https://github.com/compucorp/civihr/pull/2922/commits/79b3363199680d225a3658ae5202ede63c89e2ac

The problem is that earlier the submit buttons were rendered like that:

```
{include file="CRM/common/formButtons.tpl"}
```

which produces the following markup:

```html
<span class="crm-button crm-button-type-refresh crm-button_qf_Custom_refresh crm-i-button">
  <i class="crm-i fa-check"></i>
  <!-- Please note that this is an input with `_qf_Custom_refresh` name and a non-falsy value -->
  <input class="crm-form-submit default validate" crm-icon="fa-check" name="_qf_Custom_refresh" value="Search" type="submit" id="_qf_Custom_refresh">
</span>
```

There were two issues with this markup and they were the reasons why we couldn't use `{include file="CRM/common/formButtons.tpl"}`:
1) Because we now have two submit buttons on the page, we cannot render two buttons with the same ID.
2) Because we need to build bootstrap markup we cannot use this directive because it renders the button as a nested element and some CSS from Bootstrap will not be applied.

So we used:

```html
<button class="btn btn-primary btn-sm">Search</button>
```

This is how we lost the submission of `_qf_Custom_refresh` parameter that actually flushed the selection.

So in order to keep the custom buttons but make the form work as initially, we need to add this parameter to the form:

```
<input type="hidden" name="_qf_Custom_refresh" value="true"/>
```

That fixes the issue because now the same parameter is sent with the form on submit.

------

✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed