### PR TITLE
PCHR-4431: Remove the validation that allows only one absence type with mstphl

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -168,10 +168,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
       self::validateAddPublicHolidayToEntitlement($params);
     }
 
-    if(!empty($params['must_take_public_holiday_as_leave'])) {
-      self::validateMustTakePublicHolidayAsLeave($params);
-    }
-
     if (!empty($params['allow_request_cancelation']) &&
         !array_key_exists($params['allow_request_cancelation'], self::getRequestCancelationOptions())
     ) {
@@ -244,26 +240,6 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
           'The Calculation unit cannot be changed because the Absence Type is In Use!'
         );
       }
-    }
-  }
-
-  /**
-   * Validates the must_take_public_holiday_as_leave field.
-   *
-   * There can be only one AbsenceType where this field is true. So this
-   * method checks if one such type already exists and throws an error if that
-   * is the case.
-   *
-   * @param array $params
-   *  The params array received by the create method
-   *
-   * @throws \CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException
-   */
-  private static function validateMustTakePublicHolidayAsLeave($params) {
-    if(!self::fieldIsUnique('must_take_public_holiday_as_leave', 1, $params)) {
-      throw new CRM_HRLeaveAndAbsences_Exception_InvalidAbsenceTypeException(
-        'There is already one Absence Type where "Must staff take public holiday as leave" is selected'
-      );
     }
   }
 


### PR DESCRIPTION
## Overview
When creating leave request, there is a validation that ensures only one leave type can have `Must Take Public Holiday as Leave` set to true. This PR removes the validation based on requirement to allow creation of multiple leave type having public holiday added.

## Before
Creating multiple leave type with public holiday was not possible.

## After
Creation of multiple leave type with public holiday is now possible.

## Technical Details
The validation [implementations](https://github.com/compucorp/civihr/blob/master/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php#L235) for `validateMustTakePublicHolidayAsLeave` were removed from HRLeaveandabsences AbsenceType BAO. 