### PR TITLE
PCHR-4432:  Add support for creation of Public Holiday Requests for Absence Types with MTPHL Via Background Job

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/AbsenceType.php
@@ -536,22 +536,24 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceType extends CRM_HRLeaveAndAbsences_DAO_
   }
 
   /**
-   * Returns the AbsenceType where the must_take_public_holiday_as_leave option
-   * is set
+   * Returns the AbsenceTypes where the must_take_public_holiday_as_leave option
+   * is set to TRUE.
    *
-   * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType|null
+   * @return \CRM_HRLeaveAndAbsences_BAO_AbsenceType[]
+   *   An array of Absence Type objects
    */
-  public static function getOneWithMustTakePublicHolidayAsLeaveRequest() {
+  public static function getAllWithMustTakePublicHolidayAsLeaveRequest() {
     $absenceType = new self();
     $absenceType->must_take_public_holiday_as_leave = 1;
     $absenceType->is_active = 1;
-
     $absenceType->find();
-    if($absenceType->fetch()) {
-      return $absenceType;
+
+    $absenceTypes = [];
+    while ($absenceType->fetch()) {
+      $absenceTypes[] = clone $absenceType;
     }
 
-    return NULL;
+    return $absenceTypes;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/BAO/LeaveRequest.php
@@ -797,17 +797,24 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequest extends CRM_HRLeaveAndAbsences_DAO
   /**
    * Returns a LeaveRequest instance representing the Public Holiday Leave Request
    * for the given $publicHoliday and assigned to the Contact with the given
-   * $contactID, the leave request is returned as long as it exists in the database
-   * either soft deleted or not.
+   * $contactID and for the given Absence Type.
+   * The leave request is returned as long as it exists in the database either
+   * soft deleted or not.
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   * @param AbsenceType $absenceType
    *
    * @return \CRM_HRLeaveAndAbsences_BAO_LeaveRequest|null
    */
-  public static function findPublicHolidayLeaveRequestEvenIfDeleted($contactID, PublicHoliday $publicHoliday) {
+  public static function findPublicHolidayLeaveRequestEvenIfDeleted(
+    $contactID,
+    PublicHoliday $publicHoliday,
+    AbsenceType $absenceType
+  ) {
     $leaveRequest = new self();
     $leaveRequest->contact_id = (int)$contactID;
+    $leaveRequest->type_id = $absenceType->id;
     $leaveRequest->from_date = date('Ymd', strtotime($publicHoliday->date));
     $leaveRequest->request_type = self::REQUEST_TYPE_PUBLIC_HOLIDAY;
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/LeaveRequest.php
@@ -184,7 +184,11 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequest {
     if($leaveRequest->request_type == LeaveRequest::REQUEST_TYPE_PUBLIC_HOLIDAY) {
       $publicHoliday = new PublicHoliday();
       $publicHoliday->date = $leaveRequest->from_date;
-      $this->publicHolidayLeaveRequestDeletionService->softDeleteForContact($leaveRequest->contact_id, $publicHoliday);
+      $this->publicHolidayLeaveRequestDeletionService->softDeleteForContact(
+        $leaveRequest->contact_id,
+        $publicHoliday,
+        $leaveRequest->type_id
+      );
     }
     else {
       LeaveRequest::softDelete($leaveRequestID);

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -280,7 +280,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   private function zeroDeductionForOverlappingLeaveRequestDate(LeaveRequest $leaveRequest, LeaveRequestDate $leaveRequestDate) {
     $date = new DateTime($leaveRequestDate->date);
 
-    $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $date);
+    $leaveBalanceChange = LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate($leaveRequest, $date);
 
     if($leaveBalanceChange) {
       LeaveBalanceChange::create([

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreation.php
@@ -30,10 +30,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   private $leavePeriodEntitlementService;
 
   /**
-   * @var \CRM_HRLeaveAndAbsences_BAO_AbsenceType|null
-   *   An absence Type with MTPHL set to true
+   * @var \CRM_HRLeaveAndAbsences_BAO_AbsenceType[]
+   *   Absence Types with MTPHL set to true
    */
-  private $absenceType;
+  private $absenceTypes;
 
   public function __construct(
     JobContractService $jobContractService,
@@ -43,7 +43,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     $this->jobContractService = $jobContractService;
     $this->leaveBalanceChangeService = $leaveBalanceChangeService;
     $this->leavePeriodEntitlementService = $leavePeriodEntitlementService;
-    $this->absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+    $this->absenceTypes = AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest();
   }
 
   /**
@@ -59,7 +59,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   public function createForAllContacts(PublicHoliday $publicHoliday) {
     $absencePeriod = AbsencePeriod::getPeriodOverlappingDate(new DateTime($publicHoliday->date));
 
-    if(!$absencePeriod || !$this->absenceType) {
+    if (!$absencePeriod || empty($this->absenceTypes)) {
       return;
     }
 
@@ -72,8 +72,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     $entitlements = $this->getEntitlementsForContacts($contactIDs, $absencePeriod);
 
     foreach($contracts as $contract) {
-      if($this->contactHasEntitlement($entitlements, $contract['contact_id'])) {
-        $this->createForContact($contract['contact_id'], $publicHoliday);
+      foreach ($this->absenceTypes as $absenceType) {
+        if ($this->contactHasEntitlement($entitlements, $contract['contact_id'], $absenceType)) {
+          $this->createForContact($contract['contact_id'], $publicHoliday, $absenceType);
+        }
       }
     }
   }
@@ -93,7 +95,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    *  If not empty, Public Holiday Leave Requests are created for only these contacts
    */
   public function createAllInTheFuture(array $contactID = []) {
-    if(!$this->absenceType) {
+    if (empty($this->absenceTypes)) {
       return;
     }
 
@@ -147,7 +149,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   public function createAllForContract($contractID) {
     $contract = $this->jobContractService->getContractByID($contractID);
 
-    if (!$contract || !$this->absenceType) {
+    if (!$contract || empty($this->absenceTypes)) {
       return;
     }
 
@@ -168,8 +170,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
 
       $entitlements = $this->getEntitlementsForContacts([$contract['contact_id']], $absencePeriod);
       foreach($publicHolidays as $publicHoliday) {
-        if($this->contactHasEntitlement($entitlements, $contract['contact_id'])) {
-          $this->createForContact($contract['contact_id'], $publicHoliday);
+        foreach ($this->absenceTypes as $absenceType) {
+          if ($this->contactHasEntitlement($entitlements, $contract['contact_id'], $absenceType)) {
+            $this->createForContact($contract['contact_id'], $publicHoliday, $absenceType);
+          }
         }
       }
     }
@@ -180,21 +184,27 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * given $contactId
    *
    * @param int $contactID
+   * @param AbsenceType $absenceType
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    *
    * @return LeaveRequest|null
    */
-  public function createForContact($contactID, PublicHoliday $publicHoliday) {
-    if (!$this->absenceType) {
+  public function createForContact($contactID, PublicHoliday $publicHoliday, AbsenceType $absenceType) {
+    if (!$absenceType->must_take_public_holiday_as_leave) {
       return;
     }
 
-    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
-    if($existingLeaveRequest) {
+    $existingLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted(
+      $contactID,
+      $publicHoliday,
+      $absenceType
+    );
+
+    if ($existingLeaveRequest) {
       return;
     }
 
-    $leaveRequest = $this->createLeaveRequest($contactID, $this->absenceType, $publicHoliday);
+    $leaveRequest = $this->createLeaveRequest($contactID, $absenceType, $publicHoliday);
     $this->createLeaveBalanceChangeRecord($leaveRequest);
     $this->recalculateExpiredBalanceChange($leaveRequest);
 
@@ -334,7 +344,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * @param array $contactID
    */
   public function createAllForAbsencePeriod($absencePeriod, array $contactID = []) {
-    if(!$this->absenceType) {
+    if(empty($this->absenceTypes)) {
       return;
     }
 
@@ -355,8 +365,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
     foreach($contracts as $contract) {
       foreach($publicHolidays as $publicHoliday) {
         if($this->publicHolidayOverlapsContract($contract, $publicHoliday)) {
-          if($this->contactHasEntitlement($entitlements, $contract['contact_id'])) {
-            $this->createForContact($contract['contact_id'], $publicHoliday);
+          foreach ($this->absenceTypes as $absenceType) {
+            if ($this->contactHasEntitlement($entitlements, $contract['contact_id'], $absenceType)) {
+              $this->createForContact($contract['contact_id'], $publicHoliday, $absenceType);
+            }
           }
         }
       }
@@ -377,7 +389,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
   public function createAll() {
     $absencePeriods = $this->getAllAbsencePeriods();
 
-    if(!$absencePeriods || !$this->absenceType) {
+    if(!$absencePeriods || empty($this->absenceTypes)) {
       return;
     }
 
@@ -403,16 +415,17 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    *
    * @param array $entitlements
    * @param int $contactID
+   * @param AbsenceType $absenceType
    *
    * @return bool
    */
-  private function contactHasEntitlement($entitlements, $contactID) {
-    return !empty($entitlements[$contactID][$this->absenceType->id]) && $entitlements[$contactID][$this->absenceType->id] > 0;
+  private function contactHasEntitlement($entitlements, $contactID, $absenceType) {
+    return !empty($entitlements[$absenceType->id][$contactID][$absenceType->id]) && $entitlements[$absenceType->id][$contactID][$absenceType->id] > 0;
   }
 
   /**
    * Returns the entitlements for the given contact(s) during the absence
-   * period for the absence type with MTPHL.
+   * period for the absence types with MTPHL.
    *
    * @param array $contactIDs
    * @param AbsencePeriod $absencePeriod
@@ -420,11 +433,16 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation {
    * @return array
    */
   private function getEntitlementsForContacts($contactIDs, AbsencePeriod $absencePeriod) {
-    return $this->leavePeriodEntitlementService->getEntitlementsForContacts(
-      $contactIDs,
-      $absencePeriod->id,
-      $this->absenceType->id
-    );
+    $entitlements = [];
+    foreach ($this->absenceTypes as $absenceType) {
+      $entitlements[$absenceType->id] = $this->leavePeriodEntitlementService->getEntitlementsForContacts(
+        $contactIDs,
+        $absencePeriod->id,
+        $absenceType->id
+      );
+    }
+
+    return $entitlements;
   }
 
   /**

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -6,6 +6,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_BAO_WorkPattern as WorkPattern;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_ContactWorkPattern as ContactWorkPattern;
 use CRM_HRLeaveAndAbsences_Factory_LeaveDateAmountDeduction as LeaveDateAmountDeductionFactory;
 use CRM_HRLeaveAndAbsences_Service_ContactWorkPattern as ContactWorkPatternService;
@@ -48,14 +49,16 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
    */
   public function deleteForContact($contactID, PublicHoliday $publicHoliday) {
-    $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+    $leaveRequests = LeaveRequest::findAllPublicHolidayLeaveRequests($contactID, $publicHoliday);
 
-    if(!$leaveRequest) {
+    if (empty($leaveRequests)) {
       return;
     }
 
-    $this->deleteDatesWithBalanceChanges($leaveRequest);
-    $leaveRequest->delete();
+    foreach ($leaveRequests as $leaveRequest) {
+      $this->deleteDatesWithBalanceChanges($leaveRequest);
+      $leaveRequest->delete();
+    }
   }
 
   /**
@@ -66,11 +69,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    *
    * @param int $contactID
    * @param \CRM_HRLeaveAndAbsences_BAO_PublicHoliday $publicHoliday
+   * @param int $absenceTypeID
    */
-  public function softDeleteForContact($contactID, PublicHoliday $publicHoliday) {
-    $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+  public function softDeleteForContact($contactID, PublicHoliday $publicHoliday, $absenceTypeID) {
+    $absenceType = AbsenceType::findById($absenceTypeID);
+    $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, $absenceType);
 
-    if(!$leaveRequest) {
+    if (!$leaveRequest) {
       return;
     }
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletion.php
@@ -161,7 +161,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletion {
    * @param \DateTime $date
    */
   private function recalculateDeductionForOverlappingLeaveRequestDate(LeaveRequest $leaveRequest, DateTime $date) {
-    $leaveBalanceChange = LeaveBalanceChange::getExistingBalanceChangeForALeaveRequestDate($leaveRequest, $date);
+    $leaveBalanceChange = LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate($leaveRequest, $date);
     $dateDeductionFactory = LeaveDateAmountDeductionFactory::createForAbsenceType($leaveRequest->type_id);
     $contactWorkPatternService = new ContactWorkPatternService();
 

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Test/Fabricator/PublicHolidayLeaveRequest.php
@@ -1,10 +1,12 @@
 <?php
 
 use CRM_HRLeaveAndAbsences_BAO_PublicHoliday as PublicHoliday;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_Service_JobContract as JobContractService;
 use CRM_HRLeaveAndAbsences_Service_LeaveBalanceChange as LeaveBalanceChangeService;
 use CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreation as PublicHolidayLeaveRequestCreation;
 use CRM_HRLeaveAndAbsences_Service_LeavePeriodEntitlement as LeavePeriodEntitlementService;
+use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
 
 class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
 
@@ -34,6 +36,21 @@ class CRM_HRLeaveAndAbsences_Test_Fabricator_PublicHolidayLeaveRequest {
       $leavePeriodEntitlementService
     );
 
-    return $creationLogic->createForContact($contactID, $publicHoliday);
+    $absenceTypes = AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest();
+
+    if (empty($absenceTypes)) {
+      $absenceTypes[] = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
+    }
+
+    $publicHolidayRequests = [];
+    foreach ($absenceTypes as $absenceType) {
+      $publicHolidayRequests[] = $creationLogic->createForContact($contactID, $publicHoliday, $absenceType);
+    }
+
+    if (count($publicHolidayRequests) == 1) {
+      return $publicHolidayRequests[0];
+    }
+
+    return $publicHolidayRequests;
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/AbsenceTypeTest.php
@@ -409,28 +409,32 @@ class CRM_HRLeaveAndAbsences_BAO_AbsenceTypeTest extends BaseHeadlessTest {
     $this->assertCount(1, $absenceTypes);
   }
 
-  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnTheAbsenceTypeIfItExists() {
-    $expectedAbsenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE, 'is_active' => TRUE]);
+  public function testGetAllWithMustTakePublicHolidayAsLeaveRequestShouldNotReturnDisabledAbsenceTypes() {
+    $absenceType1 = AbsenceTypeFabricator::fabricate([
+      'must_take_public_holiday_as_leave' => TRUE,
+      'is_active' => FALSE
+    ]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate([
+      'must_take_public_holiday_as_leave' => TRUE,
+      'is_active' => TRUE
+    ]);
+    $absenceType3 = AbsenceTypeFabricator::fabricate([
+      'must_take_public_holiday_as_leave' => TRUE,
+      'is_active' => TRUE
+    ]);
 
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
-
-    $this->assertEquals($expectedAbsenceType->id, $absenceType->id);
+    $absenceTypes = AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest();
+    $this->assertCount(2, $absenceTypes);
+    $this->assertEquals($absenceTypes[0]->id, $absenceType2->id);
+    $this->assertEquals($absenceTypes[1]->id, $absenceType3->id);
   }
 
-  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnADisabledAbsenceType() {
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE, 'is_active' => FALSE]);
-
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
-
-    $this->assertNull($absenceType);
-  }
-
-  public function testGetOneWithMustTakePublicHolidayAsLeaveRequestShouldReturnNullIfThereIsNoSuchAbsenceType() {
+  public function testGetAllWithMustTakePublicHolidayAsLeaveRequestShouldReturnEmptyIfThereIsNoSuchAbsenceType() {
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => FALSE]);
 
-    $absenceType = AbsenceType::getOneWithMustTakePublicHolidayAsLeaveRequest();
+    $absenceTypes = AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest();
 
-    $this->assertNull($absenceType);
+    $this->assertEmpty($absenceTypes);
   }
 
   public function testItEnqueueAnUpdateWhenCreatingAnAbsenceTypeWithMustTakePublicHolidayAsLeave() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -5,6 +5,7 @@ use CRM_HRLeaveAndAbsences_BAO_LeaveRequest as LeaveRequest;
 use CRM_HRLeaveAndAbsences_BAO_LeaveRequestDate as LeaveRequestDate;
 use CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChange as LeaveBalanceChange;
 use CRM_HRLeaveAndAbsences_BAO_AbsencePeriod as AbsencePeriod;
+use CRM_HRLeaveAndAbsences_BAO_AbsenceType as AbsenceType;
 use CRM_HRLeaveAndAbsences_BAO_LeavePeriodEntitlement as LeavePeriodEntitlement;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsencePeriod as AbsencePeriodFabricator;
 use CRM_HRLeaveAndAbsences_Test_Fabricator_AbsenceType as AbsenceTypeFabricator;
@@ -1192,7 +1193,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $date = new DateTime('2017-03-02');
     $leaveDate = $date->format('YmdHis');
 
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    $tableName = AbsenceType::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
@@ -1218,7 +1219,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
     ]);
 
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    $tableName = AbsenceType::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
@@ -1251,7 +1252,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     ));
   }
 
-  public function testGetBalanceChangeToModifyForLeaveDateDoesWillReturnResultsWhenOnlyALeaveRequestBalanceExists() {
+  public function testGetBalanceChangeToModifyForLeaveDateWillReturnResultsWhenOnlyALeaveRequestBalanceExists() {
     $absenceType = AbsenceTypeFabricator::fabricate();
     $date = new DateTime('2017-01-01');
     $leaveDate = $date->format('YmdHis');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1193,8 +1193,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $date = new DateTime('2017-03-02');
     $leaveDate = $date->format('YmdHis');
 
-    $tableName = AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
 
@@ -1219,8 +1220,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
       'end_date' => CRM_Utils_Date::processDate('2017-12-31')
     ]);
 
-    $tableName = AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
 
@@ -3824,5 +3826,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
 
   private function calculateAmountForDateWhenWorkDayIsNull(LeaveRequest $leaveRequest, DateTime $date, $amount) {
     $this->calculateAmountForDate($leaveRequest, $date, $amount, null);
+  }
+
+  private function deleteAllExistingAbsenceTypes() {
+    $tableName = AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveBalanceChangeTest.php
@@ -1183,6 +1183,96 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveBalanceChangeTest extends BaseHeadlessTest
     $this->assertNull($leaveBalanceChange);
   }
 
+  public function testGetBalanceChangeToModifyForLeaveDateReturnsNullWhenOnlyPublicHolidayRequestBalanceExist() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $date = new DateTime('2017-03-02');
+    $leaveDate = $date->format('YmdHis');
+
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = $leaveDate;
+    $contactID = 2;
+
+    $publicHolidayLeaveRequest = $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contactID, $publicHoliday);
+    $this->assertCount(2, LeaveRequest::findAllPublicHolidayLeaveRequests($contactID, $publicHoliday));
+
+    //No leave balance record is returned because public holiday balances are not eligible for
+    //modifications.
+    $this->assertNull(LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate(
+      $publicHolidayLeaveRequest[0],
+      new DateTime($leaveDate)
+    ));
+  }
+
+  public function testGetBalanceChangeToModifyForLeaveDateReturnsNullWhenALeaveRequestBalanceCoExistsWithPublicHolidayRequestBalance() {
+    AbsencePeriodFabricator::fabricate([
+      'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
+      'end_date' => CRM_Utils_Date::processDate('2017-12-31')
+    ]);
+
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
+    $date = new DateTime('2017-02-01');
+    $leaveDate = $date->format('YmdHis');
+    $contactID = 2;
+
+    $publicHoliday = new PublicHoliday();
+    $publicHoliday->date = $leaveDate;
+
+    $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contactID, $publicHoliday);
+    $this->assertCount(2, LeaveRequest::findAllPublicHolidayLeaveRequests($contactID, $publicHoliday));
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => $absenceType1->id,
+      'from_date' => $leaveDate,
+      'to_date' => $leaveDate,
+      'from_date_type' => 1,
+      'to_date_type' =>1,
+      'status_id' => 1
+    ], true);
+
+    // No leave balance record will be returned because public holiday balances already
+    // co-exists with the leave balance for that date.
+    $this->assertNull(LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate(
+      $leaveRequest,
+      new DateTime($leaveDate)
+    ));
+  }
+
+  public function testGetBalanceChangeToModifyForLeaveDateDoesWillReturnResultsWhenOnlyALeaveRequestBalanceExists() {
+    $absenceType = AbsenceTypeFabricator::fabricate();
+    $date = new DateTime('2017-01-01');
+    $leaveDate = $date->format('YmdHis');
+    $contactID = 2;
+
+    $leaveRequest = LeaveRequestFabricator::fabricateWithoutValidation([
+      'contact_id' => $contactID,
+      'type_id' => $absenceType->id,
+      'from_date' => $leaveDate,
+      'to_date' => $leaveDate,
+      'from_date_type' => 1,
+      'to_date_type' =>1,
+      'status_id' => 1
+    ], true);
+
+    $this->assertNotNull(LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate(
+      $leaveRequest,
+      new DateTime($leaveDate)
+    ));
+  }
+
   public function testGetExistingBalanceChangeForALeaveRequestDateShouldReturnARecordIfItIsLinkedToALeaveRequestForTheSameContactTypeAndDate() {
     $date = new DateTime('2017-01-01');
     $leaveDate = $date->format('YmdHis');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -221,11 +221,20 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
-    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
+      $contactID,
+      $publicHoliday
+    );
+
     LeaveRequest::softDelete($publicHolidayRequest->id);
 
-    $publicHolidayRequestDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $publicHolidayRequestDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted(
+      $contactID,
+      $publicHoliday,
+      $absenceType
+    );
     $this->assertEquals($publicHolidayRequest->id, $publicHolidayRequestDeleted->id);
     $this->assertEquals(1, $publicHolidayRequestDeleted->is_deleted);
   }
@@ -239,10 +248,18 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
-    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
+    $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
+      $contactID,
+      $publicHoliday
+    );
 
-    $publicHolidayRequestNonDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday);
+    $publicHolidayRequestNonDeleted = LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted(
+      $contactID,
+      $publicHoliday,
+      $absenceType
+    );
     $this->assertEquals($publicHolidayRequest->id, $publicHolidayRequestNonDeleted->id);
     $this->assertEquals(0, $publicHolidayRequestNonDeleted->is_deleted);
   }
@@ -254,9 +271,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ]);
 
     $contactID = 2;
+    $absenceType = AbsenceTypeFabricator::fabricate();
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday));
+    $this->assertEmpty(LeaveRequest::findPublicHolidayLeaveRequestEvenIfDeleted($contactID, $publicHoliday, $absenceType));
   }
 
   public function testCalculateBalanceChangeForALeaveRequestForAContact() {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -45,8 +45,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     // We delete everything two avoid problems with the default absence types
     // created during the extension installation
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $this->deleteAllExistingAbsenceTypes();
 
     $messageSpoolTable = CRM_Mailing_BAO_Spool::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$messageSpoolTable}");
@@ -216,8 +215,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-01-01';
 
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
 
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
@@ -266,8 +266,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
@@ -295,8 +296,9 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
@@ -313,7 +315,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $this->assertEquals(0, $publicHolidayRequestNonDeleted->is_deleted);
   }
 
-  public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsNullForANonExistentPublicHolidayRequest() {
+  public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsEmptyForANonExistentPublicHolidayRequest() {
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2017-01-01'),
       'end_date' => CRM_Utils_Date::processDate('2017-12-01')
@@ -400,8 +402,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testCalculateBalanceChangeWhenOneOfTheRequestedLeaveDaysIsAPublicHoliday() {
     $periodStartDate = date('2016-01-01');
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
+
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
 
@@ -5355,5 +5359,10 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ];
 
     $this->assertFalse(LeaveRequest::isTOILWithPastDates($params));
+  }
+
+  private function deleteAllExistingAbsenceTypes() {
+    $tableName = AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -355,7 +355,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
   public function testCalculateBalanceChangeWhenOneOfTheRequestedLeaveDaysIsAPublicHoliday() {
     $periodStartDate = date('2016-01-01');
-    $absenceType = AbsenceTypeFabricator::fabricate();
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
     $contract = HRJobContractFabricator::fabricate(
       ['contact_id' => 1],
       ['period_start_date' => $periodStartDate]
@@ -378,6 +382,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
 
     $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($periodEntitlement->contact_id, $publicHoliday, $this->absenceType));
     PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
+    //Two public holiday leave requests exist for this day
+    $this->assertCount(2, LeaveRequest::findAllPublicHolidayLeaveRequests(
+      $periodEntitlement->contact_id,
+      $publicHoliday
+    ));
 
     $fromDate = new DateTime('2016-11-14');
     $toDate = new DateTime('2016-11-15');

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/BAO/LeaveRequestTest.php
@@ -194,11 +194,11 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-01-01';
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, $this->absenceType));
 
     PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
 
-    $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+    $leaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, $this->absenceType);
     $leaveFromDate = new DateTime($leaveRequest->from_date);
     $this->assertInstanceOf(LeaveRequest::class, $leaveRequest);
     $this->assertEquals($publicHoliday->date, $leaveFromDate->format('Y-m-d'));
@@ -209,7 +209,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-01-03';
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest(3, $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest(3, $publicHoliday, $this->absenceType));
   }
 
   public function testFindPublicHolidayLeaveRequestEvenIfDeletedReturnsResultForADeletedPublicHolidayRequest() {
@@ -221,6 +221,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
@@ -248,6 +250,8 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $contactID = 2;
 
     $publicHoliday = $this->instantiatePublicHoliday('2017-01-01');
+    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
     $publicHolidayRequest = PublicHolidayLeaveRequestFabricator::fabricate(
@@ -372,7 +376,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('2016-11-14');
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($periodEntitlement->contact_id, $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($periodEntitlement->contact_id, $publicHoliday, $this->absenceType));
     PublicHolidayLeaveRequestFabricator::fabricate($periodEntitlement->contact_id, $publicHoliday);
 
     $fromDate = new DateTime('2016-11-14');
@@ -1607,7 +1611,7 @@ class CRM_HRLeaveAndAbsences_BAO_LeaveRequestTest extends BaseHeadlessTest {
     ], true);
 
     PublicHolidayLeaveRequestFabricator::fabricate($contactID, $publicHoliday);
-    $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday);
+    $publicHolidayLeaveRequest = LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, $this->absenceType);
 
     //The start date and end date has dates in both leave request dates in both leaveRequest1,
     //leaveRequest2 and public holiday

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/LeaveRequestTest.php
@@ -267,8 +267,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
 
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     HRJobContractFabricator::fabricate(
       ['contact_id' => $this->leaveContact],
@@ -317,8 +318,9 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
 
     WorkPatternFabricator::fabricateWithA40HourWorkWeek(['is_default' => 1]);
 
-    $tableName = CRM_HRLeaveAndAbsences_BAO_AbsenceType::getTableName();
-    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
+    $this->deleteAllExistingAbsenceTypes();
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => TRUE]);
 
@@ -1391,5 +1393,10 @@ class CRM_HRLeaveAndAbsences_Service_LeaveRequestTest extends BaseHeadlessTest {
     }
 
     return $expectedBreakdown;
+  }
+
+  private function deleteAllExistingAbsenceTypes() {
+    $tableName = AbsenceType::getTableName();
+    CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -68,7 +68,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('first monday of this year');
 
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
 
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
   }
@@ -87,11 +87,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = $date->format('YmdHis');
 
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
 
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));
 
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
 
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));
   }
