### PR TITLE
PCHR-4396: Fix "creating default object from empty value" warning on the SSP

### DIFF
--- a/hrjobcontract/api/v3/HRJobContract.php
+++ b/hrjobcontract/api/v3/HRJobContract.php
@@ -346,11 +346,11 @@ function civicrm_api3_h_r_job_contract_getcurrentcontract($params) {
 
   $contactID = (int) $params['contact_id'];
   $result = CRM_Hrjobcontract_BAO_HRJobContract::getCurrentContract($contactID);
-  $return = null;
+  $return = [];
   if (!empty($result)) {
     $fields = ['contract_id', 'position', 'title', 'period_start_date', 'period_end_date', 'location'];
     foreach($fields as $field) {
-      $return->$field = $result->$field;
+      $return[$field] = $result->$field;
     }
   }
   return civicrm_api3_create_success($return, $params);


### PR DESCRIPTION
## Overview

When accessing the My Details page, as a user with an active contract, the following warning would be displayed:

![warning_sspdashboard](https://user-images.githubusercontent.com/388373/48412020-8de46b80-e72a-11e8-9917-8f7e62694c4c.PNG)

## Before

The warning was displayed on the SSP

## After

The warning is not displayed anymore

## Technical Details

The reason for the warning is that we were trying to use a null variable as an object. So, my first attempt to fix this was to replace the `$return = null` with a `$return = new stdClass`. 

That worked, however I realized that this API was returning an object rather than an array, which is what CiviCRM APIs usually return. This is confusing, so instead of initializing the object, I decided to change the response format to an array.

For clients using the API via JS, this change in the format won't affect anything, as both an object and an array will be converted to a JS object. However, this does affect people using the API via PHP (using the `civicrm_api3()` function). I could only find one place using this API via PHP and [this](https://github.com/compucorp/civihr-employee-portal/pull/562) is the fix for it