### PR TITLE
PCHR-4446: Fix Expected Variable Reference Warning

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/hrleaveandabsences.php
@@ -334,7 +334,7 @@ function hrleaveandabsences_civicrm_post($op, $objectName, $objectId, &$objectRe
     return;
   }
 
-  call_user_func_array($postFunction, [$op, $objectId, $objectRef]);
+  call_user_func_array($postFunction, [$op, $objectId, &$objectRef]);
 }
 
 /**


### PR DESCRIPTION
## Overview
When adding a new absence type or updating an existing absence type, a warning is shown on the screen after saving. 

## Before
- The error `Parameter 3 to _hrleaveandabsences_civicrm_post_absencetype() expected to be a reference, value given in hrleaveandabsences_civicrm_post()` is shown on the screen when adding a new absence type or modifying an existing absence type.

![typebefore](https://user-images.githubusercontent.com/6951813/50003766-1f066680-ffa5-11e8-8b57-29d0a029c9a9.gif)

## After
- No error is shown on the screen when adding a new absence type or modifying an existing absence type.
The `_hrleaveandabsences_civicrm_post_absencetype` function as well as the 
 other`_hrleaveandabsences_civicrm_post_*`  functions expects the `$objectRef` variable passed to be passed as a reference but it was passed by value instead. This warning shows on sites running PHP versions 5.6.38 upwards as seen [here](https://3v4l.org/R7dRS). It was fixed by simply passing the variable as a reference

![typeafter](https://user-images.githubusercontent.com/6951813/50003780-275ea180-ffa5-11e8-9e02-5a00cef6b0f7.gif)

