### PR TITLE
PCHR-4412: Fix error with a direct absence type enabling

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -164,9 +164,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    */
   private static function validateParams($params) {
-    $isEditing = !empty($params['id']);
-    $skipTitleValidation = $isEditing && !array_key_exists('title', $params);
-
     if(!empty($params['add_public_holiday_to_entitlement'])) {
       self::validateAddPublicHolidayToEntitlement($params);
     }
@@ -182,7 +179,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
           'Invalid Request Cancelation Option'
       );
     }
-    !$skipTitleValidation && self::validateAbsenceTypeTitle($params);
+    self::validateAbsenceTypeTitle($params);
     self::validateTOIL($params);
     self::validateCarryForward($params);
     self::validateCalculationUnit($params);
@@ -279,6 +276,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    */
   private static function validateAbsenceTypeTitle($params) {
+    $isEditing = array_key_exists('id', $params);
+    $titleIsPassed = array_key_exists('title', $params);
+    $skipTitleValidation = $isEditing && !$titleIsPassed;
+
+    if ($skipTitleValidation) {
+      return;
+    }
+
     $title = trim(CRM_Utils_Array::value('title', $params));
 
     if (empty($title) && $title !== '0') {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -75,7 +75,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   public static function del($id) {
     $absenceType = new CRM_HRLeaveAndAbsences_DAO_AbsenceType();
     $absenceType->id = $id;
-    $absenceType->find(true);
+    $absenceType->find(TRUE);
     $absenceType->delete();
 
     if($absenceType->must_take_public_holiday_as_leave) {
@@ -90,8 +90,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   public static function getRequestCancelationOptions() {
     return [
-      self::REQUEST_CANCELATION_NO                       => ts('No'),
-      self::REQUEST_CANCELATION_ALWAYS                   => ts('Yes - always'),
+      self::REQUEST_CANCELATION_NO => ts('No'),
+      self::REQUEST_CANCELATION_ALWAYS => ts('Yes - always'),
       self::REQUEST_CANCELATION_IN_ADVANCE_OF_START_DATE => ts('Yes - in advance of the start date of the leave')
     ];
   }
@@ -104,7 +104,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   public static function getExpirationUnitOptions() {
     return [
-      self::EXPIRATION_UNIT_DAYS   => ts('Days'),
+      self::EXPIRATION_UNIT_DAYS => ts('Days'),
       self::EXPIRATION_UNIT_MONTHS => ts('Months'),
     ];
   }
@@ -300,7 +300,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       $absenceType->whereAdd("id <> $id");
     }
 
-    $absenceType->find(true);
+    $absenceType->find(TRUE);
 
     if ($absenceType->id) {
       throw new InvalidAbsenceTypeException(
@@ -329,7 +329,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $dao = new self();
     $dao->$fieldName = $value;
 
-    $id = empty($params['id']) ? null : intval($params['id']);
+    $id = empty($params['id']) ? NULL : intval($params['id']);
     if($id) {
       $dao->whereAdd("id <> {$id}");
     }
@@ -476,7 +476,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   private static function mustUpdatePublicHolidayLeaveRequests($params) {
     if(!array_key_exists('must_take_public_holiday_as_leave', $params)) {
-      return false;
+      return FALSE;
     }
 
     if(!empty($params['id'])) {
@@ -511,7 +511,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   public function carryForwardNeverExpires() {
     if(!$this->allow_carry_forward) {
-      return null;
+      return NULL;
     }
 
     return !$this->hasExpirationDuration();
@@ -575,7 +575,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       return $absenceType;
     }
 
-    return null;
+    return NULL;
   }
 
   /**
@@ -595,7 +595,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       throw new InvalidAbsenceTypeException("This Absence Type does not allow Accruals Request");
     }
     if ($this->toilNeverExpires()) {
-      return null;
+      return NULL;
     }
 
     if ($this->accrual_expiration_unit == self::EXPIRATION_UNIT_DAYS) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -164,6 +164,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    */
   private static function validateParams($params) {
+    $isEditing = !empty($params['id']);
+    $skipTitleValidation = $isEditing && !array_key_exists('title', $params);
+
     if(!empty($params['add_public_holiday_to_entitlement'])) {
       self::validateAddPublicHolidayToEntitlement($params);
     }
@@ -179,7 +182,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
           'Invalid Request Cancelation Option'
       );
     }
-    self::validateAbsenceTypeTitle($params);
+    !$skipTitleValidation && self::validateAbsenceTypeTitle($params);
     self::validateTOIL($params);
     self::validateCarryForward($params);
     self::validateCalculationUnit($params);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -89,11 +89,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    * @return array
    */
   public static function getRequestCancelationOptions() {
-     return [
-         self::REQUEST_CANCELATION_NO                       => ts('No'),
-         self::REQUEST_CANCELATION_ALWAYS                   => ts('Yes - always'),
-         self::REQUEST_CANCELATION_IN_ADVANCE_OF_START_DATE => ts('Yes - in advance of the start date of the leave')
-     ];
+    return [
+      self::REQUEST_CANCELATION_NO                       => ts('No'),
+      self::REQUEST_CANCELATION_ALWAYS                   => ts('Yes - always'),
+      self::REQUEST_CANCELATION_IN_ADVANCE_OF_START_DATE => ts('Yes - in advance of the start date of the leave')
+    ];
   }
 
   /**
@@ -104,8 +104,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    */
   public static function getExpirationUnitOptions() {
     return [
-        self::EXPIRATION_UNIT_DAYS   => ts('Days'),
-        self::EXPIRATION_UNIT_MONTHS => ts('Months'),
+      self::EXPIRATION_UNIT_DAYS   => ts('Days'),
+      self::EXPIRATION_UNIT_MONTHS => ts('Months'),
     ];
   }
 
@@ -343,13 +343,13 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $allow_accruals_request = !empty($params['allow_accruals_request']);
     if(!empty($params['max_leave_accrual']) && !$allow_accruals_request) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To set maximum amount of leave that can be accrued you must allow staff to accrue additional days'
+        'To set maximum amount of leave that can be accrued you must allow staff to accrue additional days'
       );
     }
 
     if(!empty($params['allow_accrue_in_the_past']) && !$allow_accruals_request) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To allow accrue in the past you must allow staff to accrue additional days'
+        'To allow accrue in the past you must allow staff to accrue additional days'
       );
     }
 
@@ -357,7 +357,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $has_accrual_expiration_unit = !empty($params['accrual_expiration_unit']);
     if($has_accrual_expiration_duration && $has_accrual_expiration_unit && !$allow_accruals_request) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To set the accrual expiry duration you must allow staff to accrue additional days'
+        'To set the accrual expiry duration you must allow staff to accrue additional days'
       );
     }
 
