### PR TITLE
Update CiviHR code to be CiviCRM 5.16 complient and convert CiviHR ca…

### DIFF
--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobContractRevision.php
@@ -174,7 +174,6 @@ class CRM_Hrjobcontract_BAO_HRJobContractRevision extends CRM_Hrjobcontract_DAO_
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobDetails.php
@@ -251,7 +251,6 @@ class CRM_Hrjobcontract_BAO_HRJobDetails extends CRM_Hrjobcontract_DAO_HRJobDeta
       //Sorting fields in alphabetical order(CRM-1507)
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHealth.php
@@ -120,7 +120,6 @@ class CRM_Hrjobcontract_BAO_HRJobHealth extends CRM_Hrjobcontract_DAO_HRJobHealt
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobHour.php
@@ -111,7 +111,6 @@ class CRM_Hrjobcontract_BAO_HRJobHour extends CRM_Hrjobcontract_DAO_HRJobHour {
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobLeave.php
@@ -95,7 +95,6 @@ class CRM_Hrjobcontract_BAO_HRJobLeave extends CRM_Hrjobcontract_DAO_HRJobLeave 
       //Sorting fields in alphabetical order
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
     self::$_importableFields[$cacheKeyString] = $fields;
     if (!$isProfile) {

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobPay.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobPay.php
@@ -95,7 +95,6 @@ class CRM_Hrjobcontract_BAO_HRJobPay extends CRM_Hrjobcontract_DAO_HRJobPay {
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobPension.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobPension.php
@@ -115,7 +115,6 @@ class CRM_Hrjobcontract_BAO_HRJobPension extends CRM_Hrjobcontract_DAO_HRJobPens
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobRole.php
+++ b/hrjobcontract/CRM/Hrjobcontract/BAO/HRJobRole.php
@@ -73,7 +73,6 @@ class CRM_Hrjobcontract_BAO_HRJobRole extends CRM_Hrjobcontract_DAO_HRJobRole {
       $fields = CRM_Utils_Array::crmArraySortByField($fields, 'title');
       $fields = CRM_Utils_Array::index(array('name'), $fields);
 
-      CRM_Core_BAO_Cache::setItem($fields, 'contact fields', $cacheKeyString);
      }
 
     self::$_importableFields[$cacheKeyString] = $fields;

--- a/hrui/CRM/Core/BAO/Navigation.php
+++ b/hrui/CRM/Core/BAO/Navigation.php
@@ -166,7 +166,7 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
     $config = CRM_Core_Config::singleton();
 
     // check if we can retrieve from database cache
-    $navigations = CRM_Core_BAO_Cache::getItem('navigation', $cacheKeyString);
+    $navigations = Civi::cache('navigation')->get($cacheKeyString);
 
     if (!$navigations) {
       $domainID = CRM_Core_Config::domainID();
@@ -187,7 +187,7 @@ FROM civicrm_navigation WHERE domain_id = $domainID";
       $navigations = array();
       self::_getNavigationLabel($pidGroups[''], $navigations);
 
-      CRM_Core_BAO_Cache::setItem($navigations, 'navigation', $cacheKeyString);
+      Civi::cache('navigation')->set($cacheKeyString, $navigations);
     }
     return $navigations;
   }

--- a/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Info.php
+++ b/uk.co.compucorp.civicrm.hrcore/CRM/HRCore/Info.php
@@ -9,12 +9,12 @@ class CRM_HRCore_Info {
    */
   public static function getVersion() {
 
-    $version = CRM_Core_BAO_Cache::getItem('HRCore_Info', 'version');
+    $version = Civi::cache('HRCore_Info')->get('version');
 
     if (empty($version)) {
       $info = CRM_Extension_Info::loadFromFile(__DIR__ . '/../../info.xml');
       $version = $info->version;
-      CRM_Core_BAO_Cache::setItem($version, 'HRCore_Info', 'version');
+      Civi::cache('HRCore_Info')->set('version', $version);
     }
 
     return $version;

--- a/uk.co.compucorp.civicrm.hrcore/config/container/container.xml
+++ b/uk.co.compucorp.civicrm.hrcore/config/container/container.xml
@@ -34,6 +34,18 @@
             class="CRM_HRCore_CMSData_Role_RoleServiceInterface"
     />
     <service id="core.cache" class="CRM_Core_BAO_Cache"/>
+    <service id="cache.HRCore_Info" class="CRM_Utils_Cache_Interface"
+      factory-class="CRM_Utils_Cache" factory-method="create">
+      <argument type="collection">
+        <argument key="name">HRCore_Info</argument>
+        <argument key="type" type="collection">
+          <argument>*memory*</argument>
+          <argument>SqlGroup</argument>
+          <argument>ArrayCache</argument>
+        </argument>
+        <argument key="withArray">fast</argument>
+      </argument>
+    </service>
     <service id="core.http_client" class="CRM_Utils_HttpClient">
       <argument>%civihr.connection_timeout%</argument>
     </service>


### PR DESCRIPTION
…che group to be standard Civi::cache style

## Overview
This removes some uncessary caching storing as it doesn't appear to be doing. This also adds in a new cache.civihr service which is in the standard format as Civi::cache. Also it updates the navigation cache code to match standard for 5.16.

## Before
Code using deprecated code functions

## After
Code using standard cache

## Technical Details
This creates a new service cache.HRCore_Info which is the standard way of defining Civi cache groups.