@@ -109,7 +109,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $date = new DateTime('first monday of this year');
     $publicHoliday = $this->instantiatePublicHoliday($date->format('Ymd'));
 
-    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
     $this->assertEquals(1, $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd')));
     //soft delete the public holiday leave request
     LeaveRequest::softDelete($publicHolidayRequest->id);
@@ -122,7 +122,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //Try to create a public holiday leave request for same date
     //Null will be returned because a soft deleted request is found for same date.
     //Also the number of deleted request stays same and no new public holiday request is created.
-    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
+    $publicHolidayRequest = $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
     $this->assertNull($publicHolidayRequest);
     $numberOfDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'), FALSE);
     $numberOfNonDeletedRequests = $this->countNumberOfLeaveRequests($periodEntitlement->contact_id, $date->format('Ymd'));
@@ -152,7 +152,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('2016-01-01');
 
-    $this->getCreationLogic()->createForContact($contactID, $publicHoliday);
+    $this->getCreationLogic()->createForContact($contactID, $publicHoliday, $this->absenceType);
 
     $this->assertEquals(0, LeaveBalanceChange::getTotalBalanceChangeForLeaveRequest($leaveRequest));
   }
@@ -400,13 +400,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+5 days'));
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createForAllContacts($publicHoliday);
 
-    $leaveRequestContact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday);
-    $leaveRequestContact2 = LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday);
+    $leaveRequestContact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType);
+    $leaveRequestContact2 = LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType);
 
     $leaveRequestContact1FromDate = new DateTime($leaveRequestContact1->from_date);
     $leaveRequestContact2FromDate = new DateTime($leaveRequestContact2->from_date);
