### PR TITLE
PCHR-4408: Treat Admin As Staff For Own Requests When Not Own Leave Approver

### DIFF
--- a/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
+++ b/uk.co.compucorp.civicrm.hrcore/tests/phpunit/CRM/HRCore/Service/Stats/StatsGathererTest.php
@@ -264,8 +264,9 @@ class CRM_HRCore_Service_Stats_StatsGathererTest extends CRM_HRCore_Test_BaseHea
   public function testDeletedEntitiesWillNotBeIncluded() {
     $this->truncateTables(['civicrm_contact']);
     $contactID = ContactFabricator::fabricate()['id'];
+    $adminID = ContactFabricator::fabricate()['id'];
+    SessionHelper::registerCurrentLoggedInContactInSession($adminID);
     $this->setUpLeaveRequest($contactID);
-    SessionHelper::registerCurrentLoggedInContactInSession($contactID);
 
     $ufMatch = UFMatchFabricator::fabricate();
     civicrm_api3('UFMatch', 'delete', ['id' => $ufMatch['id']]);
@@ -296,7 +297,7 @@ class CRM_HRCore_Service_Stats_StatsGathererTest extends CRM_HRCore_Test_BaseHea
 
     $stats = $this->getGatherer()->gather();
 
-    $this->assertEquals(1, $stats->getEntityCount('contact'));
+    $this->assertEquals(2, $stats->getEntityCount('contact'));
     $this->assertEquals(0, $stats->getEntityCount('task'));
     $this->assertEquals(0, $stats->getEntityCount('assignment'));
     $this->assertEquals(0, $stats->getEntityCount('document'));

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -214,7 +214,10 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canCancelForAbsenceType($absenceTypeId, $contactId, DateTime $leaveFromDate) {
-    if ($this->currentUserIsAdmin() || $this->currentUserIsLeaveManagerOf($contactId)) {
+    $isLeaveContact = $this->currentUserIsLeaveContact($contactId);
+    $isAdmin = $this->currentUserIsAdmin();
+
+    if (($isAdmin && !$isLeaveContact) || $this->currentUserIsLeaveManagerOf($contactId)) {
       return TRUE;
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestRights.php
@@ -47,12 +47,14 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRights {
    * @return bool
    */
   public function canChangeDatesFor($contactID, $statusID, $requestType) {
-    if ($this->currentUserIsAdmin()) {
+    $currentUserIsLeaveContact = $this->currentUserIsLeaveContact($contactID);
+    $isAdmin = $this->currentUserIsAdmin();
+
+    if ($isAdmin && !$currentUserIsLeaveContact) {
       return TRUE;
     }
 
     $isOpenLeaveRequest = in_array($statusID, LeaveRequest::getOpenStatuses());
-    $currentUserIsLeaveContact = $this->currentUserIsLeaveContact($contactID);
 
     if ($currentUserIsLeaveContact && $isOpenLeaveRequest) {
       return TRUE;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrix.php
@@ -55,7 +55,7 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix {
    */
   private function shouldUseManagerMatrixForCurrentUser($leaveRequestContactID) {
     return $this->leaveManagerService->currentUserIsLeaveManagerOf($leaveRequestContactID) ||
-           $this->leaveManagerService->currentUserIsAdmin();
+           ($this->leaveManagerService->currentUserIsAdmin() && !$this->currentUserIsLeaveContact($leaveRequestContactID));
   }
 
   /**
@@ -146,15 +146,26 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrix {
    * @return array
    */
   private function getStatusMatrixForCurrentUser($leaveRequestContactID) {
-    $currentUserID = CRM_Core_Session::getLoggedInContactID();
     $statusMatrix = [];
 
     if ($this->shouldUseManagerMatrixForCurrentUser($leaveRequestContactID)) {
       $statusMatrix = $this->getManagerStatusMatrix();
-    } elseif ($currentUserID == $leaveRequestContactID) {
+    } elseif ($this->currentUserIsLeaveContact($leaveRequestContactID)) {
       $statusMatrix = $this->getStaffStatusMatrix();
     }
 
     return $statusMatrix;
+  }
+
+  /**
+   * Checks whether the current user is the leave request contact or not.
+   *
+   * @param int $contactID
+   *   The contactID of the leave request
+   *
+   * @return bool
+   */
+  private function currentUserIsLeaveContact($contactID) {
+    return CRM_Core_Session::getLoggedInContactID() == $contactID;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -44,8 +44,18 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->unregisterCurrentLoggedInContactFromSession();
   }
 
+  public function testCanDeleteForReturnsFalseWhenCurrentUserIsAdminForOwnRequestAndNotOwnLeaveApprover() {
+    $adminId = 5;
+    $this->registerCurrentLoggedInContactInSession($adminId);
+    $this->assertFalse($this->getLeaveRequestRightsForAdminAsCurrentUser()->canDeleteFor($adminId));
+    $this->unregisterCurrentLoggedInContactFromSession();
+  }
+
   public function testCanDeleteForReturnsTrueWhenCurrentUserIsAdmin() {
+    $adminId = 5;
+    $this->registerCurrentLoggedInContactInSession($adminId);
     $this->assertTrue($this->getLeaveRequestRightsForAdminAsCurrentUser()->canDeleteFor($this->leaveContact));
+    $this->unregisterCurrentLoggedInContactFromSession();
   }
 
   public function testCanDeleteForReturnsTrueWhenCurrentUserIsOwnLeaveApproverAndIsOwnRequest() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -387,6 +387,26 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
     $this->assertTrue($result);
   }
 
+  public function testAdminCanNotCancelOwnRequestForForAbsenceTypeThatDoesNotNotAllowItWhenNotOwnLeaveApprover() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['allow_request_cancelation' => AbsenceType::REQUEST_CANCELATION_NO]);
+    $adminID = 2;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    $leaveDate = new DateTime();
+    $leaveRequestRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+    $result = $leaveRequestRightsService->canCancelForAbsenceType($absenceType->id, $adminID, $leaveDate);
+    $this->assertFalse($result);
+  }
+
+  public function testAdminCanNotCancelOwnRequestForForAbsenceTypeThatDoesNotAllowFutureCancellationForPastLeaveDateWhenNotOwnLeaveApprover() {
+    $absenceType = AbsenceTypeFabricator::fabricate(['allow_request_cancelation' => AbsenceType::REQUEST_CANCELATION_IN_ADVANCE_OF_START_DATE]);
+    $adminID = 2;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    $leaveDate = new DateTime('yesterday');
+    $leaveRequestRightsService = $this->getLeaveRequestRightsForAdminAsCurrentUser();
+    $result = $leaveRequestRightsService->canCancelForAbsenceType($absenceType->id, $adminID, $leaveDate);
+    $this->assertFalse($result);
+  }
+
   public function testCanCancelForAbsenceTypeReturnsTrueWhenUserIsLeaveManager() {
     $typeId = 1;
     $contactID = 2;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestRightsTest.php
@@ -67,6 +67,71 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestRightsTest extends BaseHeadless
   /**
    * @dataProvider openLeaveRequestStatusesDataProvider
    */
+  public function testCanChangeDatesForReturnsTrueForAllRequestTypesWhenAdminIsLeaveContactAndNotOwnApproverAndTheLeaveRequestIsOpen($status) {
+    $adminId = 5;
+    $this->registerCurrentLoggedInContactInSession($adminId);
+
+    $this->assertTrue(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_LEAVE
+      )
+    );
+
+    $this->assertTrue(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_TOIL
+      )
+    );
+
+    $this->assertTrue(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_SICKNESS
+      )
+    );
+  }
+
+  /**
+   * @dataProvider closedLeaveRequestStatusesDataProvider
+   */
+  public function testCanChangeDatesForReturnsFalseForAllRequestTypesWhenAdminIsLeaveContactAndNotOwnApproverAndTheLeaveRequestIsClosed($status) {
+    $adminId = 5;
+    $this->registerCurrentLoggedInContactInSession($adminId);
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_LEAVE
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_TOIL
+      )
+    );
+
+    $this->assertFalse(
+      $this->getLeaveRequestRightsForAdminAsCurrentUser()->canChangeDatesFor(
+        $adminId,
+        $status,
+        LeaveRequest::REQUEST_TYPE_SICKNESS
+      )
+    );
+  }
+
+
+  /**
+   * @dataProvider openLeaveRequestStatusesDataProvider
+   */
   public function testCanChangeDatesForReturnsTrueForAllRequestTypesWhenCurrentUserIsLeaveContactAndTheLeaveRequestIsOpen($status) {
     $this->assertTrue(
       $this->getLeaveRightsService()->canChangeDatesFor(

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestStatusMatrixTest.php
@@ -136,26 +136,43 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     }
   }
 
-  public function testCanTransitionToReturnsFalseWhenAdminIsTheLeaveContactForAllNonPossibleManagerTransitionStatuses() {
-    $adminID = 5;
-    $this->registerCurrentLoggedInContactInSession($adminID);
+  public function testCanTransitionToReturnsFalseWhenAdminIsTheLeaveContactAndOwnLeaveApproverForAllNonPossibleManagerTransitionStatuses() {
+    $admin = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($admin['id']);
     $this->setPermissions(['administer leave and absences']);
+    $this->setContactAsLeaveApproverOf($admin, $admin);
     $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForLeaveApprover();
 
     foreach($nonPossibleTransitions as $transition) {
       $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo(
         $transition[0],
         $transition[1],
-        $adminID
+        $admin['id']
       ));
     }
   }
 
-  public function testCanTransitionToReturnsTrueWhenAdminIsTheLeaveContactForAllPossibleManagerTransitionStatuses() {
+  public function testCanTransitionToReturnsTrueWhenAdminIsTheLeaveContactAndOwnLeaveApproverForAllPossibleManagerTransitionStatuses() {
+    $admin = ContactFabricator::fabricate();
+    $this->registerCurrentLoggedInContactInSession($admin['id']);
+    $this->setPermissions(['administer leave and absences']);
+    $this->setContactAsLeaveApproverOf($admin, $admin);
+    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
+
+    foreach($possibleTransitions as $transition) {
+      $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $admin['id']
+      ));
+    }
+  }
+
+  public function testCanTransitionToReturnsTrueForAllPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContactAndNotOwnApprover() {
     $adminID = 5;
     $this->registerCurrentLoggedInContactInSession($adminID);
     $this->setPermissions(['administer leave and absences']);
-    $possibleTransitions = $this->allPossibleStatusTransitionForLeaveApprover();
+    $possibleTransitions = $this->allPossibleStatusTransitionForStaffDataProvider();
 
     foreach($possibleTransitions as $transition) {
       $this->assertTrue($this->leaveRequestStatusMatrix->canTransitionTo(
@@ -166,6 +183,20 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestStatusMatrixTest extends BaseHe
     }
   }
 
+  public function testCanTransitionToReturnsFalseForAllNonPossibleStaffTransitionStatusesWhenAdminIsTheLeaveContactAndNotOwnApprover() {
+    $adminID = 5;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+    $this->setPermissions(['administer leave and absences']);
+    $nonPossibleTransitions = $this->allNonPossibleStatusTransitionForStaffDataProvider();
+
+    foreach($nonPossibleTransitions as $transition) {
+      $this->assertFalse($this->leaveRequestStatusMatrix->canTransitionTo(
+        $transition[0],
+        $transition[1],
+        $adminID
+      ));
+    }
+  }
   public function testCanTransitionToReturnsFalseWhenUserIsTheLeaveContactAndOwnApproverForAllNonPossibleManagerTransitionStatuses() {
     $manager = ContactFabricator::fabricate();
     $this->registerCurrentLoggedInContactInSession($manager['id']);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -218,6 +218,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testDeleteSoftDeletesTheLeaveRequest() {
     $leaveRequestDateTypes = array_flip(LeaveRequest::buildOptions('from_date_type', 'validate'));
+    $adminID = 4;
+    $this->registerCurrentLoggedInContactInSession($adminID);
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => 1,
@@ -238,6 +240,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testDeleteSoftDeletesAPublicHolidayLeaveRequest() {
+    $adminID = 3;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
@@ -254,6 +258,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testPublicHolidayLeaveRequestIsDeletedAndBalanceRecalculatedForOverlappingLeaveRequestDate() {
+    $adminID = 4;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2016-12-31')
@@ -346,6 +352,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testCreateDoesNotThrowAnExceptionWhenAdminUpdatesDatesForLeaveRequest() {
+    $adminID = 6;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     $params = $this->getDefaultParams(['status_id' => 2]);
 
     $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation($params);
@@ -684,6 +692,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testBalanceChangeIsUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsTrueAndDatesChanged() {
+    $adminID = 5;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -758,6 +768,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testBalanceChangeIsUpdatedForAnExistingLeaveRequestWhenChangeBalanceParameterIsFalseAndDatesChanged() {
+    $adminID = 5;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -917,6 +929,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testBalanceRemainsSameButDatesAreUpdatedForToilWhenChangeBalanceIsTrueAndToilToAccrueNotChangedAndDatesChanged() {
+    $adminID = 5;
+    $this->registerCurrentLoggedInContactInSession($adminID);
+
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -968,6 +983,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testBalanceRemainsSameButDatesAreUpdatedForToilWhenChangeBalanceIsFalseAndToilToAccrueNotChangedAndDatesChanged() {
+    $adminID = 2;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
       ['period_start_date' => '2016-01-01']
@@ -1162,6 +1179,8 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
   }
 
   public function testToilRequestWithPastDatesCanBeCancelledWhenUserIsAdminAndAbsenceTypeDoesNotAllowPastAccrual() {
+    $adminID = 3;
+    $this->registerCurrentLoggedInContactInSession($adminID);
     $absenceType = AbsenceTypeFabricator::fabricate([
       'allow_accruals_request' => TRUE,
       'allow_accrue_in_the_past' => FALSE


### PR DESCRIPTION
## Overview
Currently the Admin has the highest rights regarding leave request administration for all contacts. The Admin can create/edit/cancel/delete leave requests for all contacts. This PR makes some changes regarding the Admin's privileges regarding his own requests particularly when the Admin is not own leave approver. Basically  for own request, in situations where the Admin is not own leave approver, the Admin is treated basically like a staff as the same principles that apply to a Staff applies to Admin in this regard.

## Before
The Admin has admin rights over all leave requests including own requests.

## After
The Admin does not have admin rights over own request when not own leave approver.

The change was implemented in the major areas for leave request administration, basically:

**Status Transitions** : The Administrator is only allowed to set Leave statuses that a staff can set when Admin is not own leave approver.

**Deleting Leave Requests**:  The Administrator is treated as a Staff in this regard also.
**Cancelling Leave Requests**
**Modifying Leave Request Dates**
