### PR TITLE
PCHR-4329: Migrate existing organisation contact

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
@@ -63,22 +63,14 @@ class CRM_Hrjobcontract_BAO_HRJobHealth extends CRM_Hrjobcontract_DAO_HRJobHealt
    * @return Integer ( Provider ID or 0 if not exist)
    */
   public static function checkProvider($searchValue, $providerType) {
-    if (is_numeric ($searchValue))  {
-      $searchField = 'id';
-    }
-    else {
-      $searchField = 'display_name';
-    }
-    $queryParam = array(1 => array($searchValue, 'String'));
-    $query = "SELECT id,contact_sub_type FROM civicrm_contact WHERE {$searchField} = %1 " .
-             " AND is_deleted = 0".
-             " LIMIT 1";
-    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
-    if ($result->fetch()) {
-      $entitySubType = explode(CRM_Core_DAO::VALUE_SEPARATOR,
-        trim($result->contact_sub_type, CRM_Core_DAO::VALUE_SEPARATOR)
-      );
-      return in_array($providerType, $entitySubType) ? $result->id : 0;
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'hrjc_' . strtolower($providerType),
+      'value' => $searchValue,
+    ]);
+
+    if ($result['count']) {
+      $optionValue = array_shift($result['values']);
+      return $optionValue['value'];
     }
 
     return 0;

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
@@ -260,9 +260,9 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
                 'where' => 'civicrm_hrjobcontract_health.provider_life_insurance',
                 'headerPattern' => '',
                 'dataPattern' => '',
-                'pseudoconstant' => array(
+                'pseudoconstant' => [
                   'optionGroupName' => 'hrjc_life_insurance_provider'
-                ),
+                ],
                 'headerPattern' => '/^life\s?insurance\s?provider/i',
                 'entity' => 'HRJobHealth',
                 'bao' => 'CRM_Hrjobcontract_DAO_HRJobHealth',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
@@ -198,9 +198,9 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
                 'where' => 'civicrm_hrjobcontract_health.provider',
                 'headerPattern' => '',
                 'dataPattern' => '',
-                'pseudoconstant' => array(
+                'pseudoconstant' => [
                   'optionGroupName' => 'hrjc_health_insurance_provider'
-                ),
+                ],
                 'headerPattern' => '/^health\s?insurance\s?provider/i',
                 'entity' => 'HRJobHealth',
                 'bao' => 'CRM_Hrjobcontract_DAO_HRJobHealth',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobHealth.php