@@ -437,13 +437,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+6 days'));
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createForAllContacts($publicHoliday);
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
   }
 
   public function testItDoesntDuplicateLeaveRequestsWhenCreatingRequestsForAllContactsWithContractsOverlappingAPublicHoliday() {
@@ -487,13 +487,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $tableName = AbsenceType::getTableName();
     CRM_Core_DAO::executeQuery("DELETE FROM {$tableName}");
 
-    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 0]);
+    $absenceType = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 0]);
     $contactID = 2;
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = CRM_Utils_Date::processDate('first monday of this year');
 
-    $this->getCreationLogic()->createForContact($contactID, $publicHoliday);
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday));
+    $this->getCreationLogic()->createForContact($contactID, $publicHoliday, $absenceType);
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contactID, $publicHoliday, $absenceType));
   }
 
   private function countNumberOfPublicHolidayBalanceChanges() {
@@ -675,9 +675,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
      $expiryDate
     );
 
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday);
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday2);
-    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday3);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday2, $this->absenceType);
+    $this->getCreationLogic()->createForContact($periodEntitlement->contact_id, $publicHoliday3, $this->absenceType);
 
     $expiredBalanceChange = LeaveBalanceChange::findById($balanceChange->id);
 
@@ -837,13 +837,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+5 days'));
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createForAllContacts($publicHoliday);
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
   }
 
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAbsencePeriod() {
@@ -902,12 +902,12 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //The first public holiday is before the absence period and the last public holiday is
     //after the absence period. So the balance will be -2 for both contacts
     $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3, $this->absenceType));
 
     $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $this->absenceType));
   }
 
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAbsencePeriodForSpecificContact() {
@@ -957,12 +957,12 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     //Public holiday leave requests will only be created for the first contact.
     $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
   }
 
   public function testPublicHolidayLeaveRequestsAreNotCreatedWhenContactHasZeroEntitlementForPeriod() {
@@ -1025,9 +1025,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //the second contact has no entitlement for the period so no public holiday
     //leave request will be created.
     $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday4));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday4, $this->absenceType));
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
@@ -1094,7 +1094,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     //Only Public holiday leave request for '2016-03-30' is created within period 1. none for period 2
     //for which contact has no entitlement.
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
@@ -1143,20 +1143,20 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = '2016-01-20';
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $this->getCreationLogic()->createForAllContacts($publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
 
     //Contact2 has zero entitlement for the period therefore the public holiday leave request will not be
     //created fot it.
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     //Contact3 has no entitlement for the period therefore the public holiday leave request will not be
     //created fot it.
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact3['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact3['id'], $publicHoliday, $this->absenceType));
   }
 
   public function testWillNotCreatePublicHolidayLeaveRequestsInTheFutureForWhereContactHasNoEntitlement() {
@@ -1219,7 +1219,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //Only Public holiday leave request for the second public holiday is created because it falls
     //within the date where the contact has entitlement.
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
@@ -1284,7 +1284,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     //Only Public holiday leave request for the second public holiday is created because it falls
     //within the date where the contact has entitlement.
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
@@ -1329,27 +1329,27 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+7 days')
     ]);
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $this->absenceType));
 
     //Create public holiday requests for all contacts for all periods.
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createAll();
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3, $this->absenceType));
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $this->absenceType));
 
     //The public holiday4 des not exist in any absence period, so will not be created for either contact
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday4));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday4));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday4, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday4, $this->absenceType));
   }
 
   private function getCreationLogicWithEntitlementsMock($contactIDs) {

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestCreationTest.php
@@ -171,17 +171,30 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInTheFuture() {
     $contact = ContactFabricator::fabricate();
 
+    AbsenceType::del($this->absenceType->id);
+    $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('2016-01-01'),
       'end_date'   => CRM_Utils_Date::processDate('+5 days'),
     ]);
 
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+    $periodEntitlement1 = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('2016-01-01'),
       new DateTime('+10 days')
     );
