### PR TITLE
PCHR-4471: Fix issues for grouped Public Holidays on Staff Leave Report

### DIFF
--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-section-header.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/partials/staff-leave-report-section-header.html
@@ -1,7 +1,8 @@
 <tr>
   <th class="chr_leave-report__table__heading--label">
     <small ng-if="section && section.groupedData &&
-      report.sections.holidays.groupedData.length < report.sections.holidays.data.length"
+      section.groupedData.length < section.data.length &&
+      $root.section !== 'my-leave'"
       ng-switch="section.grouped">
       <a href ng-switch-when="true"
         ng-click="section.grouped = false">

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
@@ -145,9 +145,9 @@
                               </td>
                               <td>
                                 <leave-request-actions
-                                  ng-if="!report.sections.holidays.grouped"
+                                  ng-if="!report.sections.holidays.grouped && $root.section !== 'my-leave'"
                                   leave-request="request"
-                                  role="$root.section === 'my-leave' ? 'staff' : report.role"
+                                  role="report.role"
                                   absence-types="report.absenceTypes"
                                   leave-request-statuses="report.leaveRequestStatuses">
                                 </leave-request-actions>

--- a/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
+++ b/uk.co.compucorp.civicrm.hrleaveandabsences/views/shared/components/staff-leave-report.html
@@ -133,7 +133,7 @@
                               <td ng-repeat="absenceType in report.absenceTypesFiltered track by $index"
                                 title="({{ absenceType.calculation_unit_label | lowercase }})">
                                 {{((
-                                    report.sections.holidays.grouped && request.types_to_balance_changes[absenceType.id] ||
+                                    report.sections.holidays.grouped && request.types_to_balance_changes[absenceType.id] !== undefined ||
                                     !report.sections.holidays.grouped && request.type_id === absenceType.id
                                   )
                                   ? ((


### PR DESCRIPTION
## Overview

This PR fixes 2 issues for grouped Public Holidays on Staff Leave Report:
1) It now renders zero balance changes correctly
2) It now does not show action dropdown for Public Holidays for Staff (because it anyway does not have any actions inside) and hides the group view switch.

## Before

In SSP My Leave you can see an empty actions dropdown.

![ssp wrong](https://user-images.githubusercontent.com/3973243/50171102-711ef300-02e9-11e9-97ac-783b06cc0797.gif)

In CIviCRM you can see missing zero balances (see After to see the difference)

![image](https://user-images.githubusercontent.com/3973243/50171096-6bc1a880-02e9-11e9-8a5b-9391399249e1.png)

## After

No switch and dropdown on SSP:

![image](https://user-images.githubusercontent.com/3973243/50170672-5dbf5800-02e8-11e9-853f-a5f18936e11e.png)

Zeros are rendered correctly in CiviCRM:

![image](https://user-images.githubusercontent.com/3973243/50170653-4f713c00-02e8-11e9-929c-182cff5c669c.png)

## Technical Details

To render zeroes we need to compare a balance prop against `undefined`: 

```html
request.types_to_balance_changes[absenceType.id] !== undefined
```

To hide actions dropdown and the group view switch we simply check for `$root.section !== 'my-leave'"`.

-----

✅Manual Tests - passed
⏹Jasmine Tests - no changes
⏹JS distributive files - no changes
⏹CSS distributive files - included
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed