### PR TITLE
PCHR-4329: Fix build issue on existing sites with foreign key constraints

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Upgrader.php
@@ -1115,12 +1115,6 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
    */
   private function updateJobContractHealthSchema() {
     $healthTableName = CRM_Hrjobcontract_BAO_HRJobHealth::getTableName();
-    CRM_Core_DAO::executeQuery("
-      ALTER TABLE $healthTableName
-      MODIFY provider VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
-      MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group'
-    ");
-
     $healthConstraintExist = CRM_Core_DAO::checkConstraintExists(
       $healthTableName,
       'FK_civicrm_hrjobcontract_health_provider'
@@ -1140,6 +1134,12 @@ class CRM_Hrjobcontract_Upgrader extends CRM_Hrjobcontract_Upgrader_Base {
         ALTER TABLE $healthTableName DROP FOREIGN KEY FK_civicrm_hrjobcontract_health_provider_life_insurance
       ");
     }
+
+    CRM_Core_DAO::executeQuery("
+      ALTER TABLE $healthTableName
+      MODIFY provider VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_health_insurance_provider option group',
+      MODIFY provider_life_insurance VARCHAR(512) COMMENT 'Reference to option value belonging to hrjc_life_insurance_provider option group'
+    ");
   }
 
   /**


### PR DESCRIPTION
## Overview
Migration of existing organisation contact was previously implemented in https://github.com/compucorp/civihr/pull/2959. A build error for existing site was introduced there which this PR fixes. 

## Before
A CIVICRM api error was generated while upgrading existing site. 

## After
No API error was generated while upgrading site.

## Comments
 The upgrader initially modifies table column and then check if any column restriction exit before attempting to remove affected foreign keys. The constraint restriction check was put in place to cater for new sites which do not have the foreign keys. Due to the constraints, an API error was thrown while modifying the columns on existing sites before foreign key constraints were removed. 
The order of implementation was therefore changed to ensure restrictions were removed (if present) before attempting to modify column.