-    $periodEntitlement->contact_id = $contact['id'];
-    $periodEntitlement->type_id = $this->absenceType->id;
+
+    $periodEntitlement1->contact_id = $contact['id'];
+    $periodEntitlement1->type_id = $absenceType1->id;
+
+    $periodEntitlement2 = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('2016-01-01'),
+      new DateTime('+10 days')
+    );
+
+    $periodEntitlement2->contact_id = $contact['id'];
+    $periodEntitlement2->type_id = $absenceType2->id;
 
     HRJobContractFabricator::fabricate([
       'contact_id' => $contact['id']
@@ -189,7 +202,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'period_start_date' => '2016-01-01',
     ]);
 
-    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
 
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' =>  CRM_Utils_Date::processDate('2016-01-01')
@@ -203,11 +217,13 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'date' =>  CRM_Utils_Date::processDate('+5 days')
     ]);
 
+    //Public holiday leave requests will be created for the two absence types with MTPHL
     $this->getCreationLogicWithEntitlementsMock([$contact['id']])->createAllInTheFuture();
 
-    // It's -2 instead of -3 because the first public holiday is in the past
-    // and we should not create a leave request for it
-    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    // It's -2 instead of -3 for both period entitlements because the first public holiday is in the past
+    // and we should not create a leave request for it.
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
 
   public function testItDoesNotDuplicateLeaveRequestsWhenCreatingLeaveRequestsForAllPublicHolidaysInTheFuture() {
@@ -276,14 +292,27 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'period_end_date' =>   CRM_Utils_Date::processDate('+100 days'),
     ]);
 
