### PR TITLE
PCHR-4330: Migrate Existing Job Role Organisation Contact

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -98,6 +98,90 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
   }
 
   /**
+   * Migrates existing job role funder to option values
+   *
+   * @return bool
+   */
+  public function upgrade_1008() {
+    $result = civicrm_api3('HrJobRoles', 'get', [
+      'return' => ['funder'],
+    ]);
+    $jobRoles = $result['values'];
+    $funderIds = $this->getFunderIds($jobRoles);
+    $contactFunders = $this->createFunderOptionValues($funderIds);
+    $this->updateJobRoleFunder($jobRoles, $contactFunders);
+
+    return TRUE;
+  }
+
+  /**
+   * Swaps job role funder contact id with option values and updates record
+   *
+   * @param array $jobRoles
+   * @param array $contactFunders
+   */
+  private function updateJobRoleFunder($jobRoles, $contactFunders) {
+    foreach ($jobRoles as $jobRole) {
+      foreach ($contactFunders as $contactId => $optionValue) {
+        $jobRole['funder'] = str_replace(
+          '|' . $contactId . '|',
+          '|' . $optionValue['value'] . '|',
+          $jobRole['funder']
+        );
+      }
+
+      civicrm_api3('HrJobRoles', 'create', [
+        'id' => $jobRole['id'],
+        'funder' => $jobRole['funder']
+      ]);
+    }
+  }
+
+  /**
+   * Sets up option values for job role funders
+   * using hrjc_funder option group
+   *
+   * @param array $funderIds
+   *
+   * @return array
+   */
+  private function createFunderOptionValues($funderIds) {
+    $funderOptionValueIds = [];
+    $contactResult = civicrm_api3('Contact', 'get', [
+      'return' => ['sort_name', 'display_name'],
+      'id' => ['IN' => $funderIds],
+    ]);
+
+    $contacts = $contactResult['values'];
+    foreach ($contacts as $contact) {
+      $funderOptionValueIds[$contact['id']] = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+        'option_group_id' => 'hrjc_funder',
+        'name' => $contact['display_name'],
+        'label' => $contact['sort_name']
+      ]);
+    }
+
+    return $funderOptionValueIds;
+  }
+
+  /**
+   * Retrieves unique id of contacts used as funder
+   *
+   * @param array $jobRoles
+   *
+   * @return array
+   */
+  private function getFunderIds($jobRoles) {
+    $funderIds = [];
+    foreach ($jobRoles as $jobRole) {
+      $funders = array_values(array_filter(explode('|', $jobRole['funder'])));
+      $funderIds = array_merge($funderIds, $funders);
+    }
+
+    return array_unique($funderIds);
+  }
+
+  /**
    * Deletes cost centre option value with name "other"
    */
   private function deleteCostCentreOther() {


### PR DESCRIPTION
## Overview
When creating job roles, funders list are provided from list of contacts previously created. Having created an option group in https://github.com/compucorp/civihr/pull/2920 for managing list of funders, this PR migrates funders in existing job roles by creating option value replica and replacing funder id with that of new created option value.

## Before
Existing job role funders were pointed to contact list

## After
Existing job role funders are linked to option value for `hrjc_funder` option group.

## Technical Details
All existing job roles were fetched and their unique funder_id extracted. 
```
private function getFunderIds($jobRoles) {
  $funderIds = [];
  foreach ($jobRoles as $jobRole) {
    $funders = array_values(array_filter(explode('|', $jobRole['funder'])));
    $funderIds = array_merge($funderIds, $funders);
  }

  return array_unique($funderIds);
}
```
Based on the returned `funder_id`, all the contact record with the ids are fetched and a option value was created with the details.
```
...
foreach ($contacts as $contact) {
  $funderOptionValueId[$contact['id']] = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
    'option_group_id' => 'hrjc_funder',
    'name' => $contact['display_name'],
    'label' => $contact['sort_name'],
    'is_reserved' => 1
  ]);
}
...
```
After successfully creating the option values, their values (mapped to the respective contact id) are returned and used in updating the job roles.
```
private function updateJobRoleFunder($jobRoles, $contactFunders) {
  foreach ($jobRoles as $jobRole) {
    foreach ($contactFunders as $key => $optionValue) {
      $jobRole['funder'] = str_replace(
        '|' . $key . '|',
        '|' . $optionValue['value'] . '|',
        $jobRole['funder']
      );
    }
     civicrm_api3('HrJobRoles', 'create', [
      'id' => $jobRole['id'],
      'funder' => $jobRole['funder']
    ]);
  }
}
```