@@ -365,13 +365,13 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
         !array_key_exists($params['accrual_expiration_unit'], self::getExpirationUnitOptions())
     ) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'Invalid Accrual Expiration Unit'
+        'Invalid Accrual Expiration Unit'
       );
     }
 
     if ($has_accrual_expiration_duration xor $has_accrual_expiration_unit) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'Invalid Accrual Expiration. It should have both Unit and Duration'
+        'Invalid Accrual Expiration. It should have both Unit and Duration'
       );
     }
   }
@@ -387,7 +387,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $allow_carry_forward = !empty($params['allow_carry_forward']);
     if(!empty($params['max_number_of_days_to_carry_forward']) && !$allow_carry_forward) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To set the Max Number of Days to Carry Forward you must allow Carry Forward'
+        'To set the Max Number of Days to Carry Forward you must allow Carry Forward'
       );
     }
 
@@ -395,21 +395,21 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
     $has_carry_forward_expiration_unit = !empty($params['carry_forward_expiration_unit']);
     if($has_carry_forward_expiration_duration && $has_carry_forward_expiration_unit && !$allow_carry_forward) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'To set the carry forward expiry duration you must allow Carry Forward'
+        'To set the carry forward expiry duration you must allow Carry Forward'
       );
     }
 
     if($has_carry_forward_expiration_unit xor $has_carry_forward_expiration_duration) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'Invalid Carry Forward Expiration. It should have both Unit and Duration'
+        'Invalid Carry Forward Expiration. It should have both Unit and Duration'
       );
     }
 
     if (!empty($params['carry_forward_expiration_unit']) &&
-        !array_key_exists($params['carry_forward_expiration_unit'], self::getExpirationUnitOptions())
+      !array_key_exists($params['carry_forward_expiration_unit'], self::getExpirationUnitOptions())
     ) {
       throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-          'Invalid Carry Forward Expiration Unit'
+        'Invalid Carry Forward Expiration Unit'
       );
     }
   }
@@ -518,8 +518,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    *
    * @return bool
    */
-  public function hasExpirationDuration()
-  {
+  public function hasExpirationDuration() {
     return $this->carry_forward_expiration_duration && $this->carry_forward_expiration_unit;
   }
 
@@ -528,8 +527,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType[]
    */
-  public static function getEnabledAbsenceTypes()
-  {
+  public static function getEnabledAbsenceTypes() {
     $absenceTypes = [];
     $absenceType = new self();
     $absenceType->is_active = 1;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -82,6 +82,20 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => true]);
   }
 
+  public function testTypeCanBeEnabledDirectly() {
+    $entity = AbsenceTypeFabricator::fabricate();
+    AbsenceType::create(['id' => $entity->id, 'is_active' => 1]);
+  }
+
+  /**
+   * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
+   * @expectedExceptionMessage The title is not provided
+   */
+  public function testTypeTitleCannotBeAnEmptyStringOnUpdate() {
+    $entity = AbsenceTypeFabricator::fabricate();
+    AbsenceType::create(['id' => $entity->id, 'title' => '']);
+  }
+
   /**
    * @expectedException CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
    * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -160,8 +160,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfMaxLeaveAccrualIsNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-        'allow_accruals_request' => false,
-        'max_leave_accrual' => 1
+      'allow_accruals_request' => false,
+      'max_leave_accrual' => 1
     ]);
   }
 
@@ -171,8 +171,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfAllowAccrueInThePast() {
     AbsenceTypeFabricator::fabricate([
-        'allow_accruals_request'   => false,
-        'allow_accrue_in_the_past' => 1
+      'allow_accruals_request' => false,
+      'allow_accrue_in_the_past' => 1
     ]);
   }
 
@@ -182,9 +182,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfAllowAccrualDurationAndUnitAreNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-        'allow_accruals_request' => false,
-        'accrual_expiration_duration' => 1,
-        'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
+      'allow_accruals_request' => false,
+      'accrual_expiration_duration' => 1,
+      'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
     ]);
   }
 
@@ -194,15 +194,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testShouldNotAllowInvalidAccrualExpirationUnit($expirationUnit, $throwsException) {
     if($throwsException) {
       $this->setExpectedException(
-          InvalidAbsenceTypeException::class,
-          'Invalid Accrual Expiration Unit'
+        InvalidAbsenceTypeException::class,
+        'Invalid Accrual Expiration Unit'
       );
     }
 
     AbsenceTypeFabricator::fabricate([
-        'allow_accruals_request' => true,
-        'accrual_expiration_duration' => 1,
-        'accrual_expiration_unit' => $expirationUnit
+      'allow_accruals_request' => true,
+      'accrual_expiration_duration' => 1,
+      'accrual_expiration_unit' => $expirationUnit
     ]);
   }
 
@@ -212,15 +212,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testShouldNotAllowAccrualExpirationUnitWithoutDurationAndViceVersa($unit, $duration, $throwsException) {
     if($throwsException) {
       $this->setExpectedException(
-          InvalidAbsenceTypeException::class,
-          'Invalid Accrual Expiration. It should have both Unit and Duration'
+        InvalidAbsenceTypeException::class,
+        'Invalid Accrual Expiration. It should have both Unit and Duration'
       );
     }
 
     AbsenceTypeFabricator::fabricate([
-        'allow_accruals_request' => true,
-        'accrual_expiration_unit' => $unit,
-        'accrual_expiration_duration' => $duration,
+      'allow_accruals_request' => true,
+      'accrual_expiration_unit' => $unit,
+      'accrual_expiration_duration' => $duration,
     ]);
   }
 
@@ -230,8 +230,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowCarryForwardShouldBeTrueIfMaxNumberOfDaysToCarryForwardIsNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-        'allow_carry_forward'   => false,
-        'max_number_of_days_to_carry_forward' => 1
+      'allow_carry_forward' => false,
+      'max_number_of_days_to_carry_forward' => 1
     ]);
   }
 
@@ -241,9 +241,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowCarryForwardShouldBeTrueIfCarryForwardExpirationDurationAndUnitAreNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-        'allow_carry_forward' => false,
-        'carry_forward_expiration_duration' => 1,
-        'carry_forward_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
+      'allow_carry_forward' => false,
+      'carry_forward_expiration_duration' => 1,
+      'carry_forward_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
     ]);
   }
 
@@ -253,15 +253,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testShouldNotAllowCarryForwardExpirationUnitWithoutDurationAndViceVersa($unit, $duration, $throwsException) {
     if($throwsException) {
       $this->setExpectedException(
-          InvalidAbsenceTypeException::class,
-          'Invalid Carry Forward Expiration. It should have both Unit and Duration'
+        InvalidAbsenceTypeException::class,
+        'Invalid Carry Forward Expiration. It should have both Unit and Duration'
       );
     }
 
     AbsenceTypeFabricator::fabricate([
-        'allow_carry_forward' => true,
-        'carry_forward_expiration_unit' => $unit,
-        'carry_forward_expiration_duration' => $duration,
+      'allow_carry_forward' => true,
+      'carry_forward_expiration_unit' => $unit,
+      'carry_forward_expiration_duration' => $duration,
     ]);
   }
 
@@ -271,15 +271,15 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testShouldNotAllowInvalidCarryForwardExpirationUnit($expirationUnit, $throwsException) {
     if($throwsException) {
       $this->setExpectedException(
-          InvalidAbsenceTypeException::class,
-          'Invalid Carry Forward Expiration Unit'
+        InvalidAbsenceTypeException::class,
+        'Invalid Carry Forward Expiration Unit'
       );
     }
 
     AbsenceTypeFabricator::fabricate([
-        'allow_carry_forward' => true,
-        'carry_forward_expiration_duration' => 1,
-        'carry_forward_expiration_unit' => $expirationUnit
+      'allow_carry_forward' => true,
+      'carry_forward_expiration_duration' => 1,
+      'carry_forward_expiration_unit' => $expirationUnit
     ]);
   }
 
@@ -289,8 +289,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testShouldNotAllowInvalidRequestCancelationOptions($requestCancelationOption, $throwsException) {
     if($throwsException) {
       $this->setExpectedException(
-          InvalidAbsenceTypeException::class,
-          'Invalid Request Cancelation Option'
+        InvalidAbsenceTypeException::class,
+        'Invalid Request Cancelation Option'
       );
     }
 
@@ -502,8 +502,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     AbsenceType::del($absenceType->id);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
-    // The number is two because another update was added when the absence type was
-    // created
+    // The number is two because another update was added
+    // when the absence type was created
     $this->assertEquals(2, $queue->numberOfItems());
   }
 
@@ -514,8 +514,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   public function expirationUnitDataProvider() {
     $data = [
-        [rand(3, PHP_INT_MAX), true],
-        [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), true],
     ];
     $validOptions = array_keys(AbsenceType::getExpirationUnitOptions());
     foreach($validOptions as $option) {
@@ -534,8 +534,8 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   public function allowRequestCancelationDataProvider() {
     $data = [
-        [rand(3, PHP_INT_MAX), true],
-        [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), true],
     ];
     $validOptions = array_keys(AbsenceType::getRequestCancelationOptions());
     foreach($validOptions as $option) {
@@ -593,7 +593,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'allow_accruals_request' => false,
       'is_active' => 1,
     ]);
-    //date to calculate TOIL expiry for
+    // date to calculate TOIL expiry for
     $date = new DateTime('2016-11-10');
     $absenceType->calculateToilExpiryDate($date);
   }
@@ -606,14 +606,14 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'accrual_expiration_duration' => null,
       'is_active' => 1,
     ]);
-    //date to calculate TOIL expiry for
+    // date to calculate TOIL expiry for
     $date = new DateTime('2016-11-10');
     $expiry = $absenceType->calculateToilExpiryDate($date);
     $this->assertNull($expiry);
   }
 
   public function testCalculateToilExpiryDateWhenAbsenceTypeAllowsAccrualsRequestAndExpiryDurationSet() {
-    //Duration set in days
+    // Duration set in days
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 1',
       'allow_accruals_request' => true,
@@ -621,12 +621,12 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
       'is_active' => 1,
     ]);
-    //date to calculate TOIL expiry for
+    // date to calculate TOIL expiry for
     $date = new DateTime('2016-11-10');
     $expiry = $absenceType->calculateToilExpiryDate($date);
     $this->assertEquals('2016-11-20', $expiry->format('Y-m-d'));
 
-    //Duration set in months
+    // Duration set in months
     $absenceType2 = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 2',
       'allow_accruals_request' => true,
@@ -634,7 +634,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_MONTHS,
       'is_active' => 1,
     ]);
-    //date to calculate TOIL expiry for
+    // date to calculate TOIL expiry for
     $date = new DateTime('2016-11-10');
     $expiry = $absenceType2->calculateToilExpiryDate($date);
     $this->assertEquals('2017-09-10', $expiry->format('Y-m-d'));
@@ -673,7 +673,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
     ], true);
 
-    //assert the records exist first before updating absence type
+    // assert the records exist first before updating absence type
     $balanceChange = new LeaveBalanceChange();
     $balanceChange->find();
     $this->assertEquals($balanceChange->N, 2);
@@ -686,7 +686,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $leaveRequestDate->find();
     $this->assertEquals($leaveRequestDate->N, 2);
 
-    //disable TOIL
+    // disable TOIL
     AbsenceType::create([
       'id' => $absenceType->id,
       'title' => $absenceType->title,
@@ -694,21 +694,21 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'color' => '#000000'
     ]);
 
-    //confirm the balance change for the expired TOIL balance was not deleted
+    // confirm the balance change for the expired TOIL balance was not deleted
     $balanceChange = new LeaveBalanceChange();
     $balanceChange->find(true);
     $this->assertEquals(1, $balanceChange->N);
     $toilRequestBalanceChange = $this->findToilRequestMainBalanceChange($toilRequest2->id);
     $this->assertEquals($toilRequestBalanceChange->id, $balanceChange->id);
 
-    //confirm the leave request for the expired TOIL balance was not deleted
+    // confirm the leave request for the expired TOIL balance was not deleted
     $leaveRequest = new LeaveRequest();
     $leaveRequest->find();
     $this->assertEquals($leaveRequest->N, 1);
     $leaveRequest->fetch();
     $this->assertEquals($leaveRequest->id, $toilRequest2->id);
 
-    //confirm the leave request dates for the expired TOIL balance was not deleted
+    // confirm the leave request dates for the expired TOIL balance was not deleted
     $leaveRequestDate = new LeaveRequestDate();
     $leaveRequestDate->find();
     $this->assertEquals($leaveRequestDate->N, 1);
@@ -748,7 +748,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $params = ['title' => 'Type 1'];
     $absenceType = AbsenceTypeFabricator::fabricate($params);
 
-    //update the absence type
+    // update the absence type
     $params['id'] = $absenceType->id;
     $params['default_entitlement'] = 50;
 
@@ -767,7 +767,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $params2 = ['title' => 'Type 2'];
     $absenceType2 = AbsenceTypeFabricator::fabricate($params2);
 
-    //update the second absence type with the title of the first type
+    // update the second absence type with the title of the first type
     $params['id'] = $absenceType2->id;
     $params['title'] = $params1['title'];
 
@@ -831,7 +831,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'calculation_unit' => $this->calculationUnitOptions['hours']
     ]);
 
-
     $this->assertTrue($absenceType->isCalculationUnitInHours());
   }
 
@@ -839,7 +838,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $absenceType = AbsenceTypeFabricator::fabricate([
       'calculation_unit' => $this->calculationUnitOptions['days']
     ]);
-
 
     $this->assertFalse($absenceType->isCalculationUnitInHours());
   }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -75,11 +75,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it
    */
   public function testThereShouldBeOnlyOneTypeWithAddPublicHolidayToEntitlementOnCreate() {
-    $basicEntity = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => true]);
+    $basicEntity = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => TRUE]);
     $entity1 = AbsenceType::findById($basicEntity->id);
     $this->assertEquals(1, $entity1->add_public_holiday_to_entitlement);
 