-    $periodEntitlement = $this->createLeavePeriodEntitlementMockForBalanceTests(
+    AbsenceType::del($this->absenceType->id);
+    $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
+    $periodEntitlement1 = $this->createLeavePeriodEntitlementMockForBalanceTests(
       new DateTime('-10 days'),
       new DateTime('+200 days')
     );
-    $periodEntitlement->contact_id = $contact['id'];
-    $periodEntitlement->type_id = $this->absenceType->id;
+    $periodEntitlement1->contact_id = $contact['id'];
+    $periodEntitlement1->type_id = $absenceType1->id;
 
-    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    $periodEntitlement2 = $this->createLeavePeriodEntitlementMockForBalanceTests(
+      new DateTime('-10 days'),
+      new DateTime('+200 days')
+    );
+    $periodEntitlement2->contact_id = $contact['id'];
+    $periodEntitlement2->type_id = $absenceType2->id;
+
+    //Entitlements for both period entitlements is Zero
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
 
     PublicHolidayFabricator::fabricateWithoutValidation([
       'date' =>  CRM_Utils_Date::processDate('yesterday')
@@ -303,11 +332,12 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $this->getCreationLogicWithEntitlementsMock([$contract['contact_id']])->createAllForContract($contract['id']);
 
-    // The balance should be -3 because three leave requests were created:
+    // The balance should be -3 for both entitlements because three leave requests were created for both absence types:
     // The one for +5 days, one for + 47 days and the one for yesterday
     // The holiday for "+101 days" is in the future, but it doesn't overlap the contract dates and
     // and no leave request will be created for it as well
-    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
+    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1));
+    $this->assertEquals(-3, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
   }
 
   public function testItCreatesLeaveRequestsForAllPublicHolidaysInTheFutureOverlappingAContractWithNoEndDate() {
@@ -391,6 +421,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
+    AbsenceType::del($this->absenceType->id);
+    $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
     AbsencePeriodFabricator::fabricate([
       'start_date' => CRM_Utils_Date::processDate('5 days ago'),
       'end_date'   => CRM_Utils_Date::processDate('+5 days'),
@@ -411,21 +445,37 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     $publicHoliday = new PublicHoliday();
     $publicHoliday->date = date('Y-m-d', strtotime('+5 days'));
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $absenceType1));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $absenceType2));
+
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $absenceType1));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $absenceType2));
 
     $this->getCreationLogicWithEntitlementsMock([$contact1['id'], $contact2['id']])->createForAllContacts($publicHoliday);
 
