### PR TITLE
PCHR-4448: Fix Warning and Notice Messages on Import Job Contract Wizard

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php
@@ -313,9 +313,9 @@ abstract class CRM_Hrjobcontract_Import_Parser extends CRM_Import_Parser {
   }
 
   /**
-   * @param $elements
+   * @param array $elements
    */
-  function setActiveFieldLocationTypes($elements) {
+  function setActiveFieldLocationTypes(Array $elements) {
     for ($i = 0; $i < count($elements); $i++) {
       $this->_activeFields[$i]->_hasLocationType = $elements[$i];
     }

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php
@@ -568,7 +568,7 @@ class CRM_Hrjobcontract_Import_Parser_Api extends CRM_Hrjobcontract_Import_Parse
     switch($key)  {
       case 'HRJobContractRevision-jobcontract_id':
         $contractDetails = CRM_Hrjobcontract_BAO_HRJobContract::checkContract($value);
-        if ($contractDetails == 0)  {
+        if (!$contractDetails)  {
           $errorMessage = "{$this->_fields[$key]->_title} is not found";
         }
         break;

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
@@ -82,8 +82,10 @@ class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import
       $field['headerPattern'] = CRM_Utils_Array::value('headerPattern', $field, '//');
       $this->addField($name, CRM_Utils_Array::value('title', $field, $name), $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
+
+    $mapperLocType = !empty($mapperLocType) ? $mapperLocType : [];
     $this->setActiveFields($this->_mapperKeys);
-    $this->setActiveFieldLocationTypes($this->_mapperLocType);
+    $this->setActiveFieldLocationTypes($mapperLocType);
 
     // Fetch select list options from the database and cache them
     $this->_optionsList['HRJobHour-hours_type'] = CRM_Hrjobcontract_SelectValues::buildDbOptions('hrjc_hours_type');

--- a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
+++ b/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php
@@ -83,7 +83,7 @@ class CRM_Hrjobcontract_Import_Parser_BaseClass extends CRM_Hrjobcontract_Import
       $this->addField($name, CRM_Utils_Array::value('title', $field, $name), $field['type'], $field['headerPattern'], $field['dataPattern']);
     }
 
-    $mapperLocType = !empty($mapperLocType) ? $mapperLocType : [];
+    $mapperLocType = !empty($this->_mapperLocType) ? $this->_mapperLocType : [];
     $this->setActiveFields($this->_mapperKeys);
     $this->setActiveFieldLocationTypes($mapperLocType);
 


### PR DESCRIPTION
## Overview
When trying to import Job contracts on a site running PHP 7.2.X. Some warnings occur on the various stages of the import screen.

## Before
- Some errors on the various stages of the Job contract import screen.

![contractbefore](https://user-images.githubusercontent.com/6951813/50012673-90531300-ffbf-11e8-97cb-cab3bd72ae47.gif)

## After
- One of the errors was related to an error regarding using count function on a variable that does not implement the Countable interface. This warning is displayed by PHP starting from PHP 7.2.
The [here](https://github.com/compucorp/civihr/blob/fb73df3b053bec0bcbadc5f9362704cc14ab8b15/hrjobcontract/CRM/Hrjobcontract/Import/Parser/BaseClass.php#L88) returns NULL sometimes and an error is thrown when using count on the variable h[ere](https://github.com/compucorp/civihr/blob/fb73df3b053bec0bcbadc5f9362704cc14ab8b15/hrjobcontract/CRM/Hrjobcontract/Import/Parser.php#L319). This was fixed by making sure an Array will always be passed to the `setActiveFieldLocationTypes` function.
- There was an issue type casting an Object to an int [here](https://github.com/compucorp/civihr/blob/693e69867d7fbb0e6e8c9514e8a26fa598a8af1a/hrjobcontract/CRM/Hrjobcontract/Import/Parser/Api.php#L571) since the `CRM_Hrjobcontract_BAO_HRJobContract::checkContract` function returns either an object or 0. This was simply fixed by checking if the variable returned is false or not. See [here](https://3v4l.org/cKGGb) for demonstration.
- There was some other error reported in the ticket, which has been fixed on #2973 

![contractafter](https://user-images.githubusercontent.com/6951813/50012684-99dc7b00-ffbf-11e8-86dc-1c0eaa1f4bcc.gif)