@@ -95,9 +95,9 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
    */
   public $id;
   /**
-   * FK to Contact ID for the organization or company which manages healthcare service
+   * Reference to option value belonging to hrjc_health_insurance_provider option group
    *
-   * @var int unsigned
+   * @var string
    */
   public $provider;
   /**
@@ -117,9 +117,9 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
    */
   public $dependents;
   /**
-   * FK to Contact ID for the organization or company which manages life insurance service
+   * Reference to option value belonging to hrjc_life_insurance_provider option group
    *
-   * @var int unsigned
+   * @var string
    */
   public $provider_life_insurance;
   /**
@@ -160,8 +160,6 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
   {
     if (!self::$_links) {
       self::$_links = array(
-        new CRM_Core_Reference_Basic(self::getTableName() , 'provider', 'civicrm_contact', 'id') ,
-        new CRM_Core_Reference_Basic(self::getTableName() , 'provider_life_insurance', 'civicrm_contact', 'id') ,
         new CRM_Core_Reference_Basic(self::getTableName() , 'jobcontract_revision_id', 'civicrm_hrjobcontract_revision', 'id') ,
       );
     }
@@ -191,14 +189,18 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
               ) ,
               'hrjobcontract_health_health_provider' => array(
                 'name' => 'provider',
-                'type' => CRM_Utils_Type::T_INT,
+                'type' => CRM_Utils_Type::T_STRING,
                 'title' => ts('Health Insurance Provider') ,
                 'export' => true,
                 'import' => true,
+                'maxlength' => 512,
+                'size' => CRM_Utils_Type::HUGE,
                 'where' => 'civicrm_hrjobcontract_health.provider',
                 'headerPattern' => '',
                 'dataPattern' => '',
-                'FKClassName' => 'CRM_Contact_DAO_Contact',
+                'pseudoconstant' => array(
+                  'optionGroupName' => 'hrjc_health_insurance_provider'
+                ),
                 'headerPattern' => '/^health\s?insurance\s?provider/i',
                 'entity' => 'HRJobHealth',
                 'bao' => 'CRM_Hrjobcontract_DAO_HRJobHealth',
@@ -249,14 +251,18 @@ class CRM_Hrjobcontract_DAO_HRJobHealth extends CRM_Hrjobcontract_DAO_Base
               ) ,
               'hrjobcontract_health_health_provider_life_insurance' => array(
                 'name' => 'provider_life_insurance',
-                'type' => CRM_Utils_Type::T_INT,
+                'type' => CRM_Utils_Type::T_STRING,
                 'title' => ts('Life insurance Provider') ,
                 'export' => true,
                 'import' => true,
+                'maxlength' => 512,
+                'size' => CRM_Utils_Type::HUGE,
                 'where' => 'civicrm_hrjobcontract_health.provider_life_insurance',
                 'headerPattern' => '',
                 'dataPattern' => '',
-                'FKClassName' => 'CRM_Contact_DAO_Contact',
+                'pseudoconstant' => array(
+                  'optionGroupName' => 'hrjc_life_insurance_provider'
+                ),
                 'headerPattern' => '/^life\s?insurance\s?provider/i',
                 'entity' => 'HRJobHealth',
                 'bao' => 'CRM_Hrjobcontract_DAO_HRJobHealth',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPension.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPension.php
@@ -114,7 +114,7 @@ class CRM_Hrjobcontract_DAO_HRJobPension extends CRM_Hrjobcontract_DAO_Base
   /**
    * Pension Type
    *
-   * @var int
+   * @var string
    */
   public $pension_type;
   /**
@@ -220,18 +220,17 @@ class CRM_Hrjobcontract_DAO_HRJobPension extends CRM_Hrjobcontract_DAO_Base
                 ) ,
                 'hrjobcontract_pension_pension_type' => array(
                   'name' => 'pension_type',
-                  'type' => CRM_Utils_Type::T_INT,
+                  'type' => CRM_Utils_Type::T_STRING,
                   'title' => ts('Pension Provider') ,
                   'export' => true,
                   'import' => true,
+                  'maxlength' => 512,
+                  'size' => CRM_Utils_Type::HUGE,
                   'where' => 'civicrm_hrjobcontract_pension.pension_type',
                   'headerPattern' => '/^pension\s?provider/i',
                   'dataPattern' => '',
-                  'FKClassName' => 'CRM_Contact_DAO_Contact',
                   'pseudoconstant' => array(
-                    'table' => 'civicrm_contact',
-                    'keyColumn' => 'id',
-                    'labelColumn' => 'display_name',
+                    'optionGroupName' => 'hrjc_pension_provider'
                   ),
                   'entity' => 'HRJobPension',
                   'bao' => 'CRM_Hrjobcontract_DAO_HRJobPension',

--- a/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPension.php
+++ b/hrjobcontract/CRM/Hrjobcontract/DAO/HRJobPension.php
@@ -229,9 +229,9 @@ class CRM_Hrjobcontract_DAO_HRJobPension extends CRM_Hrjobcontract_DAO_Base
                   'where' => 'civicrm_hrjobcontract_pension.pension_type',
                   'headerPattern' => '/^pension\s?provider/i',
                   'dataPattern' => '',
-                  'pseudoconstant' => array(
+                  'pseudoconstant' => [
                     'optionGroupName' => 'hrjc_pension_provider'
-                  ),
+                  ],
                   'entity' => 'HRJobPension',
                   'bao' => 'CRM_Hrjobcontract_DAO_HRJobPension',
                   'localizable' => 0,

--- a/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRJobPension.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Test/Fabricator/HRJobPension.php
@@ -3,49 +3,26 @@
 use CRM_Hrjobcontract_Test_Fabricator_BaseAPIFabricator as BaseAPIFabricator;
 
 class CRM_Hrjobcontract_Test_Fabricator_HRJobPension extends BaseAPIFabricator {
-  
+
   /**
-   * Fabricates Pension entity, using given parameters.  If pension type does not 
+   * Fabricates Pension entity, using given parameters.  If pension type does not
    * exist, new option value is created to be used as pension type.
-   * 
+   *
    * @param array $params
    *   Array of values to be used on creation of Pension for given contract
    */
   public static function fabricate($params) {
     if (!empty($params['pension_type'])) {
-      $pensionTypeResult = civicrm_api3('Contact', 'get', [
-        'sequential' => 1,
-        'contact_type' => 'Organization',
-        'contact_sub_type' => 'Pension_Provider',
-        'organization_name' => $params['pension_type'],
+      $pension = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+        'option_group_id' => 'hrjc_pension_provider',
+        'name' => $params['pension_type'],
+        'label' => $params['pension_type'],
+        'is_active' => TRUE,
       ]);
 
-      if ($pensionTypeResult['count'] == 0) {
-        $pensionTypeResult = self::createPensionType($params['pension_type']);
-      }
-      
-      $params['pension_type'] = $pensionTypeResult['id'];
+      $params['pension_type'] = $pension['value'];
     }
 
     return parent::fabricate($params);
-  }
-  
-  /**
-   * Creates a new pension provider.
-   * 
-   * @param string $value
-   *   Organization name.
-   * 
-   * @return array
-   *   Result of creating new provider.
-   */
-  private static function createPensionType($value) {
-    $result = civicrm_api3('Contact', 'create', [
-      'contact_type' => 'Organization',
-      'contact_sub_type' => 'pension_provider',
-      'organization_name' => $value,
-    ]);
-
-    return array_shift($result['values']);
   }
 }

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1104,26 +1104,48 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
       }
     }
 