-    $leaveRequestContact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType);
-    $leaveRequestContact2 = LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType);
+    //Two public holiday leave requests created for contact 1 because two absence types with MTPHL exists
+    $leaveRequest1Contact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $absenceType1);
+    $leaveRequest2Contact1 = LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $absenceType2);
 
-    $leaveRequestContact1FromDate = new DateTime($leaveRequestContact1->from_date);
-    $leaveRequestContact2FromDate = new DateTime($leaveRequestContact2->from_date);
+    //Two public holiday leave requests created for contact 2 because two absence types with MTPHL exists
+    $leaveRequest1Contact2 = LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $absenceType1);
+    $leaveRequest2Contact2 = LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $absenceType2);
 
-    $this->assertInstanceOf(LeaveRequest::class, $leaveRequestContact1);
-    $this->assertEquals($publicHoliday->date, $leaveRequestContact1FromDate->format('Y-m-d'));
-    $this->assertInstanceOf(LeaveRequest::class, $leaveRequestContact2);
-    $this->assertEquals($publicHoliday->date, $leaveRequestContact2FromDate->format('Y-m-d'));
+    $leaveRequest1Contact1FromDate = new DateTime($leaveRequest1Contact1->from_date);
+    $leaveRequest2Contact1FromDate = new DateTime($leaveRequest2Contact1->from_date);
+
+    $leaveRequest1Contact2FromDate = new DateTime($leaveRequest1Contact2->from_date);
+    $leaveRequest2Contact2FromDate = new DateTime($leaveRequest2Contact2->from_date);
+
+    $this->assertEquals($publicHoliday->date, $leaveRequest1Contact1FromDate->format('Y-m-d'));
+    $this->assertEquals($absenceType1->id, $leaveRequest1Contact1->type_id);
+    $this->assertEquals($publicHoliday->date, $leaveRequest2Contact1FromDate->format('Y-m-d'));
+    $this->assertEquals($absenceType2->id, $leaveRequest2Contact1->type_id);
+
+    $this->assertEquals($publicHoliday->date, $leaveRequest1Contact2FromDate->format('Y-m-d'));
+    $this->assertEquals($absenceType1->id, $leaveRequest1Contact2->type_id);
+    $this->assertEquals($publicHoliday->date, $leaveRequest2Contact2FromDate->format('Y-m-d'));
+    $this->assertEquals($absenceType2->id, $leaveRequest2Contact2->type_id);
   }
 
   public function testItDoesntCreatesLeaveRequestsForAllContactsWithoutContractsOverlappingTheGivenPublicHoliday() {
@@ -572,6 +622,10 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'end_date'   => CRM_Utils_Date::processDate('+5 days'),
     ]);
 
+    AbsenceType::del($this->absenceType->id);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
     HRJobContractFabricator::fabricate([
       'contact_id' => $contact['id']
     ],
@@ -607,9 +661,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
     ]);
 
     $this->getCreationLogicWithEntitlementsMock([$contact['id'], $contact2['id']])->createAllInFutureForWorkPatternContacts($workPattern1->id);
+
     //Public Holiday Leave Requests will not be created for contact2 because contact2 is using
-    //work pattern2
-    $this->assertEquals(1, $this->countNumberOfLeaveRequests($contact['id'], $date->format('Ymd')));
+    //work pattern2. But to public holiday leave requests will be created for contact1 since two absence types
+    //with MTPHL exists.
+    $this->assertEquals(2, $this->countNumberOfLeaveRequests($contact['id'], $date->format('Ymd')));
     $this->assertEquals(0, $this->countNumberOfLeaveRequests($contact2['id'], $date->format('Ymd')));
   }
 
@@ -858,7 +914,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
   }
 
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAbsencePeriod() {
-    $contact = ContactFabricator::fabricate();
+    $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
     $period = AbsencePeriodFabricator::fabricate([
@@ -866,24 +922,43 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
-    $periodEntitlement = LeavePeriodEntitlementFabricator::fabricate([
-      'contact_id' => $contact['id'],
+    AbsenceType::del($this->absenceType->id);
+    $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+    $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
+
+    $periodEntitlement1Contact1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact1['id'],
       'period_id' => $period->id,
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType1->id,
     ]);
 
-    $periodEntitlement2 = LeavePeriodEntitlementFabricator::fabricate([
+    $periodEntitlement2Contact1 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact1['id'],
+      'period_id' => $period->id,
+      'type_id' => $absenceType2->id,
+    ]);
+
+    $periodEntitlement1Contact2 = LeavePeriodEntitlementFabricator::fabricate([
       'contact_id' => $contact2['id'],
       'period_id' => $period->id,
-      'type_id' => $this->absenceType->id,
+      'type_id' => $absenceType1->id,
     ]);
 
-    //Add entitlements for the contacts
-    $this->createLeaveBalanceChange($periodEntitlement->id, 1);
-    $this->createLeaveBalanceChange($periodEntitlement2->id, 1);
+    $periodEntitlement2Contact2 = LeavePeriodEntitlementFabricator::fabricate([
+      'contact_id' => $contact2['id'],
+      'period_id' => $period->id,
+      'type_id' => $absenceType2->id,
+    ]);
+
+    //Add entitlement for contact 1 for the two absence types with MTPHL
+    //Add entitlement for contact2 for only the two absence types
+    $this->createLeaveBalanceChange($periodEntitlement1Contact1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2Contact1->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement1Contact2->id, 1);
+    $this->createLeaveBalanceChange($periodEntitlement2Contact2->id, 1);
 
     HRJobContractFabricator::fabricate(
-      ['contact_id' => $contact['id']],
+      ['contact_id' => $contact1['id']],
       ['period_start_date' => '2016-01-01']
     );
 
@@ -910,15 +985,26 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
     $this->getCreationLogic()->createAllForAbsencePeriod($period);
 
-    //The first public holiday is before the absence period and the last public holiday is
-    //after the absence period. So the balance will be -2 for both contacts
-    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3, $this->absenceType));
+    //The first public holiday is before the absence period and the last public holiday is after the absence period
+    //So public holiday requests will not be created for these holidays.
+    //So the balance will be -2 for contact 1 for both entitlements.
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1Contact1));
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2Contact1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2, $absenceType1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3, $absenceType1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday2, $absenceType2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday3, $absenceType2));
 
-    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $this->absenceType));
+
+    //The first public holiday is before the absence period and the last public holiday is after the absence period
+    //So public holiday requests will not be created for these holidays.
+    //So the balance will be -2 for contact 2 for both entitlements.
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement1Contact2));
+    $this->assertEquals(-2, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement2Contact2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $absenceType1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $absenceType1));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $absenceType2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday3, $absenceType2));
   }
 
   public function testCanCreatePublicHolidayLeaveRequestsForAllPublicHolidaysInAbsencePeriodForSpecificContact() {
@@ -1369,11 +1455,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestCreationTest exten
 
   private function getCreationLogic($contactIDs = [], $mockEntitlement = false) {
     $leaveBalanceChangeService = $this->createLeaveBalanceChangeServiceForPublicHolidayLeaveRequestMock();
+    $absenceTypes = AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest();
 
     if($mockEntitlement) {
       $entitlements = [];
       foreach($contactIDs as $contactID) {
-        $entitlements[$contactID] = [$this->absenceType->id => 1];
+        foreach ($absenceTypes as $absenceType) {
+          $entitlements[$contactID][$absenceType->id] = 1;
+        }
       }
       $leavePeriodEntitlementService = $this->createLeavePeriodEntitlementServiceForPublicHolidayLeaveRequestMock($entitlements);
     }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -99,7 +99,7 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->assertEquals(-1, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
 
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
-    $deletionLogic->softDeleteForContact($periodEntitlement->contact_id, $publicHoliday);
+    $deletionLogic->softDeleteForContact($periodEntitlement->contact_id, $publicHoliday, $this->absenceType->id);
 
     $this->assertEquals(0, LeaveBalanceChange::getLeaveRequestBalanceForEntitlement($periodEntitlement));
     //Check that the public holiday leave request is soft deleted.
@@ -228,9 +228,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday3);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3, $this->absenceType));
 
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForContract($contract['id']);
@@ -238,9 +238,9 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     // It's -1 instead of 0 because the public holiday 1 and public holiday 2
     // will be deleted and the public holiday 3 is after the contract end date
     // and will not be deleted.
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday3, $this->absenceType));
   }
 
   public function testItDeletesLeaveRequestsForAllPublicHolidaysOverlappingAContractWithNoEndDate() {
@@ -327,14 +327,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
     PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteForAllContacts($publicHoliday);
 
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
   }
 
   public function testItDoesntDeleteLeaveRequestsForAllContactsWithoutContractsOverlappingTheGivenPublicHoliday() {
@@ -359,14 +359,14 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     PublicHolidayLeaveRequestFabricator::fabricate($contact1['id'], $publicHoliday);
     PublicHolidayLeaveRequestFabricator::fabricate($contact2['id'], $publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteForAllContacts($publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact1['id'], $publicHoliday, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
   }
 
   private function countNumberOfPublicHolidayBalanceChanges() {
@@ -602,11 +602,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday2);
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact2['id'], $publicHoliday2);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
 
     //Delete all Public holiday leave requests for absence period 2.
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
@@ -614,11 +614,11 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
 
     //Leave Request for PublicHoliday2 which falls within the absence period will be deleted for both contacts
     //While that of Public Holiday1 will not be deleted.
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday2, $this->absenceType));
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1));
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday1, $this->absenceType));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday2, $this->absenceType));
   }
 
   public function testCanDeleteAllPublicHolidayLeaveRequestsForAbsencePeriodForSpecificContact() {
@@ -648,16 +648,16 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact['id'], $publicHoliday);
     $this->fabricatePublicHolidayLeaveRequestWithMockBalanceChange($contact2['id'], $publicHoliday);
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday));
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday, $this->absenceType));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
 
     //Delete all Public holiday leave requests for absence period for first contact only
     $deletionLogic = new PublicHolidayLeaveRequestDeletion(new JobContractService());
     $deletionLogic->deleteAllForAbsencePeriod($period, [$contact['id']]);
 
     //Leave Request for PublicHoliday will be deleted for contact1 only
-    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday));
+    $this->assertNull(LeaveRequest::findPublicHolidayLeaveRequest($contact['id'], $publicHoliday, $this->absenceType));
 
-    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday));
+    $this->assertNotNull(LeaveRequest::findPublicHolidayLeaveRequest($contact2['id'], $publicHoliday, $this->absenceType));
   }
 }

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/tests/phpunit/CRM/HRLeaveAndAbsences/Service/PublicHolidayLeaveRequestDeletionTest.php
@@ -54,6 +54,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     ]);
 
     $contactID = 2;
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
     AbsenceType::del($this->absenceType->id);
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
@@ -455,6 +457,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
     $contact1 = ContactFabricator::fabricate();
     $contact2 = ContactFabricator::fabricate();
 
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
     AbsenceType::del($this->absenceType->id);
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
@@ -624,6 +628,8 @@ class CRM_HRLeaveAndAbsences_Service_PublicHolidayLeaveRequestDeletionTest exten
       'end_date' => CRM_Utils_Date::processDate('2016-12-31'),
     ]);
 
+    //We need to delete existing absence type already created to avoid problems with this test
+    //as this test assumes no absence type should exist before.
     AbsenceType::del($this->absenceType->id);
     $absenceType1 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);
     $absenceType2 = AbsenceTypeFabricator::fabricate(['must_take_public_holiday_as_leave' => 1]);


### PR DESCRIPTION
## Overview
Due to recent changes that allows more than one Absence type to have the MTPHL property as true (see: #2964). This PR makes changes to the background job that creates these public holiday leave requests to accommodate creating public holiday leave requests for as many absence types that have MTPHL as true.

## Before
- The scheduled job that is responsible for creating public holiday leave requests will only create public holiday leave requests for only one absence type with MTPHL as true for contacts.

## After
- The scheduled job that is responsible for creating public holiday leave requests will create public holidays for as many absence types with MTPHL as true for contacts.

## Technical Details
- Apart from modifying the `PublicHolidayLeaveRequestCreation` class to now fetch all absence types with MTPHL using the new `AbsenceType::getAllWithMustTakePublicHolidayAsLeaveRequest()` method, some notable business logic was changed.  
One of such is that when a public holiday leave request is created, it will Zero the balance of any existing leave request already existing for same date. Since multiple public holidays can now exist for same date, this was also affecting an existing public holiday leave request by zeroing the balance change of an existing public holiday leave request.
A new `LeaveBalanceChange::getBalanceChangeToModifyForLeaveDate` method was created to address this issue, the method returns the balance change that can be modified when a public leave request is created or deleted in the system.
When a public holiday is deleted in the system, the balance change of an existing leave request is modified back to the state that it was before the leave request balance was zeroed. However if an existing public holiday request still exists for this date, then the leave request balance should still be kept at zero until the last public holiday leave request is deleted.

```php
  public static function getBalanceChangeToModifyForLeaveDate(LeaveRequest $leaveRequest, DateTime $date) {
    $balanceChanges = self::getBalanceChangesForLeaveRequestDate($leaveRequest, $date);

    if (empty($balanceChanges)) {
      return NULL;
    }

    $leaveBalanceChangeTypes = array_flip(self::buildOptions('type_id', 'validate'));

    $publicHolidayLeaveBalances = FALSE;
    $otherLeaveBalances = [];
    foreach ($balanceChanges as $balanceChange) {
      if ($balanceChange->type_id == $leaveBalanceChangeTypes['public_holiday']) {
        $publicHolidayLeaveBalances = TRUE;
        break;
      }

      $otherLeaveBalances[] = $balanceChange;
    }

    if (!$publicHolidayLeaveBalances && count($otherLeaveBalances) == 1) {
      return $otherLeaveBalances[0];
    }

    return NULL;
  }

```
- Also the current behaviour that when a public holiday leave request is created, the balance change of an existing leave request is changed to zero irrespective of the absence type of the public holiday leave request and that of the existing leave request is maintained.

