### PR TITLE
PCHR-4478: Unable to import job contract and job roles with migrated fields

### DIFF
--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/BAO/HrJobRoles.php
@@ -47,17 +47,24 @@ class CRM_Hrjobroles_BAO_HrJobRoles extends CRM_Hrjobroles_DAO_HrJobRoles {
   }
 
   /**
-   * Check Contact if exist   .
+   * Retrieves funder option value if it exists
    *
-   * @param String $searchValue
-   * @param String $searchField
-   * @return Integer ( Contact ID or 0 if not exist)
+   * @param $searchValue
+   *
+   * @return int
    */
-  public static function contactExists($searchValue, $searchField) {
-    $queryParam = array(1 => array($searchValue, 'String'));
-    $query = "SELECT id from civicrm_contact where ".$searchField." = %1";
-    $result = CRM_Core_DAO::executeQuery($query, $queryParam);
-    return $result->fetch() ? $result->id : 0;
+  public static function funderExists($searchValue) {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'hrjc_funder',
+      'name' => $searchValue,
+    ]);
+
+    if ($result['count']) {
+      $optionValue = array_shift($result['values']);
+      return $optionValue['value'];
+    }
+
+    return 0;
   }
 
   /**

--- a/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
+++ b/com.civicrm.hrjobroles/CRM/Hrjobroles/Import/Parser/HrJobRoles.php
@@ -249,14 +249,7 @@ class CRM_Hrjobroles_Import_Parser_HrJobRoles extends CRM_Hrjobroles_Import_Pars
 
       $funder_error = FALSE;
       if (!empty($params['funder'])) {
-        $funder_value = $params['funder'];
-        if (is_numeric ($funder_value))  {
-          $search_field = 'id';
-        }
-        else {
-          $search_field = 'display_name';
-        }
-        $result = CRM_Hrjobroles_BAO_HrJobRoles::contactExists($funder_value, $search_field);
+        $result = CRM_Hrjobroles_BAO_HrJobRoles::funderExists($params['funder']);
         if ($result !== 0)  {
           $params['funder'] = $result;
           if (!empty($params['hrjc_funder_val_type']))  {

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
@@ -65,7 +65,7 @@ class CRM_Hrjobcontract_BAO_HRJobHealth extends CRM_Hrjobcontract_DAO_HRJobHealt
   public static function checkProvider($searchValue, $providerType) {
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => 'hrjc_' . strtolower($providerType),
-      'value' => $searchValue,
+      'name' => $searchValue,
     ]);
 
     if ($result['count']) {


### PR DESCRIPTION
## Overview
Before the implementation of https://github.com/compucorp/civihr/pull/2949 and https://github.com/compucorp/civihr/pull/2959, job contract insurance and job role funders are loaded contacts. This affects import of job contract and job roles as reference is still being made to contacts. This PR made updates on the search for insurer and funder id.

## Before
Import of job contract and job role failed, raising `Undefined Property` notice.

## After
Import of job contract and job role are now successful.

## Technical Details
In [HRJobHealth](https://github.com/compucorp/civihr/blob/master/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php#L65), api call make use of value in search. This was changed name as the insurers name are now stored under the name column of option value table

For [HRJobRoles](https://github.com/compucorp/civihr/blob/master/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php#L65), call to check if contact exists was changed. Instead of selecting contact details, an API call was made to fetch funder details from `hrjc_funder` option values.
```
$result = civicrm_api3('OptionValue', 'get', [
  'option_group_id' => 'hrjc_funder',
  'name' => $searchValue,
]);
```