-    AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => true]);
+    AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => TRUE]);
   }
 
   public function testTypeCanBeEnabledDirectly() {
@@ -101,22 +101,22 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    * @expectedExceptionMessage There is already one Absence Type where public holidays should be added to it
    */
   public function testThereShouldBeOnlyOneTypeWithAddPublicHolidayToEntitlementOnUpdate() {
-    $basicEntity1 = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => true]);
+    $basicEntity1 = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => TRUE]);
     $basicEntity2 = AbsenceTypeFabricator::fabricate();
     $entity1 = AbsenceType::findById($basicEntity1->id);
     $entity2 = AbsenceType::findById($basicEntity2->id);
     $this->assertEquals(1, $entity1->add_public_holiday_to_entitlement);
     $this->assertEquals(0, $entity2->add_public_holiday_to_entitlement);
 
-    $this->updateBasicType($basicEntity2->id, ['add_public_holiday_to_entitlement' => true]);
+    $this->updateBasicType($basicEntity2->id, ['add_public_holiday_to_entitlement' => TRUE]);
   }
 
   public function testUpdatingATypeWithAddPublicHolidayToEntitlementShouldNotTriggerErrorAboutHavingAnotherTypeWithItSelected() {
-    $basicEntity = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => true]);
+    $basicEntity = AbsenceTypeFabricator::fabricate(['add_public_holiday_to_entitlement' => TRUE]);
     $entity1 = AbsenceType::findById($basicEntity->id);
     $this->assertEquals(1, $entity1->add_public_holiday_to_entitlement);
 
