### PR TITLE
PCHR-4334: Fixed Display Issue with Existing Job Roles Funder

### DIFF
--- a/com.civicrm.hrjobroles/js/src/job-roles/controllers/job-role-panel.html
+++ b/com.civicrm.hrjobroles/js/src/job-roles/controllers/job-role-panel.html
@@ -327,12 +327,10 @@
                 <thead>
                   <tr>
                     <th style="width:40%">
-                    <th style="width:40%">
                       Funder
                       <span class="btn-link pointer" ng-click="jobroles.openOptionsEditor('hrjc_funder')">
                         <i class="fa fa-wrench"></i>
                       </span>
-                    </th>
                     </th>
                     <th style="width:15%">Type</th>
                     <th style="width:15%">% Amount</th>


### PR DESCRIPTION
## Overview
Funder tool icon implementation was previously implemented in https://github.com/compucorp/civihr/pull/2951. A display issue was introduced which was fixed by this PR.

## Before
<img width="578" alt="before_display_fix" src="https://user-images.githubusercontent.com/1507645/48900134-d3ebae80-ee51-11e8-915b-38eba64a42d4.png">


## After
<img width="577" alt="after_display_fix" src="https://user-images.githubusercontent.com/1507645/48900032-85d6ab00-ee51-11e8-8b3a-906c790be923.png">


## Comment
The table header had a replication of `th` tag causing issue with the display. The extra tags were removed in this PR.