### PR TITLE
PCHR-4441: Fix errors on the L&A settings page

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php
@@ -9,18 +9,6 @@ require_once 'CRM/Core/Form.php';
  */
 class CRM_HRLeaveAndAbsences_Form_GeneralSettings extends CRM_Core_Form {
 
-  /**
-   * @var array
-   *   The filter to pass to the setting.getfields API
-   */
-  private $settingFilter = ['group' => 'leave_and_absences_general_settings'];
-
-  /**
-   * @var array
-   *   An array to store settings once it has been retrieved from the settings API
-   */
-  private $settings = [];
-
   private $submittedValues = [];
 
   public function buildQuickForm() {
@@ -28,7 +16,9 @@ class CRM_HRLeaveAndAbsences_Form_GeneralSettings extends CRM_Core_Form {
 
     foreach ($settings as $name => $setting) {
       if ($name == 'relationship_types_allowed_to_approve_leave') {
-        $this->$setting['html_type'](
+        $htmlType = $setting['html_type'];
+
+        $this->$htmlType(
           $name,
           [
             'options' => $this->getRelationshipTypes(),
@@ -84,9 +74,9 @@ class CRM_HRLeaveAndAbsences_Form_GeneralSettings extends CRM_Core_Form {
    * @return array
    */
   public function getFormSettings() {
-    if (empty($this->settings)) {
-      $settings = civicrm_api3('Setting', 'getfields', ['filters' => $this->settingFilter]);
-    }
+    $settingFilter = ['group' => 'leave_and_absences_general_settings'];
+
+    $settings = civicrm_api3('Setting', 'getfields', ['filters' => $settingFilter]);
 
     return $settings['values'];
   }


### PR DESCRIPTION
## Problem

After the upgrade to PHP 7, some notices and errors started appearing on L&A settings page. The settings form itself would not load:

```
Notice: Array to string conversion in CRM_HRLeaveAndAbsences_Form_GeneralSettings->buildQuickForm() (line 31 of /sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php).
Notice: Undefined property: CRM_HRLeaveAndAbsences_Form_GeneralSettings::$Array in CRM_HRLeaveAndAbsences_Form_GeneralSettings->buildQuickForm() (line 31 of /sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php).
Error: Function name must be a string in CRM_HRLeaveAndAbsences_Form_GeneralSettings->buildQuickForm() (line 31 of /sites/all/modules/civicrm/tools/extensions/civihr/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Form/GeneralSettings.php)
```

## Solution

The errors were caused by changes introduced in PHP 7.0 on how to handle variable variables. See [here](https://secure.php.net/manual/ro/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect) for more details.

The `buildQuickForm()` method would read the form settings, get the value from the `html_type` option and call a method with that name to add a form element to the page. The line that does that looked like this:

```php
$this->$setting['html_type']();
```

On PHP 5.6, this would be interpreted like this:

```php
$this->{$setting['html_type']}()
```

That is, first evaluate `$setting['html_type']` and then use that as the method name to be called on `$this`.

On PHP 7, it is now interpreted like this:

```php
{$this->$setting}['html_type']()
```

That is, it first evaluates `$this->$setting`. The `$setting` variable in this context is an array, so it will try to convert this to a string in order to be able to search for a property with that name. It will fail (hence the "Array to string conversion" and the "Undefined property" errors). This will finally return null, an invalid method name, resulting in the "Function name must be a string" error.