-    $this->updateJobContractSchema();
+    $this->updateJobContractHealthSchema();
+    $this->updateJobContractPensionSchema();
 
     return TRUE;
   }
 
   /**
-   * Updates schema for the following Hrjobcontract tables
-   * 1. civicrm_hrjobcontract_pension
-   * 2. civicrm_hrjobcontract_health
+   * Updates job contract health schema
    */
-  private function updateJobContractSchema() {
+  private function updateJobContractHealthSchema() {
     $healthTableName = CRM_Hrjobcontract_BAO_HRJobHealth::getTableName();
     CRM_Core_DAO::executeQuery("
       ALTER TABLE $healthTableName
       MODIFY provider VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
-      MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group',
-      DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider,
-      DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider_life_insurance
+      MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group'
     ");
 
+    $healthConstraintExist = CRM_Core_DAO::checkConstraintExists(
+      $healthTableName,
+      'FK_civicrm_hrjobcontract_health_provider'
+    );
+    if ($healthConstraintExist) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE $healthTableName DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider
+      ");
+    }
+
+    $lifeInsuranceConstraintExist = CRM_Core_DAO::checkConstraintExists(
+      $healthTableName,
+      'FK_civicrm_hrjobcontract_health_provider'
+    );
+    if ($lifeInsuranceConstraintExist) {
+      CRM_Core_DAO::executeQuery("
+        ALTER TABLE $healthTableName DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider_life_insurance
+      ");
+    }
+  }
+
+  /**
+   * Updates job contract pension schema
+   */
+  private function updateJobContractPensionSchema() {
     $pensionTableName = CRM_Hrjobcontract_BAO_HRJobPension::getTableName();
     CRM_Core_DAO::executeQuery("
       ALTER TABLE $pensionTableName

--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1116,26 +1116,13 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    */
   private function updateJobContractSchema() {
     $healthTableName = CRM_Hrjobcontract_BAO_HRJobHealth::getTableName();
-    try {
-      CRM_Core_DAO::executeQuery("
-        ALTER TABLE $healthTableName
-        MODIFY provider VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
-        MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group',
-        DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider,
-        DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider_life_insurance
-      ");
-    } catch (Exception $e) {
-      $healthTableColumnCheck = CRM_Core_DAO::executeQuery("DESC $healthTableName");
-
-      while ($healthTableColumnCheck->fetch()) {
-        if ($healthTableColumnCheck->Field === 'provider' && $healthTableColumnCheck->Type != 'varchar(512)') {
-          throw new Exception("Error updating $healthTableName table: " . $e->getMessage());
-        }
-        elseif ($healthTableColumnCheck->Field === 'provider_life_insurance' && $healthTableColumnCheck->Type != 'varchar(512)') {
-          throw new Exception("Error updating $healthTableName table: " . $e->getMessage());
-        }
-      }
-    }
+    CRM_Core_DAO::executeQuery("
+      ALTER TABLE $healthTableName
+      MODIFY provider VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
+      MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group',
+      DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider,
+      DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider_life_insurance
+    ");
 
     $pensionTableName = CRM_Hrjobcontract_BAO_HRJobPension::getTableName();
     CRM_Core_DAO::executeQuery("

--- a/hrjobcontract/sql/install.sql
+++ b/hrjobcontract/sql/install.sql
@@ -136,11 +136,11 @@ CREATE TABLE `civicrm_hrjobcontract_pay` (
 
 CREATE TABLE `civicrm_hrjobcontract_health` (
     `id` int unsigned NOT NULL AUTO_INCREMENT  COMMENT 'Unique HRJobHealth ID',
-    `provider` int unsigned    COMMENT 'FK to Contact ID for the organization or company which manages healthcare service',
+    `provider` varchar(512)    COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
     `plan_type` varchar(63)   COMMENT '.',
     `description` text    ,
     `dependents` text,
-    `provider_life_insurance` int unsigned    COMMENT 'FK to Contact ID for the organization or company which manages life insurance service',
+    `provider_life_insurance` varchar(512)    COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group',
     `plan_type_life_insurance` varchar(63)    COMMENT '.',
     `description_life_insurance` text,
     `dependents_life_insurance` text,
@@ -151,8 +151,6 @@ CREATE TABLE `civicrm_hrjobcontract_health` (
     INDEX `index_provider_life_insurance`(provider_life_insurance),
     INDEX `index_plan_type_life_insurance`(plan_type_life_insurance),
     INDEX `index_jobcontract_revision_id` (jobcontract_revision_id ASC),
-    CONSTRAINT `FK_civicrm_hrjobcontract_health_provider` FOREIGN KEY (`provider`)  REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL,
-    CONSTRAINT `FK_civicrm_hrjobcontract_health_provider_life_insurance` FOREIGN KEY (`provider_life_insurance`)  REFERENCES `civicrm_contact`(`id`) ON DELETE SET NULL,
     CONSTRAINT `FK_civicrm_hrjobcontract_health_jobcontract_revision_id` FOREIGN KEY (`jobcontract_revision_id`)  REFERENCES `civicrm_hrjobcontract_revision` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
 
@@ -213,7 +211,7 @@ CREATE TABLE `civicrm_hrjobcontract_pension` (
     `is_enrolled` tinyint   DEFAULT 0 ,
     `ee_contrib_pct` double   DEFAULT 0 COMMENT 'Employee Contribution Percentage',
     `er_contrib_pct` double   DEFAULT 0 COMMENT 'Employer Contribution Percentage',
-    `pension_type` varchar(63) COMMENT 'Pension Type',
+    `pension_type` varchar(512) COMMENT 'Pension Type',
     `ee_contrib_abs` decimal(20,2)   DEFAULT 0 COMMENT 'Employee Contribution Absolute Amount',
     `ee_evidence_note` varchar(127)   COMMENT 'Employee evidence note',
     `jobcontract_revision_id` INT(10) UNSIGNED DEFAULT NULL,

--- a/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/Import/Parser/ApiTest.php
+++ b/hrjobcontract/tests/phpunit/CRM/Hrjobcontract/Import/Parser/ApiTest.php
@@ -435,13 +435,14 @@ class CRM_Hrjobcontract_Import_Parser_ApiTest extends CRM_Hrjobcontract_Test_Bas
   }
 
   private function createProvider($providerName, $type) {
-    $provider = ContactFabricator::fabricateOrganization([
-      'contact_type' => 'Organization',
-      'contact_sub_type' => $type,
-      'organization_name' => $providerName,
+    $providerOption = CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'hrjc_' . strtolower($type),
+      'name' => $providerName,
+      'label' => $providerName,
+      'is_active' => TRUE,
     ]);
 
-    return $provider['id'];
+    return $providerOption['value'];
   }
 
   public function testImportingContractWithEndDateWithoutEndReason() {


### PR DESCRIPTION
## Overview
Existing organisation contacts were used for health, life and pension insurance provider. Having created an option group in https://github.com/compucorp/civihr/pull/2919 for managing list of providers, this PR migrates providers in existing job roles by creating option value replica.

## Before
Providers in organisation contact were not migrated to option value for their respective option group

## After
Providers which are previously in contact are migrated to option value for their respective option group.

## Technical Details
The install file in [hrjobcontract](https://github.com/compucorp/civihr/blob/master/hrjobcontract/sql/install.sql) was manually modified to remove the contact constraint on `civicrm_hrjobcontract_pension` and `civicrm_hrjobcontract_health`. This was due lack of proper integration with CiviCRM GenCode implementation. Their column types were also changed to varchar(255), the data type used for option value's value column. Their DAO were also modified for same reason, change the data type, maxlength, and pseudoconstant reference to their option group. For existing sites, an upgrader caters for modifying the tables
```
$healthTableName = CRM_Hrjobcontract_BAO_HRJobHealth::getTableName();
CRM_Core_DAO::executeQuery("
  ...
");

$pensionTableName = CRM_Hrjobcontract_BAO_HRJobPension::getTableName();
CRM_Core_DAO::executeQuery("
  ...
");
```

An upgrader was written to migrate the existing records to option value. The upgrade copied the details of each contact
```
$result = civicrm_api3('Contact', 'get', [
  'contact_sub_type' => ['IN' => $provider],
]);
```
and created another record with the same details. 
```
$params = [
  'option_group_id' => 'hrjc_' .  strtolower($contactType),
  'value' => $contact['id'],
  'name' => $contact['organization_name'],
  'label' => $contact['sort_name']
];
```
Due to possibilities of having two different contacts with the same name, all organisation (irrespective of name) were migrated separately to option value. The contact ids become the option value. This means there is no need of updating existing provider record. Also, this helps avoid issue with upgrader overriding a previously updated provider record due to its id being equal to the new ones to be updated.
```
 civicrm_api3('OptionValue', 'create', $params);
```
The provider's option value are not reserved. Any duplicate option value can be safely migrated and the duplicate ones deleted by users.

## Comment
Migrated contact records were not deleted in this PR. This was meant to be a fail-safe recovery mechanism. This will be handled in a separate PR.