### PR TITLE
PCHR-4426: Fix warning on the Work Patterns list page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php
@@ -414,7 +414,7 @@ class CRM_HRLeaveAndAbsences_BAO_WorkPattern extends CRM_HRLeaveAndAbsences_DAO_
         'time_to' => $row['time_to'],
         'break' => $row['break'],
         'leave_days' => $row['leave_days'],
-        'number_of_hours' => $row['number_of_hours'],
+        'number_of_hours' => (float)$row['number_of_hours'],
       ];
 
       $workDayIndex++;

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/ContactWorkPatternTest.php
@@ -182,7 +182,7 @@ class CRM_HRLeaveAndAbsences_Service_ContactWorkPatternTest extends BaseHeadless
       'time_to' => CRM_Utils_Array::value('time_to', $workDay, ''),
       'break' => CRM_Utils_Array::value('break', $workDay, ''),
       'leave_days' => !empty($workDay['leave_days']) ? $workDay['leave_days'] : '',
-      'number_of_hours' =>  !empty($workDay['number_of_hours']) ? $workDay['number_of_hours'] : ''
+      'number_of_hours' => (float)CRM_Utils_Array::value('number_of_hours', $workDay, 0),
     ];
   }
 }


### PR DESCRIPTION
## Problem

On sites running on PHP 7.2, the following warning is displayed when accessing the Work Patterns list page:

```
Warning: A non-numeric value encountered in CRM_HRLeaveAndAbsences_BAO_WorkPattern->getNumberOfHours() (line 249 of /var/www/master-php7.civihr.net/httpdocs/sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/WorkPattern.php).
```

## Solution

The error was being thrown by the method used to calculate the total number of working hours for each work pattern. It does that by summing the `number_of_hours` for each Work Day of each Work Week in the pattern. For non-working days, the `number_of_hours` field will an empty string, which is not a numeric value, hence the warning.

To fix it, the make sure of converting the values fetched from the database to valid floats, resulting in the empty `number_of_hours` being converted to 0.

## Comments

But why didn't we have this warning before? It turns out this warning message has been introduced only in PHP 7.1.25, as it can been [here](https://3v4l.org/NeeYo)