### PR TITLE
PCHR-4445: Remove reference to deleted partial

### DIFF
--- a/org.civicrm.bootstrapcivihr/scss/overrides/_variables.scss
+++ b/org.civicrm.bootstrapcivihr/scss/overrides/_variables.scss
@@ -1,5 +1,4 @@
 @import 'SCSSROOT/org.civicrm.shoreditch/scss/bootstrap/overrides/variables';
-@import 'SCSSROOT/org.civicrm.shoreditch/base/scss/overrides/variables';
 @import 'SCSSROOT/org.civicrm.shoreditch/base/scss/vendor/bootstrap/variables';
 @import 'SCSSROOT/org.civicrm.shoreditch/scss/bootstrap/vendor/font-awesome/variables';
 @import 'SCSSROOT/org.civicrm.shoreditch/scss/civicrm/variables';


### PR DESCRIPTION
The `org.civicrm.shoreditch/base/scss/overrides/_variables.scss` partial had been removed from Shoreditch (see above PR for additional details), so we need to remove its reference in the `org.civicrm.bootstrapcivihr` sass codebase

**Note:** the `gulp sass` task had been executed on every CiviHR extension and in the SSP theme, and as expected no changes in the minified css files had been detected

**Note 2:** a different ticket to track the fork syncing was created after the branch of this PR had already been created, hence the reason the branch name is referencing a different ticket number