### PR TITLE
PCHR-4401: Fix regression with bulk actions on Staff Directory

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectory.tpl
@@ -1,5 +1,3 @@
-{* This input is needed to flush the selections after submit *}
-<input type="hidden" name="_qf_Custom_refresh" value="true"/>
 <div id="bootstrap-theme">
   <div class="staff-directory panel panel-default">
     {* Top bar section *}

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryFiltersSection.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryFiltersSection.tpl
@@ -29,7 +29,7 @@
   {include file="CRM/HRCore/Form/Search/StaffDirectoryFiltersSectionDateRange.tpl" fieldName="contract_end_date" from='_low' to='_high'}
   <div class="row form-group">
     <div class="col-md-2 col-sm-3">
-      <button class="btn btn-primary btn-sm form-control">Filter</button>
+      <input class="btn btn-sm btn-primary" name="_qf_Custom_refresh" value="Filter" type="submit"/>
     </div>
   </div>
 </div>

--- a/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryTopBarSection.tpl
+++ b/uk.co.compucorp.civicrm.hrcore/templates/CRM/HRCore/Form/Search/StaffDirectoryTopBarSection.tpl
@@ -13,7 +13,7 @@
       <div class="input-group">
         {$form.name.html}
         <div class="input-group-btn">
-          <button class="btn btn-primary btn-sm">Search</button>
+          <input class="btn btn-sm btn-primary" name="_qf_Custom_refresh" value="Search" type="submit"/>
         </div>
       </div>
       <div class="text-right">


### PR DESCRIPTION
## Overview

This PR fixes the issue introduced after https://github.com/compucorp/civihr/pull/2938. The solution in the https://github.com/compucorp/civihr/pull/2938 finally worked but broke Bulk Actions selector.

## Before

See https://github.com/compucorp/civihr/pull/2938.

## After

Now everything works:
- Filter forms reset the staff counter
- Bulk actions work as expected

![3](https://user-images.githubusercontent.com/3973243/48414373-6c8f7980-e742-11e8-88f9-b9084fbfd930.gif)

## Technical Details

It was thought that the solution in https://github.com/compucorp/civihr/pull/2938 would help to submit the `_qf_Custom_refresh`, but the problem is that is should *not always* be submitted. It should be submitted only on filters applying.

So, original markup that is used by CiviCRM was used instead:

```
<input class="btn btn-sm btn-primary" name="_qf_Custom_refresh" value="Filter" type="submit"/>
```

## Comments

The "Filter" button is now smaller, this looks better and saves some space. It was agreed with QA.

-----

✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed