### PR TITLE
PCHR-4330: Fix for upgrade error when no funder exist during migration

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -108,6 +108,11 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     ]);
     $jobRoles = $result['values'];
     $funderIds = $this->getFunderIds($jobRoles);
+
+    if (count($funderIds) === 0) {
+      return TRUE;
+    }
+
     $contactFunders = $this->createFunderOptionValues($funderIds);
     $this->updateJobRoleFunder($jobRoles, $contactFunders);
 


### PR DESCRIPTION
## Overview
After the implementation at https://github.com/compucorp/civihr/pull/2949, it was discovered that an error is being raised (`invalid criteria for IN`) for existing sites with no funder in job role. This PR fixes the issue.

## Before
An upgrade error was raised when no funder record exist in existing sites.

## After
Upgrader runs successfully in existing site when no funder record exist.

## Comment
A check was carried out to ensure funder record exists before proceeding with the upgrade.