-    $this->updateBasicType($entity1->id, ['add_public_holiday_to_entitlement' => true]);
+    $this->updateBasicType($entity1->id, ['add_public_holiday_to_entitlement' => TRUE]);
   }
 
   /**
@@ -124,11 +124,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    * @expectedExceptionMessage There is already one Absence Type where "Must staff take public holiday as leave" is selected
    */
   public function testThereShouldBeOnlyOneTypeWithMustTakePublicHolidayAsLeaveOnCreate() {
-    $basicEntity = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $basicEntity = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     $entity1 = AbsenceType::findById($basicEntity->id);
     $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
 
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
   }
 
   /**
@@ -136,22 +136,22 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    * @expectedExceptionMessage There is already one Absence Type where "Must staff take public holiday as leave" is selected
    */
   public function testThereShouldBeOnlyOneTypeWithMustTakePublicHolidayAsLeaveOnUpdate() {
-    $basicEntity1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $basicEntity1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     $basicEntity2 = AbsenceTypeFabricator::fabricate();
     $entity1 = AbsenceType::findById($basicEntity1->id);
     $entity2 = AbsenceType::findById($basicEntity2->id);
     $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
     $this->assertEquals(0, $entity2->must_take_public_holiday_as_leave);
 
-    $this->updateBasicType($basicEntity2->id, ['must_take_public_holiday_as_leave' => true]);
+    $this->updateBasicType($basicEntity2->id, ['must_take_public_holiday_as_leave' => TRUE]);
   }
 
   public function testUpdatingATypeWithMustTakePublicHolidayAsLeaveShouldNotTriggerErrorAboutHavingAnotherTypeWithItSelected() {
-    $basicEntity = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $basicEntity = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     $entity1 = AbsenceType::findById($basicEntity->id);
     $this->assertEquals(1, $entity1->must_take_public_holiday_as_leave);
 
-    $this->updateBasicType($entity1->id, ['must_take_public_holiday_as_leave' => true]);
+    $this->updateBasicType($entity1->id, ['must_take_public_holiday_as_leave' => TRUE]);
   }
 
   /**
@@ -160,7 +160,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfMaxLeaveAccrualIsNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => false,
+      'allow_accruals_request' => FALSE,
       'max_leave_accrual' => 1
     ]);
   }
@@ -171,7 +171,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfAllowAccrueInThePast() {
     AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => false,
+      'allow_accruals_request' => FALSE,
       'allow_accrue_in_the_past' => 1
     ]);
   }
@@ -182,7 +182,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowAccrualsRequestShouldBeTrueIfAllowAccrualDurationAndUnitAreNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => false,
+      'allow_accruals_request' => FALSE,
       'accrual_expiration_duration' => 1,
       'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
     ]);
@@ -200,7 +200,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     }
 
     AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
+      'allow_accruals_request' => TRUE,
       'accrual_expiration_duration' => 1,
       'accrual_expiration_unit' => $expirationUnit
     ]);
@@ -218,7 +218,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     }
 
     AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
+      'allow_accruals_request' => TRUE,
       'accrual_expiration_unit' => $unit,
       'accrual_expiration_duration' => $duration,
     ]);
@@ -230,7 +230,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowCarryForwardShouldBeTrueIfMaxNumberOfDaysToCarryForwardIsNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => false,
+      'allow_carry_forward' => FALSE,
       'max_number_of_days_to_carry_forward' => 1
     ]);
   }
@@ -241,7 +241,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testAllowCarryForwardShouldBeTrueIfCarryForwardExpirationDurationAndUnitAreNotEmpty() {
     AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => false,
+      'allow_carry_forward' => FALSE,
       'carry_forward_expiration_duration' => 1,
       'carry_forward_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS
     ]);
@@ -259,7 +259,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     }
 
     AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => true,
+      'allow_carry_forward' => TRUE,
       'carry_forward_expiration_unit' => $unit,
       'carry_forward_expiration_duration' => $duration,
     ]);
@@ -277,7 +277,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     }
 
     AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => true,
+      'allow_carry_forward' => TRUE,
       'carry_forward_expiration_duration' => 1,
       'carry_forward_expiration_unit' => $expirationUnit
     ]);
@@ -349,11 +349,11 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   public function testHasExpirationDuration() {
     $absenceType1 = AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => true
+      'allow_carry_forward' => TRUE
     ]);
 
     $absenceType2 = AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => true,
+      'allow_carry_forward' => TRUE,
       'carry_forward_expiration_duration' => 3,
       'carry_forward_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
     ]);
@@ -363,13 +363,13 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testCarryForwardNeverExpiresShouldReturnTrueIfTypeHasNoExpirationDuration() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['allow_carry_forward' => true]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['allow_carry_forward' => TRUE]);
     $this->assertTrue($absenceType->carryForwardNeverExpires());
   }
 
   public function testCarryForwardNeverExpiresShouldReturnFalseIfTypeHasExpirationDuration() {
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_carry_forward' => true,
+      'allow_carry_forward' => TRUE,
       'carry_forward_expiration_duration' => 4,
       'carry_forward_expiration_unit' => AbsenceType::EXPIRATION_UNIT_MONTHS
     ]);
@@ -377,7 +377,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testCarryForwardNeverExpiresShouldBeNullIfTypeDoesAllowCarryForward() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['allow_carry_forward' => false]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['allow_carry_forward' => FALSE]);
     $this->assertNull($absenceType->carryForwardNeverExpires());
   }
 
@@ -413,7 +413,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnTheAbsenceTypeIfItExists() {
-    $expectedAbsenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true, 'is_active' => true]);
+    $expectedAbsenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE, 'is_active' => TRUE]);
 
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
 
@@ -421,7 +421,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnADisabledAbsenceType() {
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true, 'is_active' => false]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE, 'is_active' => FALSE]);
 
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
 
@@ -429,7 +429,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnNullIfThereIsNoSuchAbsenceType() {
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => false]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => FALSE]);
 
     $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
 
@@ -437,7 +437,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testItEnqueueAnUpdateWhenCreatingAnAbsenceTypeWithMustTakePublicHolidayAsLeave() {
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(1, $queue->numberOfItems());
@@ -450,35 +450,35 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testItDoesntEnqueueAnUpdateWhenCreatingAnAbsenceTypeWithoutMustTakePublicHolidayAsLeave() {
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => false]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => FALSE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(0, $queue->numberOfItems());
   }
 
   public function testItEnqueueAnUpdateWhenChangingTheMustTakePublicHolidayAsLeaveValueForAnAbsenceTypeFromFalseToTrue() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => false]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => FALSE]);
 
-    $this->updateBasicType($absenceType->id, ['must_take_public_holiday_as_leave' => true]);
+    $this->updateBasicType($absenceType->id, ['must_take_public_holiday_as_leave' => TRUE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(1, $queue->numberOfItems());
   }
 
   public function testItEnqueueAnUpdateWhenChangingTheMustTakePublicHolidayAsLeaveValueForAnAbsenceTypeFromTrueToFalse() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(1, $queue->numberOfItems());
 
-    $this->updateBasicType($absenceType->id, ['must_take_public_holiday_as_leave' => false]);
+    $this->updateBasicType($absenceType->id, ['must_take_public_holiday_as_leave' => FALSE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(2, $queue->numberOfItems());
   }
 
   public function testItDoesntEnqueueAnUpdateWhenUpdatingAnAbsenceTypeWithoutChangingMustTakePublicHolidayAsLeave() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
     $this->assertEquals(1, $queue->numberOfItems());
@@ -490,7 +490,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testItDoesntEnqueueAnUpdateWhenDeletingAnAbsenceTypeWithoutMustTakePublicHolidayAsLeave() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => false]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => FALSE]);
     AbsenceType::del($absenceType->id);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
@@ -498,7 +498,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   }
 
   public function testItShouldEnqueueAnUpdateWhenDeletingAnAbsenceTypeWithMustTakePublicHolidayAsLeave() {
-    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => true]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     AbsenceType::del($absenceType->id);
 
     $queue = PublicHolidayLeaveRequestUpdatesQueue::getQueue();
@@ -514,45 +514,45 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
 
   public function expirationUnitDataProvider() {
     $data = [
-      [rand(3, PHP_INT_MAX), true],
-      [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), TRUE],
+      [rand(3, PHP_INT_MAX), TRUE],
     ];
     $validOptions = array_keys(AbsenceType::getExpirationUnitOptions());
     foreach($validOptions as $option) {
-      $data[] = [$option, false];
+      $data[] = [$option, FALSE];
     }
     return $data;
   }
 
   public function accrualExpirationUnitAndDurationDataProvider() {
     return [
-      [AbsenceType::EXPIRATION_UNIT_DAYS, null, true],
-      [null, 10, true],
-      [AbsenceType::EXPIRATION_UNIT_MONTHS, 5, false],
+      [AbsenceType::EXPIRATION_UNIT_DAYS, NULL, TRUE],
+      [NULL, 10, TRUE],
+      [AbsenceType::EXPIRATION_UNIT_MONTHS, 5, FALSE],
     ];
   }
 
   public function allowRequestCancelationDataProvider() {
     $data = [
-      [rand(3, PHP_INT_MAX), true],
-      [rand(3, PHP_INT_MAX), true],
+      [rand(3, PHP_INT_MAX), TRUE],
+      [rand(3, PHP_INT_MAX), TRUE],
     ];
     $validOptions = array_keys(AbsenceType::getRequestCancelationOptions());
     foreach($validOptions as $option) {
-      $data[] = [$option, false];
+      $data[] = [$option, FALSE];
     }
     return $data;
   }
 
   public function carryForwardExpirationDateDataProvider() {
     return [
-      [12, 12, false],
-      [1, 2, false],
-      [31, 1, false],
-      [30, 2, true],
-      [31, 4, true],
-      [77, 9, true],
-      [12, 31, true],
+      [12, 12, FALSE],
+      [1, 2, FALSE],
+      [31, 1, FALSE],
+      [30, 2, TRUE],
+      [31, 4, TRUE],
+      [77, 9, TRUE],
+      [12, 31, TRUE],
     ];
   }
 
@@ -590,7 +590,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testCalculateToilExpiryDateWhenAbsenceTypeDoesNotAllowAccrualsRequest() {
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 1',
-      'allow_accruals_request' => false,
+      'allow_accruals_request' => FALSE,
       'is_active' => 1,
     ]);
     // date to calculate TOIL expiry for
@@ -601,9 +601,9 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
   public function testCalculateToilExpiryDateWhenAbsenceTypeAllowsAccrualsRequestAndNeverExpires() {
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 1',
-      'allow_accruals_request' => true,
-      'accrual_expiration_unit' => null,
-      'accrual_expiration_duration' => null,
+      'allow_accruals_request' => TRUE,
+      'accrual_expiration_unit' => NULL,
+      'accrual_expiration_duration' => NULL,
       'is_active' => 1,
     ]);
     // date to calculate TOIL expiry for
@@ -616,7 +616,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     // Duration set in days
     $absenceType = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 1',
-      'allow_accruals_request' => true,
+      'allow_accruals_request' => TRUE,
       'accrual_expiration_duration' => 10,
       'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_DAYS,
       'is_active' => 1,
@@ -629,7 +629,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     // Duration set in months
     $absenceType2 = AbsenceTypeFabricator::fabricate([
       'title' => 'Title 2',
-      'allow_accruals_request' => true,
+      'allow_accruals_request' => TRUE,
       'accrual_expiration_duration' => 10,
       'accrual_expiration_unit' => AbsenceType::EXPIRATION_UNIT_MONTHS,
       'is_active' => 1,
@@ -647,7 +647,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     ]);
 
     $absenceType = AbsenceTypeFabricator::fabricate([
-      'allow_accruals_request' => true,
+      'allow_accruals_request' => TRUE,
       'max_leave_accrual' => 1,
     ]);
 
@@ -660,7 +660,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_duration' => 120,
       'toil_expiry_date' => CRM_Utils_Date::processDate('+100 days'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
-    ], true);
+    ], TRUE);
 
     $toilRequest2 = LeaveRequestFabricator::fabricateWithoutValidation([
       'type_id' => $absenceType->id,
@@ -671,7 +671,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
       'toil_duration' => 120,
       'toil_expiry_date' => CRM_Utils_Date::processDate('2016-12-10'),
       'request_type' => LeaveRequest::REQUEST_TYPE_TOIL
-    ], true);
+    ], TRUE);
 
     // assert the records exist first before updating absence type
     $balanceChange = new LeaveBalanceChange();
@@ -690,13 +690,13 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     AbsenceType::create([
       'id' => $absenceType->id,
       'title' => $absenceType->title,
-      'allow_accruals_request' => false,
+      'allow_accruals_request' => FALSE,
       'color' => '#000000'
     ]);
 
     // confirm the balance change for the expired TOIL balance was not deleted
     $balanceChange = new LeaveBalanceChange();
-    $balanceChange->find(true);
+    $balanceChange->find(TRUE);
     $this->assertEquals(1, $balanceChange->N);
     $toilRequestBalanceChange = $this->findToilRequestMainBalanceChange($toilRequest2->id);
     $this->assertEquals($toilRequestBalanceChange->id, $balanceChange->id);
@@ -785,7 +785,7 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
    */
   public function testPublicHolidayEntitlementCannotBeAddedWhenLeaveIsCalculatedInHours() {
     AbsenceTypeFabricator::fabricate([
-      'add_public_holiday_to_entitlement' => true,
+      'add_public_holiday_to_entitlement' => TRUE,
       'calculation_unit' => $this->calculationUnitOptions['hours']
     ]);
   }


### PR DESCRIPTION
## Overview

This PR fixes a regression introduced in https://github.com/compucorp/civihr/pull/2864/commits/060a945806e901e08f8f2f9382518a2338989ee5. Due to the regression it was not possible to directly enable/disable absence type.

## Before

![1](https://user-images.githubusercontent.com/3973243/48719052-7c143400-ec14-11e8-9847-50294bc1cc6c.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/48719010-656ddd00-ec14-11e8-80de-cbe3cc195f3d.gif)

## Technical Details

We do not validate title if we are editing an absence type and the `title` param is not passed.

```php
private static function validateAbsenceTypeTitle($params) {
  $isEditing = array_key_exists('id', $params);
  $titleIsPassed = array_key_exists('title', $params);
  $skipTitleValidation = $isEditing && !$titleIsPassed;

  if ($skipTitleValidation) {
    return;

  // ...
}
```

-----
✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
✅PHP Unit Tests - added and passed