### PR TITLE
PCHR-4460: Fix 'Undefined index: role_revision_id' Error In Job Contract Import Screen

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php
@@ -45,15 +45,9 @@ class CRM_Hrjobcontract_BAO_HRJobHour extends CRM_Hrjobcontract_DAO_HRJobHour {
     $hook = empty($params['id']) ? 'create' : 'edit';
     $instance = parent::create($params);
 
-    $currentInstanceResult = civicrm_api3('HRJobHour', 'get', array(
-        'sequential' => 1,
-        'id' => $instance->id,
-    ));
-
-    $currentInstance = CRM_Utils_Array::first($currentInstanceResult['values']);
     $revisionResult = civicrm_api3('HRJobContractRevision', 'get', array(
         'sequential' => 1,
-        'id' => $currentInstance['jobcontract_revision_id'],
+        'id' => $instance->jobcontract_revision_id,
     ));
     $revision = CRM_Utils_Array::first($revisionResult['values']);
 


### PR DESCRIPTION
## Overview
When Importing a job contract, on the last screen after the import has completed, a notice is displayed.

## Before
When Importing a job contract, on the last screen after the import has completed, a notice is displayed : `Notice: Undefined index: role_revision_id in CRM_Hrjobcontract_BAO_HRJobHour::create() 
(line 63 of /var/www/master-php7.civihr.net/httpdocs/sites/all/modules/civicrm/tools/extensions/civihr/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php)`

<img width="1203" alt="import job contracts staging57 2019-01-03 11-14-11 1" src="https://user-images.githubusercontent.com/6951813/50636021-c9dec480-0f54-11e9-85bb-63a60131dc26.png">


## After
The call to return an [HRJobHourInstance](https://github.com/compucorp/civihr/blob/1f3ff3fdb74d768b4e97c2b8e917edb250b97d95/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php#L48-L53), returns NULL because the API call is wrapped in a transaction and the details is not yet available until the API call is done. Hence, subsequent calls to get the Job contract revision [details](https://github.com/compucorp/civihr/blob/1f3ff3fdb74d768b4e97c2b8e917edb250b97d95/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php#L54-L58) for the JobHour returns all the records in the database (since the id passed is NULL), will assumes all records is to be fetched. Since the first record is fetched, a wrong record is returned and if that record has NULL for the role_revision_id value, it is not returned at all as is the case with Civi API.

The solution was to use the `jobcontract_revision_id` already available on the HrJobHour instance when saved rather than trying to fetch it again from the database.

<img width="1212" alt="import job contracts staging57 2019-01-03 12-25-42" src="https://user-images.githubusercontent.com/6951813/50636036-d400c300-0f54-11e9-9ac3-1ed37acca82e.png">

