### PR TITLE
PCHR-4444: Funders of Type Individual is not saved with the correct Contact ID

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -266,7 +266,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
   {
     if (!(self::$_fields)) {
       self::$_fields = array(
-        'id' => array(
+        'hrjobroles_id' => array(
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'required' => true,

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php
@@ -266,7 +266,7 @@ class CRM_Hrjobroles_DAO_HrJobRoles extends CRM_Core_DAO
   {
     if (!(self::$_fields)) {
       self::$_fields = array(
-        'hrjobroles_id' => array(
+        'hr_job_roles_id' => array(
           'name' => 'id',
           'type' => CRM_Utils_Type::T_INT,
           'required' => true,

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Upgrader.php
@@ -129,7 +129,7 @@ class CRM_Hrjobroles_Upgrader extends CRM_Hrjobroles_Upgrader_Base {
     $allowUpdate = FALSE;
     foreach ($funders as $index => $funder) {
       $jobRoleIds = array_column($contactDetails, 'jobrole_id');
-      $funderIndex = array_search($funder, $jobRoleIds, TRUE);
+      $funderIndex = array_search($funder, $jobRoleIds);
       if ($funderIndex !== FALSE) {
         $funders[$index] = $contactDetails[$funderIndex]['id'];
         $allowUpdate = TRUE;


### PR DESCRIPTION
## Overview
When making request via Contact API, response usually contains job role id if the requested contact has existing job role. This was because job role id is [exportable](https://github.com/compucorp/civihr/blob/master/com.civicrm.hrjobroles/CRM/Hrjobroles/DAO/HrJobRoles.php#L273) and its key [overrides](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L487) that of contact id when loading contact details. 
This process also have effect on adding funder to individual contact type. Instead of saving contact id of the funder, funder's job role id was used in place of its contact id if contact happens to have existing job role.

## Before
Contact API request returns funder id instead of contact id when contact have an existing job role.

## After
Contact API request returns contact id even when the contact have an existing job role.

## Technical Details
A call to the contact api attempts to [fetch](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L486) DAO exportable fields provided by hook implementers of CRM_Contact_BAO_Query_Hook. CRM_Hrjobroles_BAO_Query extends the CRM_Contact_BAO_Query_Interface interface, which means its fields will likely be loaded when fetching contacts especially when specific columns are to be returned. 
Key definition for HRJobroles DAO was changed from `id` to `hrjobroles_id` to avoid conflict with that of contact id
```
'hrjobroles_id' => array(
  'name' => 'id',
  'type' => CRM_Utils_Type::T_INT,
  'required' => true,
  'export' => true,
  'title' => 'Job Role ID',
  'where' => 'civicrm_hrjobroles.id',
  'entity' => 'HrJobRoles',
  'bao' => 'CRM_Hrjobroles_DAO_HrJobRoles',
  'localizable' => 0,
) ,
```

An upgrader was written to cater for situations where individual contact type used as funder had their job roles saved instead of contact id. All existing job role with funder were fetch via api
```
$jobRoles = civicrm_api3('HrJobRoles', 'get', [
  'funder' => ['!=' => '|'],
]);
```
The funders for each job roles were iterated over. A check was made to see if funder matches any contact's jobrole_id. 
```
$jobRoleIds = array_column($contactDetails, 'jobrole_id');
$funderIndex = array_search($funder, $jobRoleIds);
```
If the funder was found, its `id` was used to update the affected job role funder.
```
civicrm_api3('HrJobRoles', 'create', [
  'id' => $key,
  'funder' => '|' . implode('|', $funders) . '|',
]);
```

